### PR TITLE
新增record key分佈設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Run the benchmark from source
 10. --prop.file: the path to property file.
 11. --partitioner: the partitioner to use in producers
 12. --jmx.servers: the jmx server addresses of the brokers 
-13. --key.distribution: possible keys and key possibility for record. Default: (No key)
+13. --key.distribution: Name of the distribution. Default: (No key)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Run the benchmark from source
 10. --prop.file: the path to property file.
 11. --partitioner: the partitioner to use in producers
 12. --jmx.servers: the jmx server addresses of the brokers 
-13. --key.distribution: Name of the distribution. Default: (No key)
+13. --key.distribution: Name of the distribution. Available distribution names: "uniform", "zipfian", "latest". Default: (No key)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Run the benchmark from source
 10. --prop.file: the path to property file.
 11. --partitioner: the partitioner to use in producers
 12. --jmx.servers: the jmx server addresses of the brokers 
+13. --key.distribution: possible keys and key possibility for record. Default: (No key)
 
 ---
 

--- a/app/src/main/java/org/astraea/performance/Distribution.java
+++ b/app/src/main/java/org/astraea/performance/Distribution.java
@@ -1,0 +1,23 @@
+package org.astraea.performance;
+
+import com.beust.jcommander.IStringConverter;
+import com.beust.jcommander.ParameterException;
+
+import java.util.Set;
+
+/** Name of distributions. */
+public enum Distribution {
+    NONE, UNIFORM, ZIPFIAN, LATEST;
+
+    public static class DistributionConverter implements IStringConverter<Distribution> {
+        @Override
+        public Distribution convert(String value) {
+            switch (value){
+                case "uniform": return UNIFORM;
+                case "zipfian": return ZIPFIAN;
+                case "latest": return LATEST;
+                default: throw new ParameterException("Unknown distribution.");
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/astraea/performance/Distribution.java
+++ b/app/src/main/java/org/astraea/performance/Distribution.java
@@ -34,24 +34,25 @@ public interface Distribution {
     }
   }
 
+  /** A distribution for providing a random long number from range [0, 2147483647) */
   static Distribution uniform() {
     return uniform(Integer.MAX_VALUE);
   }
 
-  /** Provide a random long number */
+  /** A distribution for providing a random long number from range [0, N) */
   static Distribution uniform(int N) {
     var rand = new Random();
     return () -> (long) (rand.nextInt(N));
   }
 
-  /** Provide different value every 2 seconds */
+  /** A distribution for providing different value every 2 seconds */
   static Distribution latest() {
     return () -> System.currentTimeMillis() / 2000L;
   }
 
   /**
-   * Building a zipfian distribution with PDF: 1/k/H_N, where H_N is the Nth harmonic number; k is
-   * the key id
+   * Building a zipfian distribution with PDF: 1/k/H_N, where H_N is the Nth harmonic number (= 1/1
+   * + 1/2 + ... + 1/N); k is the key id
    */
   static Distribution zipfian(int N) {
     var rand = new Random();

--- a/app/src/main/java/org/astraea/performance/Distribution.java
+++ b/app/src/main/java/org/astraea/performance/Distribution.java
@@ -3,21 +3,26 @@ package org.astraea.performance;
 import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.ParameterException;
 
-import java.util.Set;
-
 /** Name of distributions. */
 public enum Distribution {
-    NONE, UNIFORM, ZIPFIAN, LATEST;
+  NONE,
+  UNIFORM,
+  ZIPFIAN,
+  LATEST;
 
-    public static class DistributionConverter implements IStringConverter<Distribution> {
-        @Override
-        public Distribution convert(String value) {
-            switch (value){
-                case "uniform": return UNIFORM;
-                case "zipfian": return ZIPFIAN;
-                case "latest": return LATEST;
-                default: throw new ParameterException("Unknown distribution.");
-            }
-        }
+  public static class DistributionConverter implements IStringConverter<Distribution> {
+    @Override
+    public Distribution convert(String value) {
+      switch (value) {
+        case "uniform":
+          return UNIFORM;
+        case "zipfian":
+          return ZIPFIAN;
+        case "latest":
+          return LATEST;
+        default:
+          throw new ParameterException("Unknown distribution.");
+      }
     }
+  }
 }

--- a/app/src/main/java/org/astraea/performance/Distribution.java
+++ b/app/src/main/java/org/astraea/performance/Distribution.java
@@ -2,27 +2,70 @@ package org.astraea.performance;
 
 import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.ParameterException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
-/** Name of distributions. */
-public enum Distribution {
-  NONE,
-  UNIFORM,
-  ZIPFIAN,
-  LATEST;
+/** Randomly generate a long number with respect to some distribution */
+public interface Distribution extends Supplier<Long> {
 
-  public static class DistributionConverter implements IStringConverter<Distribution> {
+  class DistributionConverter implements IStringConverter<Distribution> {
     @Override
-    public Distribution convert(String value) {
-      switch (value) {
+    public Distribution convert(String rawArgument) {
+      var args = rawArgument.split(":");
+      var name = rawArgument.split(":")[0];
+
+      switch (name) {
         case "uniform":
-          return UNIFORM;
-        case "zipfian":
-          return ZIPFIAN;
+          if (args.length > 1) return uniform(Integer.parseInt(args[1]));
+          return uniform();
         case "latest":
-          return LATEST;
+          return latest();
+        case "zipfian":
+          if (args.length > 1) return zipfian(Integer.parseInt(args[1]));
+          return zipfian(30);
         default:
-          throw new ParameterException("Unknown distribution.");
+          throw new ParameterException("Unknown distribution \"" + name + "\".");
       }
     }
+  }
+
+  static Distribution uniform() {
+    return uniform(Integer.MAX_VALUE);
+  }
+
+  /** Provide a random long number */
+  static Distribution uniform(int N) {
+    var rand = new Random();
+    return () -> (long) (rand.nextInt(N));
+  }
+
+  /** Provide different value every 2 seconds */
+  static Distribution latest() {
+    return () -> System.currentTimeMillis() / 2000L;
+  }
+
+  /**
+   * Building a zipfian distribution with PDF: 1/k/H_N, where H_N is the Nth harmonic number; k is
+   * the key id
+   */
+  static Distribution zipfian(int N) {
+    var rand = new Random();
+    final List<Double> cumulativeDensityTable = new ArrayList<>();
+    var H_N = IntStream.range(1, N + 1).mapToDouble(k -> 1D / k).sum();
+    cumulativeDensityTable.add(1D / H_N);
+    IntStream.range(1, N)
+        .forEach(
+            i ->
+                cumulativeDensityTable.add(cumulativeDensityTable.get(i - 1) + 1D / (i + 1) / H_N));
+    return () -> {
+      final double randNum = rand.nextDouble();
+      for (int i = 0; i < cumulativeDensityTable.size(); ++i) {
+        if (randNum < cumulativeDensityTable.get(i)) return (long) i;
+      }
+      return (long) cumulativeDensityTable.size() - 1L;
+    };
   }
 }

--- a/app/src/main/java/org/astraea/performance/Distribution.java
+++ b/app/src/main/java/org/astraea/performance/Distribution.java
@@ -5,11 +5,12 @@ import com.beust.jcommander.ParameterException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
 /** Randomly generate a long number with respect to some distribution */
-public interface Distribution extends Supplier<Long> {
+public interface Distribution {
+
+  long get();
 
   class DistributionConverter implements IStringConverter<Distribution> {
     @Override
@@ -27,7 +28,8 @@ public interface Distribution extends Supplier<Long> {
           if (args.length > 1) return zipfian(Integer.parseInt(args[1]));
           return zipfian(30);
         default:
-          throw new ParameterException("Unknown distribution \"" + name + "\".");
+          throw new ParameterException(
+              "Unknown distribution \"" + name + "\". use \"uniform\", \"latest\", \"zipfian\".");
       }
     }
   }

--- a/app/src/main/java/org/astraea/performance/Manager.java
+++ b/app/src/main/java/org/astraea/performance/Manager.java
@@ -105,6 +105,6 @@ public class Manager {
   /** Randomly choose a key according to the distribution. */
   public Optional<byte[]> getKey() {
     if (distribution == null) return Optional.empty();
-    return Optional.of(("" + distribution.get()).getBytes());
+    return Optional.of((String.valueOf(distribution.get())).getBytes());
   }
 }

--- a/app/src/main/java/org/astraea/performance/Manager.java
+++ b/app/src/main/java/org/astraea/performance/Manager.java
@@ -22,7 +22,7 @@ public class Manager {
   private final List<Metrics> producerMetrics, consumerMetrics;
   private final long start = System.currentTimeMillis();
   private final AtomicLong payloadNum = new AtomicLong(0);
-  private final String distribution;
+  private final Distribution distribution;
   private final List<Double> cumulativeDensityTable = new ArrayList<>();
 
   /**
@@ -50,7 +50,7 @@ public class Manager {
     this.consumerMetrics = consumerMetrics;
     this.exeTime = argument.exeTime;
     this.distribution = argument.distribution;
-    if (this.distribution.equals("zipfian")) {
+    if (this.distribution == Distribution.ZIPFIAN) {
       buildZipfianTable(30);
     }
   }
@@ -110,10 +110,10 @@ public class Manager {
   /** Randomly choose a key according to the distribution. */
   public Optional<byte[]> getKey() {
     switch (distribution) {
-      case "uniform":
+      case UNIFORM:
         // The key uniformly distribute in integer range
         return Optional.of(("key-" + rand.nextInt()).getBytes());
-      case "zipfian":
+      case ZIPFIAN:
         // The first key ("key-0") has double possibility than the second key, has
         // triple possibility than the third key, and so on.
         final double randNum = rand.nextDouble();
@@ -121,7 +121,7 @@ public class Manager {
           if (randNum < cumulativeDensityTable.get(i)) return Optional.of(("key-" + i).getBytes());
         }
         return Optional.empty();
-      case "latest":
+      case LATEST:
         // Keys in a period of time are the same
         return Optional.of(("key-" + System.currentTimeMillis() / 2000).getBytes());
       default:

--- a/app/src/main/java/org/astraea/performance/Manager.java
+++ b/app/src/main/java/org/astraea/performance/Manager.java
@@ -105,6 +105,6 @@ public class Manager {
   /** Randomly choose a key according to the distribution. */
   public Optional<byte[]> getKey() {
     if (distribution == null) return Optional.empty();
-    return Optional.of(("key-" + distribution.get()).getBytes());
+    return Optional.of(("" + distribution.get()).getBytes());
   }
 }

--- a/app/src/main/java/org/astraea/performance/Manager.java
+++ b/app/src/main/java/org/astraea/performance/Manager.java
@@ -107,7 +107,7 @@ public class Manager {
     return producedDone() && consumedRecords() >= producedRecords();
   }
 
-  /** Randomly choose a key according to the possibility table. */
+  /** Randomly choose a key according to the distribution. */
   public Optional<byte[]> getKey() {
     switch (distribution) {
       case "uniform":

--- a/app/src/main/java/org/astraea/performance/Performance.java
+++ b/app/src/main/java/org/astraea/performance/Performance.java
@@ -275,7 +275,7 @@ public class Performance {
         names = {"--key.distribution"},
         description = "String: Distribution name. e.g. \"uniform\", \"zipfian\", \"latest\"",
         converter = Distribution.DistributionConverter.class)
-    Distribution distribution = Distribution.NONE;
+    Distribution distribution = null;
   }
 
   static class CompressionArgument implements IStringConverter<CompressionType> {

--- a/app/src/main/java/org/astraea/performance/Performance.java
+++ b/app/src/main/java/org/astraea/performance/Performance.java
@@ -273,8 +273,9 @@ public class Performance {
 
     @Parameter(
         names = {"--key.distribution"},
-        description = "String: Distribution name. e.g. \"uniform\", \"zipfian\", \"latest\"")
-    String distribution = "";
+        description = "String: Distribution name. e.g. \"uniform\", \"zipfian\", \"latest\"",
+    converter = Distribution.DistributionConverter.class)
+    Distribution distribution = Distribution.NONE;
   }
 
   static class CompressionArgument implements IStringConverter<CompressionType> {

--- a/app/src/main/java/org/astraea/performance/Performance.java
+++ b/app/src/main/java/org/astraea/performance/Performance.java
@@ -5,6 +5,8 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -169,6 +171,7 @@ public class Performance {
         producer
             .sender()
             .topic(param.topic)
+            .key(manager.getKey().orElse(null))
             .value(payload.get())
             .timestamp(start)
             .run()
@@ -269,6 +272,11 @@ public class Performance {
             "String: the compression algorithm used by producer. Available algorithm are none, gzip, snappy, lz4, and zstd",
         converter = CompressionArgument.class)
     CompressionType compression = CompressionType.NONE;
+
+    @Parameter(
+        names = {"--key.distribution"},
+        description = "String: a key and the possibility. e.g. \"key-01:0.2,key-02:0.3\"")
+    List<String> distribution = new ArrayList<>();
   }
 
   static class CompressionArgument implements IStringConverter<CompressionType> {

--- a/app/src/main/java/org/astraea/performance/Performance.java
+++ b/app/src/main/java/org/astraea/performance/Performance.java
@@ -274,7 +274,7 @@ public class Performance {
     @Parameter(
         names = {"--key.distribution"},
         description = "String: Distribution name. e.g. \"uniform\", \"zipfian\", \"latest\"",
-    converter = Distribution.DistributionConverter.class)
+        converter = Distribution.DistributionConverter.class)
     Distribution distribution = Distribution.NONE;
   }
 

--- a/app/src/main/java/org/astraea/performance/Performance.java
+++ b/app/src/main/java/org/astraea/performance/Performance.java
@@ -273,7 +273,8 @@ public class Performance {
 
     @Parameter(
         names = {"--key.distribution"},
-        description = "String: Distribution name. e.g. \"uniform\", \"zipfian\", \"latest\"",
+        description =
+            "String: Distribution name. Available distribution names: \"uniform\", \"zipfian\", \"latest\". Default: (No key)",
         converter = Distribution.DistributionConverter.class)
     Distribution distribution = null;
   }

--- a/app/src/main/java/org/astraea/performance/Performance.java
+++ b/app/src/main/java/org/astraea/performance/Performance.java
@@ -5,8 +5,6 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -275,8 +273,8 @@ public class Performance {
 
     @Parameter(
         names = {"--key.distribution"},
-        description = "String: a key and the possibility. e.g. \"key-01:0.2,key-02:0.3\"")
-    List<String> distribution = new ArrayList<>();
+        description = "String: Distribution name. e.g. \"uniform\", \"zipfian\", \"latest\"")
+    String distribution = "";
   }
 
   static class CompressionArgument implements IStringConverter<CompressionType> {

--- a/app/src/test/java/org/astraea/performance/DistributionTest.java
+++ b/app/src/test/java/org/astraea/performance/DistributionTest.java
@@ -1,0 +1,23 @@
+package org.astraea.performance;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DistributionTest {
+  @Test
+  void testLatest() throws InterruptedException {
+    var distribution = Distribution.latest();
+    Assertions.assertEquals(distribution.get(), distribution.get());
+
+    long first = distribution.get();
+    Thread.sleep(2000);
+
+    Assertions.assertNotEquals(first, distribution.get());
+  }
+
+  @Test
+  void testZipfian() {
+    var distribution = Distribution.zipfian(5);
+    Assertions.assertTrue(distribution.get() < 5);
+  }
+}

--- a/app/src/test/java/org/astraea/performance/ManagerTest.java
+++ b/app/src/test/java/org/astraea/performance/ManagerTest.java
@@ -52,4 +52,16 @@ public class ManagerTest {
     // Assertion failed with probability < 1/102400
     Assertions.assertFalse(same);
   }
+
+  @Test
+  void testGetKey() {
+    var argument = new Performance.Argument();
+    argument.distribution = List.of("key-01:0.5", "key-02:0.5");
+    var manager = new Manager(argument, List.of(), List.of());
+    Assertions.assertTrue(manager.getKey().isPresent());
+
+    argument.distribution = List.of();
+    manager = new Manager(argument, List.of(), List.of());
+    Assertions.assertTrue(manager.getKey().isEmpty());
+  }
 }

--- a/app/src/test/java/org/astraea/performance/ManagerTest.java
+++ b/app/src/test/java/org/astraea/performance/ManagerTest.java
@@ -56,11 +56,11 @@ public class ManagerTest {
   @Test
   void testGetKey() {
     var argument = new Performance.Argument();
-    argument.distribution = List.of("key-01:0.5", "key-02:0.5");
+    argument.distribution = "zipfian";
     var manager = new Manager(argument, List.of(), List.of());
     Assertions.assertTrue(manager.getKey().isPresent());
 
-    argument.distribution = List.of();
+    argument.distribution = "";
     manager = new Manager(argument, List.of(), List.of());
     Assertions.assertTrue(manager.getKey().isEmpty());
   }

--- a/app/src/test/java/org/astraea/performance/ManagerTest.java
+++ b/app/src/test/java/org/astraea/performance/ManagerTest.java
@@ -56,11 +56,11 @@ public class ManagerTest {
   @Test
   void testGetKey() {
     var argument = new Performance.Argument();
-    argument.distribution = "zipfian";
+    argument.distribution = Distribution.ZIPFIAN;
     var manager = new Manager(argument, List.of(), List.of());
     Assertions.assertTrue(manager.getKey().isPresent());
 
-    argument.distribution = "";
+    argument.distribution = Distribution.NONE;
     manager = new Manager(argument, List.of(), List.of());
     Assertions.assertTrue(manager.getKey().isEmpty());
   }

--- a/app/src/test/java/org/astraea/performance/ManagerTest.java
+++ b/app/src/test/java/org/astraea/performance/ManagerTest.java
@@ -56,11 +56,20 @@ public class ManagerTest {
   @Test
   void testGetKey() {
     var argument = new Performance.Argument();
-    argument.distribution = Distribution.ZIPFIAN;
+
+    argument.distribution = Distribution.uniform();
     var manager = new Manager(argument, List.of(), List.of());
     Assertions.assertTrue(manager.getKey().isPresent());
 
-    argument.distribution = Distribution.NONE;
+    argument.distribution = Distribution.zipfian(10);
+    manager = new Manager(argument, List.of(), List.of());
+    Assertions.assertTrue(manager.getKey().isPresent());
+
+    argument.distribution = Distribution.latest();
+    manager = new Manager(argument, List.of(), List.of());
+    Assertions.assertTrue(manager.getKey().isPresent());
+
+    argument.distribution = null;
     manager = new Manager(argument, List.of(), List.of());
     Assertions.assertTrue(manager.getKey().isEmpty());
   }


### PR DESCRIPTION
#135  新增一個參數用以設定record key的分佈情況。

使用方法
`performance --bootstrap.servers localhost:9092 --key.distribution key-01:0.2,key-02:0.3`
可以讓20%的record使用"key-01"作為record key；30%的record使用"key-02"作為record key；剩下50%的record不使用key。