### PR TITLE
印出produce/consume時間

### DIFF
--- a/app/src/main/java/org/astraea/performance/Tracker.java
+++ b/app/src/main/java/org/astraea/performance/Tracker.java
@@ -8,6 +8,7 @@ public class Tracker implements ThreadPool.Executor {
   private final List<Metrics> producerData;
   private final List<Metrics> consumerData;
   private final long records;
+  private long duration = 0L;
 
   public Tracker(List<Metrics> producerData, List<Metrics> consumerData, long records) {
     this.producerData = producerData;
@@ -38,6 +39,9 @@ public class Tracker implements ThreadPool.Executor {
 
     if (completed == 0) return false;
 
+    ++duration;
+    System.out.println(
+        "Time: " + duration / 3600 + "hr " + duration / 60 + "min " + duration % 60 + "sec");
     System.out.printf("producers完成度: %.2f%%%n", ((double) completed * 100.0 / (double) records));
     System.out.printf("  輸出%.3fMB/second%n", bytes);
     System.out.println("  發送max latency: " + max + "ms");

--- a/app/src/main/java/org/astraea/performance/Tracker.java
+++ b/app/src/main/java/org/astraea/performance/Tracker.java
@@ -8,7 +8,7 @@ public class Tracker implements ThreadPool.Executor {
   private final List<Metrics> producerData;
   private final List<Metrics> consumerData;
   private final long records;
-  private long duration = 0L;
+  private long start = 0L;
 
   public Tracker(List<Metrics> producerData, List<Metrics> consumerData, long records) {
     this.producerData = producerData;
@@ -39,9 +39,16 @@ public class Tracker implements ThreadPool.Executor {
 
     if (completed == 0) return false;
 
-    ++duration;
+    if (start == 0L) start = System.currentTimeMillis();
+    var duration = System.currentTimeMillis() - start;
     System.out.println(
-        "Time: " + duration / 3600 + "hr " + duration / 60 + "min " + duration % 60 + "sec");
+        "Time: "
+            + duration / 3600000
+            + "hr "
+            + duration / 60000
+            + "min "
+            + duration / 1000 % 60
+            + "sec");
     System.out.printf("producers完成度: %.2f%%%n", ((double) completed * 100.0 / (double) records));
     System.out.printf("  輸出%.3fMB/second%n", bytes);
     System.out.println("  發送max latency: " + max + "ms");

--- a/app/src/main/java/org/astraea/performance/Tracker.java
+++ b/app/src/main/java/org/astraea/performance/Tracker.java
@@ -1,5 +1,6 @@
 package org.astraea.performance;
 
+import java.time.Duration;
 import java.util.List;
 import org.astraea.concurrent.ThreadPool;
 
@@ -40,14 +41,14 @@ public class Tracker implements ThreadPool.Executor {
     if (completed == 0) return false;
 
     if (start == 0L) start = System.currentTimeMillis();
-    var duration = System.currentTimeMillis() - start;
+    var duration = Duration.ofMillis(System.currentTimeMillis() - start);
     System.out.println(
         "Time: "
-            + duration / 3600000
+            + duration.toHoursPart()
             + "hr "
-            + duration / 60000
+            + duration.toMinutesPart()
             + "min "
-            + duration / 1000 % 60
+            + duration.toSecondsPart()
             + "sec");
     System.out.printf("producers完成度: %.2f%%%n", ((double) completed * 100.0 / (double) records));
     System.out.printf("  輸出%.3fMB/second%n", bytes);


### PR DESCRIPTION
測試時，為了方便紀錄produce/consume所花費的時間，故先新增"印出時間"。