### PR TITLE
singleton partitioner

### DIFF
--- a/app/src/main/java/org/astraea/partitioner/PartitionerFactory.java
+++ b/app/src/main/java/org/astraea/partitioner/PartitionerFactory.java
@@ -1,0 +1,89 @@
+package org.astraea.partitioner;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.TreeMap;
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.common.Cluster;
+
+public class PartitionerFactory {
+  private final Object lock = new Object();
+  private final Map<Map<String, ?>, Integer> count;
+  private final Map<Map<String, ?>, Partitioner> instances;
+
+  PartitionerFactory() {
+    this((o1, o2) -> o1.equals(o2) ? 0 : Integer.compare(o1.hashCode(), o2.hashCode()));
+  }
+
+  /**
+   * create a factory with specific comparator.
+   *
+   * @param comparator used to compare the partitioners. There is no new producer if the comparator
+   *     returns 0 (equal).
+   */
+  PartitionerFactory(Comparator<Map<String, ?>> comparator) {
+    this.count = new TreeMap<>(comparator);
+    this.instances = new TreeMap<>(comparator);
+  }
+
+  Partitioner getOrCreate(Class<? extends Partitioner> clz, Map<String, ?> configs) {
+    synchronized (lock) {
+      var partitioner = instances.get(configs);
+      if (partitioner != null) {
+        count.put(configs, count.get(configs) + 1);
+        return partitioner;
+      }
+      return create(clz, configs);
+    }
+  }
+
+  private Partitioner create(Class<? extends Partitioner> clz, Map<String, ?> configs) {
+    try {
+      var partitioner = clz.getDeclaredConstructor().newInstance();
+      partitioner.configure(configs);
+      var proxy =
+          new Partitioner() {
+            @Override
+            public int partition(
+                String topic,
+                Object key,
+                byte[] keyBytes,
+                Object value,
+                byte[] valueBytes,
+                Cluster cluster) {
+              return partitioner.partition(topic, key, keyBytes, value, valueBytes, cluster);
+            }
+
+            @Override
+            public void onNewBatch(String topic, Cluster cluster, int prevPartition) {
+              partitioner.onNewBatch(topic, cluster, prevPartition);
+            }
+
+            @Override
+            public void close() {
+              synchronized (lock) {
+                var current = count.get(configs);
+                if (current == 1) {
+                  try {
+                    partitioner.close();
+                  } finally {
+                    count.remove(configs);
+                    instances.remove(configs);
+                  }
+                } else count.put(configs, current - 1);
+              }
+            }
+
+            @Override
+            public void configure(Map<String, ?> configs) {
+              partitioner.configure(configs);
+            }
+          };
+      count.put(configs, 1);
+      instances.put(configs, proxy);
+      return proxy;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/app/src/test/java/org/astraea/partitioner/PartitionerFactoryTest.java
+++ b/app/src/test/java/org/astraea/partitioner/PartitionerFactoryTest.java
@@ -1,0 +1,143 @@
+package org.astraea.partitioner;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.common.Cluster;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class PartitionerFactoryTest {
+  private static long countOfPartition = 0;
+  private static long countOfOnConfigure = 0;
+  private static long countOfClose = 0;
+
+  @Test
+  void test() {
+    var configs = Map.of("a", "b");
+
+    // create multiples partitioners
+    var partitioners =
+        IntStream.range(0, 10)
+            .mapToObj(
+                i -> {
+                  var partitioner = new PassToProducer();
+                  partitioner.configure(configs);
+                  return partitioner;
+                })
+            .collect(Collectors.toList());
+
+    // ThreadSafePartitioner is created only once
+    Assertions.assertEquals(1, countOfOnConfigure);
+    Assertions.assertEquals(0, countOfPartition);
+    Assertions.assertEquals(0, countOfClose);
+
+    // try to call partition
+    partitioners.get(0).partition(null, null, null, null, null, null);
+    partitioners.get(1).partition(null, null, null, null, null, null);
+    partitioners.get(2).partition(null, null, null, null, null, null);
+    Assertions.assertEquals(1, countOfOnConfigure);
+    Assertions.assertEquals(3, countOfPartition);
+    Assertions.assertEquals(0, countOfClose);
+
+    // ThreadSafePartitioner is not closed if not all PassToProducers are closed.
+    partitioners.subList(1, partitioners.size()).forEach(Partitioner::close);
+    Assertions.assertEquals(1, countOfOnConfigure);
+    Assertions.assertEquals(3, countOfPartition);
+    Assertions.assertEquals(0, countOfClose);
+
+    // ok, all are closed
+    partitioners.get(0).close();
+    Assertions.assertEquals(1, countOfOnConfigure);
+    Assertions.assertEquals(3, countOfPartition);
+    Assertions.assertEquals(1, countOfClose);
+
+    // let us create it again
+    var partitioner = new PassToProducer();
+    partitioner.configure(configs);
+    Assertions.assertEquals(2, countOfOnConfigure);
+    Assertions.assertEquals(3, countOfPartition);
+    Assertions.assertEquals(1, countOfClose);
+
+    // close it
+    partitioner.close();
+    Assertions.assertEquals(2, countOfOnConfigure);
+    Assertions.assertEquals(3, countOfPartition);
+    Assertions.assertEquals(2, countOfClose);
+
+    // create two ThreadSafePartitioner with two configs
+    var partitioner0 = new PassToProducer();
+    partitioner0.configure(Map.of("key", "value0"));
+    var partitioner1 = new PassToProducer();
+    partitioner1.configure(Map.of("key", "value1"));
+    Assertions.assertEquals(4, countOfOnConfigure);
+    Assertions.assertEquals(3, countOfPartition);
+    Assertions.assertEquals(2, countOfClose);
+
+    // close them
+    partitioner0.close();
+    partitioner1.close();
+    Assertions.assertEquals(4, countOfOnConfigure);
+    Assertions.assertEquals(3, countOfPartition);
+    Assertions.assertEquals(4, countOfClose);
+  }
+
+  private static class PassToProducer implements Partitioner {
+
+    private static final PartitionerFactory FACTORY = new PartitionerFactory();
+
+    private Partitioner partitioner;
+
+    @Override
+    public int partition(
+        String topic,
+        Object key,
+        byte[] keyBytes,
+        Object value,
+        byte[] valueBytes,
+        Cluster cluster) {
+      return partitioner.partition(topic, key, keyBytes, value, valueBytes, cluster);
+    }
+
+    @Override
+    public void onNewBatch(String topic, Cluster cluster, int prevPartition) {
+      partitioner.onNewBatch(topic, cluster, prevPartition);
+    }
+
+    @Override
+    public void close() {
+      partitioner.close();
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+      partitioner = FACTORY.getOrCreate(ThreadSafePartitioner.class, configs);
+    }
+  }
+
+  static class ThreadSafePartitioner implements Partitioner {
+
+    @Override
+    public int partition(
+        String topic,
+        Object key,
+        byte[] keyBytes,
+        Object value,
+        byte[] valueBytes,
+        Cluster cluster) {
+      countOfPartition += 1;
+      return 0;
+    }
+
+    @Override
+    public void close() {
+      countOfClose += 1;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+      countOfOnConfigure += 1;
+    }
+  }
+}


### PR DESCRIPTION
@wycccccc 這個PR展示了如何實作一個簡單的singleton partitioner，你參考看看是否要運用這種架構。

這個架構的好處是，可以讓partitioner直接看到“整個JVM"所有出去的資料，可以更快反應資料的變話（比起總是要等伺服器端的metrics更新)