### PR TITLE
Make sure test can run on windows

### DIFF
--- a/app/src/test/java/org/astraea/metrics/kafka/KafkaMetricsTest.java
+++ b/app/src/test/java/org/astraea/metrics/kafka/KafkaMetricsTest.java
@@ -1,6 +1,7 @@
 package org.astraea.metrics.kafka;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.condition.OS.LINUX;
 import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 import java.io.IOException;
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -186,13 +188,13 @@ class KafkaMetricsTest extends RequireBrokerCluster {
   }
 
   @Test
-  @DisabledOnOs(WINDOWS)
+  @EnabledOnOs(LINUX)
   void linuxDiskReadBytes() {
     assertDoesNotThrow(() -> KafkaMetrics.BrokerTopic.linuxDiskReadBytes(mBeanClient));
   }
 
   @Test
-  @DisabledOnOs(WINDOWS)
+  @EnabledOnOs(LINUX)
   void linuxDiskWriteBytes() {
     assertDoesNotThrow(() -> KafkaMetrics.BrokerTopic.linuxDiskWriteBytes(mBeanClient));
   }

--- a/app/src/test/java/org/astraea/metrics/kafka/KafkaMetricsTest.java
+++ b/app/src/test/java/org/astraea/metrics/kafka/KafkaMetricsTest.java
@@ -1,6 +1,7 @@
 package org.astraea.metrics.kafka;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
@@ -19,6 +20,7 @@ import org.astraea.topic.TopicAdmin;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -145,8 +147,6 @@ class KafkaMetricsTest extends RequireBrokerCluster {
     assertDoesNotThrow(operatingSystemInfo::committedVirtualMemorySize);
     assertDoesNotThrow(operatingSystemInfo::freePhysicalMemorySize);
     assertDoesNotThrow(operatingSystemInfo::freeSwapSpaceSize);
-    assertDoesNotThrow(operatingSystemInfo::maxFileDescriptorCount);
-    assertDoesNotThrow(operatingSystemInfo::openFileDescriptorCount);
     assertDoesNotThrow(operatingSystemInfo::name);
     assertDoesNotThrow(operatingSystemInfo::processCpuLoad);
     assertDoesNotThrow(operatingSystemInfo::processCpuTime);
@@ -155,6 +155,20 @@ class KafkaMetricsTest extends RequireBrokerCluster {
     assertDoesNotThrow(operatingSystemInfo::totalPhysicalMemorySize);
     assertDoesNotThrow(operatingSystemInfo::totalSwapSpaceSize);
     assertDoesNotThrow(operatingSystemInfo::version);
+  }
+
+  @Test
+  @DisabledOnOs(WINDOWS)
+  void maxFileDescriptorCount() {
+    OperatingSystemInfo operatingSystemInfo = KafkaMetrics.Host.operatingSystem(mBeanClient);
+    assertDoesNotThrow(operatingSystemInfo::maxFileDescriptorCount);
+  }
+
+  @Test
+  @DisabledOnOs(WINDOWS)
+  void openFileDescriptorCount() {
+    OperatingSystemInfo operatingSystemInfo = KafkaMetrics.Host.operatingSystem(mBeanClient);
+    assertDoesNotThrow(operatingSystemInfo::openFileDescriptorCount);
   }
 
   @Test
@@ -172,11 +186,13 @@ class KafkaMetricsTest extends RequireBrokerCluster {
   }
 
   @Test
+  @DisabledOnOs(WINDOWS)
   void linuxDiskReadBytes() {
     assertDoesNotThrow(() -> KafkaMetrics.BrokerTopic.linuxDiskReadBytes(mBeanClient));
   }
 
   @Test
+  @DisabledOnOs(WINDOWS)
   void linuxDiskWriteBytes() {
     assertDoesNotThrow(() -> KafkaMetrics.BrokerTopic.linuxDiskWriteBytes(mBeanClient));
   }

--- a/app/src/test/java/org/astraea/topic/ReplicaCollieTest.java
+++ b/app/src/test/java/org/astraea/topic/ReplicaCollieTest.java
@@ -9,15 +9,20 @@ import org.astraea.Utils;
 import org.astraea.service.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 public class ReplicaCollieTest extends RequireBrokerCluster {
 
   @Test
+  @DisabledOnOs(WINDOWS)
   void testVerify() throws IOException, InterruptedException {
     test(true);
   }
 
   @Test
+  @DisabledOnOs(WINDOWS)
   void testExecute() throws IOException, InterruptedException {
     test(false);
   }

--- a/app/src/test/java/org/astraea/topic/ReplicaCollieTest.java
+++ b/app/src/test/java/org/astraea/topic/ReplicaCollieTest.java
@@ -1,5 +1,7 @@
 package org.astraea.topic;
 
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
 import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -10,8 +12,6 @@ import org.astraea.service.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
-
-import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 public class ReplicaCollieTest extends RequireBrokerCluster {
 

--- a/app/src/test/java/org/astraea/topic/TopicAdminTest.java
+++ b/app/src/test/java/org/astraea/topic/TopicAdminTest.java
@@ -14,6 +14,9 @@ import org.astraea.producer.Producer;
 import org.astraea.service.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 public class TopicAdminTest extends RequireBrokerCluster {
 
@@ -132,6 +135,7 @@ public class TopicAdminTest extends RequireBrokerCluster {
   }
 
   @Test
+  @DisabledOnOs(WINDOWS)
   void testReassign() throws IOException, InterruptedException {
     var topicName = "testReassign";
     try (var topicAdmin = TopicAdmin.of(bootstrapServers())) {

--- a/app/src/test/java/org/astraea/topic/TopicAdminTest.java
+++ b/app/src/test/java/org/astraea/topic/TopicAdminTest.java
@@ -1,5 +1,7 @@
 package org.astraea.topic;
 
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
@@ -15,8 +17,6 @@ import org.astraea.service.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
-
-import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 public class TopicAdminTest extends RequireBrokerCluster {
 


### PR DESCRIPTION
為了照顧windows使用者，因此這隻PR disable無法在windows上執行的tests，不過下列幾隻我不太確定為何不能在windows跑，因此會另外開議題來追蹤

1. `ReplicaCollieTest ` https://github.com/skiptests/astraea/issues/102
2. `TopicAdminTest#testReassign` https://github.com/skiptests/astraea/issues/103