### PR TITLE
Correct the average bytes

### DIFF
--- a/app/src/main/java/org/astraea/performance/Performance.java
+++ b/app/src/main/java/org/astraea/performance/Performance.java
@@ -156,6 +156,7 @@ public class Performance {
             .sender()
             .topic(param.topic)
             .value(payload)
+            .timestamp(start)
             .run()
             .whenComplete(
                 (m, e) -> metrics.put(System.currentTimeMillis() - start, payload.length));

--- a/app/src/main/java/org/astraea/performance/Tracker.java
+++ b/app/src/main/java/org/astraea/performance/Tracker.java
@@ -18,26 +18,28 @@ public class Tracker implements ThreadPool.Executor {
   @Override
   public State execute() throws InterruptedException {
     long completed = 0;
-    long bytes = 0L;
+    double bytes = 0;
     long max = 0;
     long min = Long.MAX_VALUE;
 
     /* producer */
     for (Metrics data : producerData) {
       completed += data.num();
-      bytes += data.bytesThenReset();
-      if (max < data.max()) max = data.max();
-      if (min > data.min()) min = data.min();
+      bytes += data.avgBytes();
+      max = Math.max(max, data.max());
+      min = Math.min(min, data.min());
     }
     if (completed == 0) {
       Thread.sleep(1000);
       return State.RUNNING;
     }
     System.out.printf("producers完成度: %.2f%%%n", ((double) completed * 100.0 / (double) records));
-    System.out.printf("  輸出%.3fMB/second%n", ((double) bytes / (1 << 20)));
+    System.out.printf("  輸出%.3fMB/second%n", bytes);
     System.out.println("  發送max latency: " + max + "ms");
     System.out.println("  發送mim latency: " + min + "ms");
     for (int i = 0; i < producerData.size(); ++i) {
+      System.out.printf(
+          "  producer[%d]的發送average bytes: %.3fMB%n", i, producerData.get(i).avgBytes());
       System.out.printf(
           "  producer[%d]的發送average latency: %.3fms%n", i, producerData.get(i).avgLatency());
     }
@@ -48,15 +50,17 @@ public class Tracker implements ThreadPool.Executor {
     min = Long.MAX_VALUE;
     for (Metrics data : consumerData) {
       completed += data.num();
-      bytes += data.bytesThenReset();
-      if (max < data.max()) max = data.max();
-      if (min > data.min()) min = data.min();
+      bytes += data.avgBytes();
+      max = Math.max(max, data.max());
+      min = Math.min(min, data.min());
     }
     System.out.printf("consumer完成度: %.2f%%%n", ((double) completed * 100.0 / (double) records));
-    System.out.printf("  輸入%.3fMB/second%n", ((double) bytes / (1 << 20)));
+    System.out.printf("  輸入%.3fMB/second%n", bytes);
     System.out.println("  端到端max latency: " + max + "ms");
     System.out.println("  端到端mim latency: " + min + "ms");
     for (int i = 0; i < consumerData.size(); ++i) {
+      System.out.printf(
+          "  consumer[%d]的端到端average bytes: %.3fMB%n", i, consumerData.get(i).avgBytes());
       System.out.printf(
           "  consumer[%d]的端到端average latency: %.3fms%n", i, consumerData.get(i).avgLatency());
     }

--- a/app/src/test/java/org/astraea/performance/MetricsTest.java
+++ b/app/src/test/java/org/astraea/performance/MetricsTest.java
@@ -1,13 +1,11 @@
 package org.astraea.performance;
 
 import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.LongAdder;
-import org.astraea.concurrent.ThreadPool;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class MetricsTest {
+
   @Test
   void testAverage() {
     Random rand = new Random();
@@ -20,55 +18,18 @@ public class MetricsTest {
     for (int i = 0; i < num; ++i) {
       long next = rand.nextInt();
       avg += ((double) next - avg) / (i + 1);
-      metrics.putLatency(next);
+      metrics.put(next, 0);
     }
 
     Assertions.assertEquals(avg, metrics.avgLatency());
   }
 
-  // Simultaneously add and get
   @Test
   void testBytes() {
-    final Metrics metrics = new Metrics();
-    final LongAdder longAdder = new LongAdder();
-    final AtomicInteger adderCount = new AtomicInteger(0);
-    final AtomicInteger getterCount = new AtomicInteger(0);
-    final long input = 100;
-    final int loopCount = 10000;
+    var metrics = new Metrics();
 
-    try (ThreadPool threadPool =
-        ThreadPool.builder()
-            .executor(
-                () -> {
-                  metrics.addBytes(input);
-                  if (adderCount.incrementAndGet() < loopCount)
-                    return ThreadPool.Executor.State.RUNNING;
-                  else return ThreadPool.Executor.State.DONE;
-                })
-            .executor(
-                () -> {
-                  longAdder.add(metrics.bytesThenReset());
-                  if (getterCount.incrementAndGet() < loopCount)
-                    return ThreadPool.Executor.State.RUNNING;
-                  else return ThreadPool.Executor.State.DONE;
-                })
-            .build()) {
-      threadPool.waitAll();
-    }
-    longAdder.add(metrics.bytesThenReset());
-
-    Assertions.assertEquals(loopCount * input, longAdder.sum());
-  }
-
-  @Test
-  public void testReset() {
-    final Metrics metrics = new Metrics();
-    metrics.addBytes(10);
-    metrics.putLatency(11);
-
-    metrics.reset();
-
-    Assertions.assertEquals(0, metrics.bytesThenReset());
-    Assertions.assertEquals(0, metrics.avgLatency());
+    Assertions.assertEquals(0, metrics.bytes());
+    metrics.put(0, 1000);
+    Assertions.assertEquals(1000, metrics.bytes());
   }
 }

--- a/app/src/test/java/org/astraea/performance/PerformanceTest.java
+++ b/app/src/test/java/org/astraea/performance/PerformanceTest.java
@@ -27,7 +27,7 @@ public class PerformanceTest extends RequireBrokerCluster {
       executor.execute();
 
       Utils.waitFor(() -> metrics.num() == 1);
-      Assertions.assertEquals(1024, metrics.bytesThenReset());
+      Assertions.assertEquals(1024, metrics.bytes());
     }
   }
 
@@ -43,7 +43,7 @@ public class PerformanceTest extends RequireBrokerCluster {
       executor.execute();
 
       Assertions.assertEquals(0, metrics.num());
-      Assertions.assertEquals(0, metrics.bytesThenReset());
+      Assertions.assertEquals(0, metrics.bytes());
 
       try (var producer = Producer.builder().brokers(bootstrapServers()).build()) {
         producer.sender().topic(topicName).value(new byte[1024]).run().toCompletableFuture().get();
@@ -51,7 +51,7 @@ public class PerformanceTest extends RequireBrokerCluster {
       executor.execute();
 
       Assertions.assertEquals(1, metrics.num());
-      Assertions.assertNotEquals(1024, metrics.bytesThenReset());
+      Assertions.assertNotEquals(1024, metrics.bytes());
     }
   }
 }


### PR DESCRIPTION
原本的average bytes算法是“這一秒取得的資料量“，但對於吞吐量測試中，我們其實並不在意”某一秒”的狀況，反之，從開始到現在的平均量才是我們在意的。因此這隻PR調整了平均量的算法，此外也包含以下幾個修正：

1. 簡化`max`和`min`的算法
2. 簡化一部分的測試