### PR TITLE
Add migrator interface

### DIFF
--- a/app/src/main/java/org/astraea/topic/Migrator.java
+++ b/app/src/main/java/org/astraea/topic/Migrator.java
@@ -1,0 +1,31 @@
+package org.astraea.topic;
+
+import java.util.Set;
+
+/** used to migrate partitions to another broker or broker folder. */
+public interface Migrator {
+  /**
+   * move all partitions (leader replica and follower replicas) of topic
+   *
+   * @param topic topic name
+   * @return this migrator
+   */
+  Migrator topic(String topic);
+
+  /**
+   * move one partition (leader replica and follower replicas) of topic
+   *
+   * @param topic topic name
+   * @param partition partition id
+   * @return this migrator
+   */
+  Migrator partition(String topic, int partition);
+
+  /**
+   * move partitions to specify brokers. Noted that the number of brokers must be equal to the
+   * number of replicas
+   *
+   * @param brokers to host partitions
+   */
+  void moveTo(Set<Integer> brokers);
+}

--- a/app/src/main/java/org/astraea/topic/ReplicaCollie.java
+++ b/app/src/main/java/org/astraea/topic/ReplicaCollie.java
@@ -59,7 +59,8 @@ public class ReplicaCollie {
             });
     result.forEach(
         (tp, assignments) -> {
-          if (!args.verify) admin.reassign(tp.topic(), tp.partition(), assignments.getValue());
+          if (!args.verify)
+            admin.migrator().partition(tp.topic(), tp.partition()).moveTo(assignments.getValue());
         });
     return result;
   }

--- a/app/src/main/java/org/astraea/topic/TopicAdmin.java
+++ b/app/src/main/java/org/astraea/topic/TopicAdmin.java
@@ -50,12 +50,6 @@ public interface TopicAdmin extends Closeable {
   /** @return all brokers' ids */
   Set<Integer> brokerIds();
 
-  /**
-   * Assign the topic partition to specific brokers.
-   *
-   * @param topicName topic name
-   * @param partition partition
-   * @param brokers to hold all the
-   */
-  void reassign(String topicName, int partition, Set<Integer> brokers);
+  /** @return a partition migrator used to move partitions to another broker or folder. */
+  Migrator migrator();
 }

--- a/app/src/test/java/org/astraea/topic/TopicAdminTest.java
+++ b/app/src/test/java/org/astraea/topic/TopicAdminTest.java
@@ -136,14 +136,14 @@ public class TopicAdminTest extends RequireBrokerCluster {
 
   @Test
   @DisabledOnOs(WINDOWS)
-  void testReassign() throws IOException, InterruptedException {
-    var topicName = "testReassign";
+  void testMigrateSinglePartition() throws IOException, InterruptedException {
+    var topicName = "testMigrateSinglePartition";
     try (var topicAdmin = TopicAdmin.of(bootstrapServers())) {
       topicAdmin.creator().topic(topicName).numberOfPartitions(1).create();
       // wait for syncing topic creation
       TimeUnit.SECONDS.sleep(5);
       var broker = topicAdmin.brokerIds().iterator().next();
-      topicAdmin.reassign(topicName, 0, Set.of(broker));
+      topicAdmin.migrator().partition(topicName, 0).moveTo(Set.of(broker));
       Utils.waitFor(
           () -> {
             var replicas = topicAdmin.replicas(Set.of(topicName));
@@ -151,6 +151,27 @@ public class TopicAdminTest extends RequireBrokerCluster {
             return replicas.size() == 1
                 && partitionReplicas.size() == 1
                 && partitionReplicas.get(0).broker() == broker;
+          });
+    }
+  }
+
+  @Test
+  @DisabledOnOs(WINDOWS)
+  void testMigrateAllPartitions() throws IOException, InterruptedException {
+    var topicName = "testMigrateAllPartitions";
+    try (var topicAdmin = TopicAdmin.of(bootstrapServers())) {
+      topicAdmin.creator().topic(topicName).numberOfPartitions(3).create();
+      // wait for syncing topic creation
+      TimeUnit.SECONDS.sleep(5);
+      var broker = topicAdmin.brokerIds().iterator().next();
+      topicAdmin.migrator().topic(topicName).moveTo(Set.of(broker));
+      Utils.waitFor(
+          () -> {
+            var replicas = topicAdmin.replicas(Set.of(topicName));
+            if (replicas.size() != 3) return false;
+            if (!replicas.values().stream().allMatch(rs -> rs.size() == 1)) return false;
+            return replicas.values().stream()
+                .allMatch(rs -> rs.stream().allMatch(r -> r.broker() == broker));
           });
     }
   }


### PR DESCRIPTION
考量我們要完整支援partition assignments，因此將該操作的設定獨立成一個介面(`migrator`)以便可擴充支援所有行為