### PR TITLE
Enable to run kafka from source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,11 @@ This project offers a way to run kafka official tool by container. For example:
 ### Run kafka-topics.sh
 
 ```shell
-./docker/start_tool.sh kafka-topics.sh --bootstrap-server 192.168.50.178:14082 --list
+./docker/start_kafka_tool.sh kafka-topics.sh --bootstrap-server 192.168.50.178:14082 --list
 ```
 
 ### Show Available Official Tools
 
 ```shell
-./docker/start_tool.sh help
+./docker/start_kafka_tool.sh help
 ```

--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ This project offers many kafka tools to simplify the life for kafka users.
 
 ---
 
-## Quickstart a Kafka Env
+## Kafka Cluster Quick Start
 
-There are two scripts which can setup env quickly by container
+The following scripts can build a kafka cluster by containers in one minute.
 
-### Set up zookeeper with default version
+### Set up zookeeper
 
 ```shell
 ./docker/start_zookeeper.sh
 ```
 
-The above script creates a zookeeper instance by container. Also, it will show the command used to add broker instance. For example:
+The script creates a zookeeper instance by container. Also, it will show the command used to add broker instance. For example:
 
 ```shell
 =================================================
@@ -32,13 +32,9 @@ run ./docker/start_broker.sh zookeeper.connect=192.168.50.178:17228 to join kafk
 =================================================
 ```
 
-### Set up zookeeper with specific version
+You can define `ZOOKEEPER_VERSION` to change the binary version.
 
-```shell
-ZOOKEEPER_VERSION=3.6.3 ./docker/start_zookeeper.sh
-```
-
-### Set up (kafka) broker with default version
+### Set up (kafka) broker
 
 After the zk env is running, you can copy the command (see above example) from zk script output to set up kafka. For example:
 ```shell
@@ -54,13 +50,8 @@ jmx address: 192.168.50.224:15905
 =================================================
 ```
 
-Noted that the command to set up broker can be executed multiple times to create a broker cluster.
-
-### Set up (kafka) broker with specific version
-
-```shell
-KAFKA_VERSION=2.8.0 ./docker/start_broker.sh zookeeper.connect=192.168.50.178:17228
-```
+The command to set up broker can be executed multiple times to create a broker cluster. The env `KAFKA_VERSION` is used to
+define the release version of kafka. Or you can define `KAFKA_REVISION` to run kafka based on specify revision of source code.
 
 ---
 

--- a/docker/start_broker.sh
+++ b/docker/start_broker.sh
@@ -35,8 +35,11 @@ if [[ -z "$KAFKA_VERSION" ]]; then
   KAFKA_VERSION=2.8.0
 fi
 
-USER=broker
+USER=astraea
 image_name=astraea/broker:$KAFKA_VERSION
+if [[ -n "$KAFKA_REVISION" ]]; then
+  image_name=astraea/broker:$KAFKA_REVISION
+fi
 broker_id="$(($RANDOM % 1000))"
 address=$(getAddress)
 broker_port="$(($(($RANDOM % 10000)) + 10000))"
@@ -121,7 +124,33 @@ if [[ "$(cat $config_file | grep transaction.state.log.min.isr)" == "" ]]; then
 fi
 # ==============================================================================
 
-docker build -t $image_name - <<Dockerfile
+if [[ -n "$KAFKA_REVISION" ]]; then
+
+  docker build -t $image_name - <<Dockerfile
+FROM ubuntu:20.04
+
+# install tools
+RUN apt-get update && apt-get upgrade -y && DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-11-jdk wget git curl
+
+# add user
+RUN groupadd $USER && useradd -ms /bin/bash -g $USER $USER
+
+# change user
+USER $USER
+
+# build kafka from source code
+RUN git clone https://github.com/apache/kafka /tmp/kafka
+WORKDIR /tmp/kafka
+RUN git checkout $KAFKA_REVISION
+RUN ./gradlew clean releaseTarGz
+RUN mkdir /home/$USER/kafka
+RUN tar -zxvf \$(find ./core/build/distributions/ -maxdepth 1 -type f -name kafka_*.tgz | head -n 1) -C /home/$USER/kafka --strip-components=1
+WORKDIR "/home/$USER/kafka"
+
+Dockerfile
+
+else
+  docker build -t $image_name - <<Dockerfile
 FROM ubuntu:20.04
 
 # install tools
@@ -134,11 +163,14 @@ RUN groupadd $USER && useradd -ms /bin/bash -g $USER $USER
 USER $USER
 
 # download kafka
-WORKDIR /home/$USER
+WORKDIR /tmp
 RUN wget https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_2.13-${KAFKA_VERSION}.tgz
-RUN tar -zxvf kafka_2.13-${KAFKA_VERSION}.tgz
-WORKDIR /home/$USER/kafka_2.13-${KAFKA_VERSION}
+RUN mkdir /home/$USER/kafka
+RUN tar -zxvf kafka_2.13-${KAFKA_VERSION}.tgz -C /home/$USER/kafka --strip-components=1
+WORKDIR "/home/$USER/kafka"
+
 Dockerfile
+fi
 
 docker run -d \
   -e KAFKA_HEAP_OPTS="$KAFKA_HEAP" \
@@ -146,7 +178,7 @@ docker run -d \
   -v $config_file:/tmp/broker.properties:ro \
   -p $broker_port:9092 \
   -p $broker_jmx_port:$broker_jmx_port \
-  $image_name /home/$USER/kafka_2.13-${KAFKA_VERSION}/bin/kafka-server-start.sh /tmp/broker.properties
+  $image_name ./bin/kafka-server-start.sh /tmp/broker.properties
 
 echo "================================================="
 echo "broker address: ${address}:$broker_port"

--- a/docker/start_broker.sh
+++ b/docker/start_broker.sh
@@ -144,7 +144,7 @@ WORKDIR /tmp/kafka
 RUN git checkout $KAFKA_REVISION
 RUN ./gradlew clean releaseTarGz
 RUN mkdir /home/$USER/kafka
-RUN tar -zxvf \$(find ./core/build/distributions/ -maxdepth 1 -type f -name kafka_*.tgz | head -n 1) -C /home/$USER/kafka --strip-components=1
+RUN tar -zxvf \$(find ./core/build/distributions/ -maxdepth 1 -type f -name kafka_*SNAPSHOT.tgz) -C /home/$USER/kafka --strip-components=1
 WORKDIR "/home/$USER/kafka"
 
 Dockerfile

--- a/docker/start_kafka_tool.sh
+++ b/docker/start_kafka_tool.sh
@@ -26,7 +26,7 @@ image_name=astraea/kafka-tool:$KAFKA_VERSION
 # set JVM heap
 KAFKA_HEAP="${KAFKA_HEAP:-"-Xmx2G -Xms2G"}"
 
-USER=broker
+USER=astraea
 
 docker build -t $image_name - <<Dockerfile
 FROM ubuntu:20.04
@@ -41,16 +41,18 @@ RUN groupadd $USER && useradd -ms /bin/bash -g $USER $USER
 USER $USER
 
 # download kafka
-WORKDIR /home/$USER
+WORKDIR /tmp
 RUN wget https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_2.13-${KAFKA_VERSION}.tgz
-RUN tar -zxvf kafka_2.13-${KAFKA_VERSION}.tgz
-WORKDIR /home/$USER/kafka_2.13-${KAFKA_VERSION}
+RUN mkdir /home/$USER/kafka
+RUN tar -zxvf kafka_2.13-${KAFKA_VERSION}.tgz -C /home/$USER/kafka --strip-components=1
+WORKDIR "/home/$USER/kafka"
+
 Dockerfile
 
 if [[ "$script" == "help" ]]; then
-  docker run --rm $image_name /bin/bash -c "ls /home/$USER/kafka_2.13-${KAFKA_VERSION}/bin"
+  docker run --rm $image_name /bin/bash -c "ls ./bin"
 else
   docker run --rm -ti \
     -e KAFKA_HEAP_OPTS="$KAFKA_HEAP" \
-    $image_name /home/$USER/kafka_2.13-${KAFKA_VERSION}/bin/"$script" "$@"
+    $image_name ./bin/"$script" "$@"
 fi

--- a/docker/start_tool.sh
+++ b/docker/start_tool.sh
@@ -21,7 +21,7 @@ fi
 if [[ -z "$KAFKA_VERSION" ]]; then
   KAFKA_VERSION=2.8.0
 fi
-image_name=astraea/broker:$KAFKA_VERSION
+image_name=astraea/kafka-tool:$KAFKA_VERSION
 
 # set JVM heap
 KAFKA_HEAP="${KAFKA_HEAP:-"-Xmx2G -Xms2G"}"

--- a/docker/start_zookeeper.sh
+++ b/docker/start_zookeeper.sh
@@ -24,7 +24,7 @@ if [[ -z "$ZOOKEEPER_VERSION" ]]; then
   ZOOKEEPER_VERSION=3.6.3
 fi
 
-USER=zookeeper
+USER=astraea
 image_name=astraea/zookeeper:$ZOOKEEPER_VERSION
 zk_port="$(($(($RANDOM % 10000)) + 10000))"
 address=$(getAddress)
@@ -42,10 +42,11 @@ RUN groupadd $USER && useradd -ms /bin/bash -g $USER $USER
 USER $USER
 
 # download zookeeper
-WORKDIR /home/$USER
+WORKDIR /tmp
 RUN wget https://archive.apache.org/dist/zookeeper/zookeeper-${ZOOKEEPER_VERSION}/apache-zookeeper-${ZOOKEEPER_VERSION}-bin.tar.gz
-RUN tar -zxvf apache-zookeeper-${ZOOKEEPER_VERSION}-bin.tar.gz
-WORKDIR /home/$USER/apache-zookeeper-${ZOOKEEPER_VERSION}-bin
+RUN mkdir /home/$USER/zookeeper
+RUN tar -zxvf apache-zookeeper-${ZOOKEEPER_VERSION}-bin.tar.gz -C /home/$USER/zookeeper --strip-components=1
+WORKDIR /home/$USER/zookeeper
 
 # create config file
 RUN echo "tickTime=2000" >> ./conf/zoo.cfg
@@ -55,7 +56,7 @@ Dockerfile
 
 docker run -d \
   -p $zk_port:2181 \
-  $image_name /home/$USER/apache-zookeeper-${ZOOKEEPER_VERSION}-bin/bin/zkServer.sh start-foreground
+  $image_name ./bin/zkServer.sh start-foreground
 
 echo "================================================="
 echo "run ./docker/start_broker.sh zookeeper.connect=$address:$zk_port to join kafka broker"


### PR DESCRIPTION
考量我們可能需要測試最新的kafka，因此腳本需要能基於source code來運行kafka，簡單說就是定義`KAFKA_REVISION`後再執行腳本，腳本就會去下載原始碼編譯並建置kafka。詳細說明請見readme