### PR TITLE
Enable to create topic repeatedly

### DIFF
--- a/app/src/test/java/org/astraea/topic/TopicAdminTest.java
+++ b/app/src/test/java/org/astraea/topic/TopicAdminTest.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.apache.kafka.common.config.TopicConfig;
 import org.astraea.Utils;
 import org.astraea.producer.Producer;
@@ -27,6 +28,43 @@ public class TopicAdminTest extends RequireBrokerCluster {
           .create();
       Assertions.assertEquals(
           "lz4", topicAdmin.topics().get(topicName).get(TopicConfig.COMPRESSION_TYPE_CONFIG));
+    }
+  }
+
+  @Test
+  void testCreateTopicRepeatedly() throws IOException {
+    var topicName = "testCreateTopicRepeatedly";
+    try (var topicAdmin = TopicAdmin.of(bootstrapServers())) {
+      IntStream.range(0, 10)
+          .forEach(
+              i ->
+                  topicAdmin
+                      .creator()
+                      .configs(Map.of(TopicConfig.COMPRESSION_TYPE_CONFIG, "lz4"))
+                      .numberOfReplicas((short) 1)
+                      .numberOfPartitions(3)
+                      .topic(topicName)
+                      .create());
+
+      // changing number of partitions can producer error
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> topicAdmin.creator().numberOfPartitions(1).topic(topicName).create());
+
+      // changing number of replicas can producer error
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> topicAdmin.creator().numberOfReplicas((short) 2).topic(topicName).create());
+
+      // changing config can producer error
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () ->
+              topicAdmin
+                  .creator()
+                  .configs(Map.of(TopicConfig.COMPRESSION_TYPE_CONFIG, "gzip"))
+                  .topic(topicName)
+                  .create());
     }
   }
 


### PR DESCRIPTION
之前的版本我們允許重複建立topic (透過檢查，存在則忽略）

現在這個版本還原之前的邏輯，並新增更完整的確認，包含:

1. number of partitions
1. number of replicas
1. all configs

上述只要有任何一個不一樣則拋出錯誤