### PR TITLE
The embedded jmx server should use JNDI

### DIFF
--- a/app/src/main/java/org/astraea/metrics/jmx/MBeanClient.java
+++ b/app/src/main/java/org/astraea/metrics/jmx/MBeanClient.java
@@ -1,5 +1,6 @@
 package org.astraea.metrics.jmx;
 
+import java.net.MalformedURLException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -19,6 +20,21 @@ import javax.management.remote.JMXServiceURL;
  * }</pre>
  */
 public interface MBeanClient extends AutoCloseable {
+
+  /**
+   * @param host the address of jmx server
+   * @param port the port of jmx server
+   * @return a mbean client using JNDI to lookup metrics.
+   */
+  static MBeanClient jndi(String host, int port) {
+    try {
+      return of(
+          new JMXServiceURL(
+              String.format("service:jmx:rmi:///jndi/rmi://%s:%s/jmxrmi", host, port)));
+    } catch (MalformedURLException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
 
   static MBeanClient of(JMXServiceURL url) {
     return new MBeanClientImpl(url);

--- a/app/src/test/java/org/astraea/service/RequireJmxServer.java
+++ b/app/src/test/java/org/astraea/service/RequireJmxServer.java
@@ -29,7 +29,7 @@ public abstract class RequireJmxServer {
    *
    * @return JMXConnectorServer
    */
-  public static JMXConnectorServer jmxConnectorServer(int port) {
+  private static JMXConnectorServer jmxConnectorServer(int port) {
     try {
       LocateRegistry.createRegistry(port);
       var mBeanServer = ManagementFactory.getPlatformMBeanServer();
@@ -49,7 +49,7 @@ public abstract class RequireJmxServer {
     }
   }
 
-  public static int freePort() {
+  private static int freePort() {
     try (var server = new ServerSocket(0)) {
       return server.getLocalPort();
     } catch (IOException e) {

--- a/app/src/test/java/org/astraea/service/RequireJmxServer.java
+++ b/app/src/test/java/org/astraea/service/RequireJmxServer.java
@@ -1,6 +1,10 @@
 package org.astraea.service;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.management.ManagementFactory;
+import java.net.ServerSocket;
+import java.rmi.registry.LocateRegistry;
 import javax.management.remote.JMXConnectorServer;
 import javax.management.remote.JMXConnectorServerFactory;
 import javax.management.remote.JMXServiceURL;
@@ -9,7 +13,7 @@ import org.junit.jupiter.api.AfterAll;
 
 public abstract class RequireJmxServer {
 
-  private static final JMXConnectorServer JMX_CONNECTOR_SERVER = jmxConnectorServer();
+  private static final JMXConnectorServer JMX_CONNECTOR_SERVER = jmxConnectorServer(freePort());
 
   protected static JMXServiceURL jmxServiceURL() {
     return JMX_CONNECTOR_SERVER.getAddress();
@@ -25,16 +29,31 @@ public abstract class RequireJmxServer {
    *
    * @return JMXConnectorServer
    */
-  private static JMXConnectorServer jmxConnectorServer() {
+  public static JMXConnectorServer jmxConnectorServer(int port) {
     try {
-      var serviceURL = new JMXServiceURL("service:jmx:rmi://127.0.0.1");
+      LocateRegistry.createRegistry(port);
       var mBeanServer = ManagementFactory.getPlatformMBeanServer();
       var jmxServer =
-          JMXConnectorServerFactory.newJMXConnectorServer(serviceURL, null, mBeanServer);
+          JMXConnectorServerFactory.newJMXConnectorServer(
+              // we usually use JNDI to get metrics in production, so the embedded server should use
+              // JNDI too.
+              new JMXServiceURL(
+                  String.format(
+                      "service:jmx:rmi://127.0.0.1:%s/jndi/rmi://127.0.0.1:%s/jmxrmi", port, port)),
+              null,
+              mBeanServer);
       jmxServer.start();
       return jmxServer;
     } catch (Exception e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  public static int freePort() {
+    try (var server = new ServerSocket(0)) {
+      return server.getLocalPort();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
     }
   }
 }

--- a/app/src/test/java/org/astraea/service/RequireJmxServerTest.java
+++ b/app/src/test/java/org/astraea/service/RequireJmxServerTest.java
@@ -9,8 +9,13 @@ import org.junit.jupiter.api.Test;
 public class RequireJmxServerTest extends RequireBrokerCluster {
 
   @Test
-  void testQueryBeans() throws Exception {
-    try (var client = MBeanClient.of(jmxServiceURL())) {
+  void testQueryBeans() {
+    testQueryBeans(MBeanClient.jndi(jmxServiceURL().getHost(), jmxServiceURL().getPort()));
+    testQueryBeans(MBeanClient.of(jmxServiceURL()));
+  }
+
+  private void testQueryBeans(MBeanClient client) {
+    try (client) {
       var result = client.queryBeans(BeanQuery.all());
       Assertions.assertFalse(result.isEmpty());
     }
@@ -18,7 +23,12 @@ public class RequireJmxServerTest extends RequireBrokerCluster {
 
   @Test
   void testMemory() throws Exception {
-    try (var client = MBeanClient.of(jmxServiceURL())) {
+    testMemory(MBeanClient.jndi(jmxServiceURL().getHost(), jmxServiceURL().getPort()));
+    testMemory(MBeanClient.of(jmxServiceURL()));
+  }
+
+  private void testMemory(MBeanClient client) {
+    try (client) {
       var memory = KafkaMetrics.Host.jvmMemory(client);
       Assertions.assertNotEquals(0, memory.heapMemoryUsage().getMax());
     }


### PR DESCRIPTION
將測試用途的jmx server也改成用JNDI，這樣與我們實際使用一致