### PR TITLE
 The processing of dependency data partitioner

### DIFF
--- a/app/src/main/java/org/astraea/partitioner/nodeLoadMetric/NodeLoadClient.java
+++ b/app/src/main/java/org/astraea/partitioner/nodeLoadMetric/NodeLoadClient.java
@@ -91,4 +91,8 @@ public class NodeLoadClient implements ThreadPool.Executor {
       nodeMetadata.setTotalBytes(nodeMetrics.totalBytesPerSec());
     }
   }
+
+  public Collection<NodeMetadata> getNodeMetadataCollection() {
+    return this.nodeMetadataCollection;
+  }
 }

--- a/app/src/main/java/org/astraea/partitioner/partitionerFactory/DataDependencyPartitioner.java
+++ b/app/src/main/java/org/astraea/partitioner/partitionerFactory/DataDependencyPartitioner.java
@@ -1,0 +1,52 @@
+package org.astraea.partitioner.partitionerFactory;
+
+import static org.astraea.partitioner.partitionerFactory.LinkPartitioner.getAddressMap;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.PartitionInfo;
+import org.astraea.partitioner.nodeLoadMetric.NodeLoadClient;
+import org.astraea.partitioner.nodeLoadMetric.NodeMetadata;
+
+public class DataDependencyPartitioner implements Partitioner {
+  private NodeLoadClient nodeLoadClient;
+  private String minNodeID;
+  private int partitionID = -1;
+
+  @Override
+  public int partition(
+      String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes, Cluster cluster) {
+    if (partitionID < 0) {
+      var partitions =
+          cluster.partitionsForNode(Integer.parseInt(minNodeID)).stream()
+              .map(PartitionInfo::partition)
+              .collect(Collectors.toList());
+      Random rand = new Random();
+      partitionID = partitions.get(rand.nextInt(partitions.size()));
+    }
+    return partitionID;
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    try {
+      nodeLoadClient = new NodeLoadClient((getAddressMap(configs)));
+      nodeLoadClient.refreshNodesMetrics();
+      minNodeID =
+          nodeLoadClient.getNodeMetadataCollection().stream()
+              .min(Comparator.comparing(NodeMetadata::getTotalBytes))
+              .get()
+              .getNodeID();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/app/src/test/java/org/astraea/partitioner/nodeLoadMetric/PartitionerTest.java
+++ b/app/src/test/java/org/astraea/partitioner/nodeLoadMetric/PartitionerTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 public class PartitionerTest extends RequireBrokerCluster {
   public final String brokerList = bootstrapServers();
   TopicAdmin admin = TopicAdmin.of(bootstrapServers());
-  public final String topicName = "address";
 
   public Properties initProConfig() {
     Properties props = new Properties();
@@ -39,6 +38,7 @@ public class PartitionerTest extends RequireBrokerCluster {
 
   @Test
   public void testAstraeaPartitioner() {
+    var topicName = "address";
     admin.creator().topic(topicName).numberOfPartitions(10).create();
 
     var key = "tainan";
@@ -90,6 +90,7 @@ public class PartitionerTest extends RequireBrokerCluster {
 
   @Test
   public void testDataDependencyPartitioner() {
+    var topicName = "dataD";
     admin.creator().topic(topicName).numberOfPartitions(10).create();
 
     var key = "DataDependency";


### PR DESCRIPTION
Implement functions in #79 
增加了一個使用者可以設定的參數“dataDenpendency”，不設定時默認為overload possion partitioner。
當設置為“true”時則會根據當前集群的狀況，分配一個狀況最好的（thoughput最小的）node。從該node中再挑選一個隨即partition，接下去所有record都會發送給這個partition。

我有思考過是否需要沿用possion partitioner的計算方式。但是possion partitioner需要收集一定時間的數據，才能得出結果。我認為使用者建立producer發送資料應該不希望延遲一小段時間再開始send。所以直接選擇了比較thoughout狀況進行抉擇。