### PR TITLE
Throw exception while `execute` calls `close`

### DIFF
--- a/app/src/main/java/org/astraea/performance/latency/CloseableThread.java
+++ b/app/src/main/java/org/astraea/performance/latency/CloseableThread.java
@@ -31,6 +31,15 @@ abstract class CloseableThread implements Runnable, Closeable {
 
   @Override
   public void close() {
+    if (StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE)
+        .walk(
+            s ->
+                s.anyMatch(
+                    stack ->
+                        (stack.getMethodName().equals("execute"))
+                            && (stack.getDeclaringClass() == this.getClass())))) {
+      throw new RuntimeException();
+    }
     closed.set(true);
     try {
       closeLatch.await();

--- a/app/src/test/java/org/astraea/performance/latency/CloseableThreadTest.java
+++ b/app/src/test/java/org/astraea/performance/latency/CloseableThreadTest.java
@@ -2,6 +2,7 @@ package org.astraea.performance.latency;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test;
 class CloseableThreadTest {
 
   @Test
-  void testAllActions() throws InterruptedException {
+  void testExecuteAndCleanup() throws InterruptedException {
     var executeCount = new AtomicInteger();
     var cleanupCount = new AtomicInteger();
     var thread =
@@ -37,5 +38,30 @@ class CloseableThreadTest {
 
     Assertions.assertTrue(executeCount.get() > 0);
     Assertions.assertEquals(1, cleanupCount.get());
+  }
+
+  @Test
+  void testThrowException() throws InterruptedException {
+    var exceptionThrow = new AtomicBoolean(false);
+    var thread =
+        new CloseableThread() {
+          @Override
+          void execute() {
+            try {
+              close();
+            } catch (RuntimeException re) {
+              exceptionThrow.set(true);
+            }
+          }
+        };
+
+    var service = Executors.newSingleThreadExecutor();
+    service.execute(thread);
+    Thread.sleep(1);
+    thread.close();
+    service.shutdown();
+
+    Assertions.assertTrue(service.awaitTermination(10, TimeUnit.SECONDS));
+    Assertions.assertTrue(exceptionThrow.get());
   }
 }

--- a/app/src/test/java/org/astraea/performance/latency/CloseableThreadTest.java
+++ b/app/src/test/java/org/astraea/performance/latency/CloseableThreadTest.java
@@ -51,10 +51,10 @@ class CloseableThreadTest {
           }
         };
 
-    Assertions.assertThrows(
-        RuntimeException.class,
-        () -> thread.run(),
-        "java.lang.RuntimeException: Should not call close() in execute().");
+    Assertions.assertTrue(
+        Assertions.assertThrows(RuntimeException.class, () -> thread.run())
+            .toString()
+            .equals("java.lang.RuntimeException: Should not call close() in execute()."));
   }
 
   @Test

--- a/app/src/test/java/org/astraea/performance/latency/CloseableThreadTest.java
+++ b/app/src/test/java/org/astraea/performance/latency/CloseableThreadTest.java
@@ -51,10 +51,9 @@ class CloseableThreadTest {
           }
         };
 
-    Assertions.assertTrue(
-        Assertions.assertThrows(RuntimeException.class, () -> thread.run())
-            .toString()
-            .equals("java.lang.RuntimeException: Should not call close() in execute()."));
+    Assertions.assertEquals(
+        "Should not call close() in execute().",
+        Assertions.assertThrows(RuntimeException.class, thread::run).getMessage());
   }
 
   @Test

--- a/app/src/test/java/org/astraea/performance/latency/CloseableThreadTest.java
+++ b/app/src/test/java/org/astraea/performance/latency/CloseableThreadTest.java
@@ -2,7 +2,6 @@ package org.astraea.performance.latency;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -41,8 +40,7 @@ class CloseableThreadTest {
   }
 
   @Test
-  void testThrowException() throws InterruptedException {
-    var exceptionThrow = new AtomicBoolean(false);
+  void testThrowException() {
     var thread =
         new CloseableThread() {
           @Override

--- a/app/src/test/java/org/astraea/performance/latency/CloseableThreadTest.java
+++ b/app/src/test/java/org/astraea/performance/latency/CloseableThreadTest.java
@@ -47,22 +47,14 @@ class CloseableThreadTest {
         new CloseableThread() {
           @Override
           void execute() {
-            try {
-              close();
-            } catch (RuntimeException re) {
-              exceptionThrow.set(true);
-            }
+            close();
           }
         };
 
-    var service = Executors.newSingleThreadExecutor();
-    service.execute(thread);
-    Thread.sleep(1);
-    thread.close();
-    service.shutdown();
-
-    Assertions.assertTrue(service.awaitTermination(10, TimeUnit.SECONDS));
-    Assertions.assertTrue(exceptionThrow.get());
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () -> thread.run(),
+        "java.lang.RuntimeException: Should not call close() in execute().");
   }
 
   @Test


### PR DESCRIPTION
Throw exception while `execute()` calls `close()`.