### PR TITLE
Directly test `run()` instead of using thread pool

### DIFF
--- a/app/src/test/java/org/astraea/performance/latency/CloseableThreadTest.java
+++ b/app/src/test/java/org/astraea/performance/latency/CloseableThreadTest.java
@@ -55,7 +55,7 @@ class CloseableThreadTest {
   }
 
   @Test
-  void testExecuteOnce() throws InterruptedException {
+  void testExecuteOnce() {
     var executeCount = new AtomicInteger();
     var thread =
         new CloseableThread(true) {
@@ -65,11 +65,7 @@ class CloseableThreadTest {
           }
         };
 
-    var service = Executors.newSingleThreadExecutor();
-    service.execute(thread);
-    service.shutdown();
-
-    Assertions.assertTrue(service.awaitTermination(10, TimeUnit.SECONDS));
+    thread.run();
 
     Assertions.assertEquals(1, executeCount.get());
   }


### PR DESCRIPTION
看過"testExecuteAndCleanup()"的測試後，發現並不適合直接測試，還是需要新增執行緒。
`ConsumerThread`, `ProducerThread`的測試都已經是直接測試。
因此只有改動`testExecuteOnce()`。