### PR TITLE
List members of partitions

### DIFF
--- a/app/src/main/java/org/astraea/offset/OffsetExplorer.java
+++ b/app/src/main/java/org/astraea/offset/OffsetExplorer.java
@@ -29,8 +29,12 @@ public class OffsetExplorer {
       this.partition = partition;
       this.earliestOffset = startOffset;
       this.latestOffset = endOffset;
-      this.groups = groups;
-      this.replicas = replicas;
+      this.groups =
+          groups.stream().sorted(Comparator.comparing(g -> g.groupId)).collect(Collectors.toList());
+      this.replicas =
+          replicas.stream()
+              .sorted(Comparator.comparing(r -> r.broker))
+              .collect(Collectors.toList());
     }
 
     @Override

--- a/app/src/main/java/org/astraea/topic/TopicAdmin.java
+++ b/app/src/main/java/org/astraea/topic/TopicAdmin.java
@@ -89,7 +89,7 @@ public interface TopicAdmin extends Closeable {
                             partitionMembers.getOrDefault(tp, List.of()).stream()
                                 .map(
                                     m ->
-                                        new GroupMember(
+                                        new Member(
                                             m.consumerId(),
                                             m.groupInstanceId(),
                                             m.clientId(),
@@ -260,9 +260,9 @@ public interface TopicAdmin extends Closeable {
   class Group {
     public final String groupId;
     public final OptionalLong offset;
-    public final List<GroupMember> members;
+    public final List<Member> members;
 
-    public Group(String groupId, OptionalLong offset, List<GroupMember> members) {
+    public Group(String groupId, OptionalLong offset, List<Member> members) {
       this.groupId = groupId;
       this.offset = offset;
       this.members = members;
@@ -282,14 +282,13 @@ public interface TopicAdmin extends Closeable {
     }
   }
 
-  class GroupMember {
+  class Member {
     private final String memberId;
     private final Optional<String> groupInstanceId;
     private final String clientId;
     private final String host;
 
-    public GroupMember(
-        String memberId, Optional<String> groupInstanceId, String clientId, String host) {
+    public Member(String memberId, Optional<String> groupInstanceId, String clientId, String host) {
       this.memberId = memberId;
       this.groupInstanceId = groupInstanceId;
       this.clientId = clientId;
@@ -298,7 +297,7 @@ public interface TopicAdmin extends Closeable {
 
     @Override
     public String toString() {
-      return "GroupMember{"
+      return "Member{"
           + "memberId='"
           + memberId
           + '\''

--- a/app/src/test/java/org/astraea/offset/OffsetExplorerTest.java
+++ b/app/src/test/java/org/astraea/offset/OffsetExplorerTest.java
@@ -1,8 +1,6 @@
 package org.astraea.offset;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import org.apache.kafka.common.TopicPartition;
 import org.astraea.topic.TopicAdmin;
 import org.junit.jupiter.api.Assertions;
@@ -38,7 +36,9 @@ public class OffsetExplorerTest {
 
           @Override
           public Map<TopicPartition, List<Group>> groups(Set<String> topics) {
-            return Map.of(topicPartition, List.of(new Group(groupId, groupOffset)));
+            return Map.of(
+                topicPartition,
+                List.of(new Group(groupId, OptionalLong.of(groupOffset), List.of())));
           }
 
           @Override
@@ -66,8 +66,8 @@ public class OffsetExplorerTest {
       Assertions.assertEquals(earliestOffset, result.get(0).earliestOffset);
       Assertions.assertEquals(latestOffset, result.get(0).latestOffset);
       Assertions.assertEquals(1, result.get(0).groups.size());
-      Assertions.assertEquals(groupId, result.get(0).groups.get(0).id);
-      Assertions.assertEquals(groupOffset, result.get(0).groups.get(0).offset);
+      Assertions.assertEquals(groupId, result.get(0).groups.get(0).groupId);
+      Assertions.assertEquals(groupOffset, result.get(0).groups.get(0).offset.getAsLong());
       Assertions.assertEquals(1, result.get(0).replicas.size());
       Assertions.assertEquals(brokerId, result.get(0).replicas.get(0).broker);
       Assertions.assertEquals(lag, result.get(0).replicas.get(0).lag);


### PR DESCRIPTION
業務需求，`offset tool`將會顯示訂閱的members，範例如下：
```
topic='ikea', partition=0, earliestOffset=0, latestOffset=3001066, groups=[Group{groupId='group-id-1634149410666', offset=1662438, members=[]}, Group{groupId='group-id-1634149443685', offset=none, members=[Member{memberId='consumer-group-id-1634149443685-1-3516cee9-dac2-4b1a-bcf5-93a12fcf720d', groupInstanceId=Optional.empty, clientId='consumer-group-id-1634149443685-1', host='/172.17.0.1'}]}], replicas=[Replica{broker=372, lag=0, leader=true, inSync=true}]
```