### PR TITLE
Rename the image name from spark to spark-job

### DIFF
--- a/docker/submit_spark_job.sh
+++ b/docker/submit_spark_job.sh
@@ -34,7 +34,7 @@ done
 
 spark_user=astraea
 version=${REVISION:-${VERSION:-3.1.2}}
-repo=${REPO:-astraea/spark}
+repo=${REPO:-astraea/spark-job}
 image_name="$repo:$version"
 run_container=${RUN:-true}
 


### PR DESCRIPTION
用來提交任務的docker和用來建立叢集的應該要分開