### PR TITLE
Use `DataSize` to rewrite `--record.size` for performance tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Run the benchmark from source
 5. --consumers: the number of consumers (threads). Default: 1
 6. --producers: the number of producers (threads). Default: 1
 7. --run.until: the total number of records sent by the producers. Default: 1000records
-8. --record.size: the (bound of) record size in byte. Default: 1024 byte
+8. --record.size: the (bound of) record size in byte. Default: 1 KiB
 9. --fixed.size: the flag to let all records have the same size
 10. --prop.file: the path to property file.
 11. --partitioner: the partitioner to use in producers

--- a/app/src/main/java/org/astraea/performance/Manager.java
+++ b/app/src/main/java/org/astraea/performance/Manager.java
@@ -6,6 +6,8 @@ import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import org.astraea.utils.DataSize;
+import org.astraea.utils.DataUnit;
 
 /**
  * Thread safe This class is used for managing the start/end of the producer/consumer threads.
@@ -15,7 +17,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class Manager {
   private final ExeTime exeTime;
   private final boolean fixedSize;
-  private final int size;
+  private final DataSize dataSize;
   private final CountDownLatch getAssignment;
   private final AtomicInteger producerClosed;
   private final Random rand = new Random();
@@ -42,7 +44,7 @@ public class Manager {
   public Manager(
       Performance.Argument argument, List<Metrics> producerMetrics, List<Metrics> consumerMetrics) {
     this.fixedSize = argument.fixedSize;
-    this.size = argument.recordSize;
+    this.dataSize = argument.recordSize;
     this.getAssignment = new CountDownLatch(argument.consumers);
     this.producerClosed = new AtomicInteger(argument.producers);
     this.producerMetrics = producerMetrics;
@@ -61,7 +63,10 @@ public class Manager {
     if (exeTime.percentage(payloadNum.getAndIncrement(), System.currentTimeMillis() - start)
         >= 100D) return Optional.empty();
 
-    byte[] payload = (this.fixedSize) ? new byte[size] : new byte[rand.nextInt(size) + 1];
+    byte[] payload =
+        (this.fixedSize)
+            ? new byte[dataSize.measurement(DataUnit.Byte).intValue()]
+            : new byte[rand.nextInt(dataSize.measurement(DataUnit.Byte).intValue()) + 1];
     rand.nextBytes(payload);
     return Optional.of(payload);
   }

--- a/app/src/main/java/org/astraea/performance/Manager.java
+++ b/app/src/main/java/org/astraea/performance/Manager.java
@@ -45,6 +45,8 @@ public class Manager {
       Performance.Argument argument, List<Metrics> producerMetrics, List<Metrics> consumerMetrics) {
     this.fixedSize = argument.fixedSize;
     this.dataSize = argument.recordSize;
+    if (dataSize.greaterThan(DataUnit.Byte.of(Integer.MAX_VALUE)))
+      throw new IllegalArgumentException("record size exceed integer range");
     this.getAssignment = new CountDownLatch(argument.consumers);
     this.producerClosed = new AtomicInteger(argument.producers);
     this.producerMetrics = producerMetrics;

--- a/app/src/main/java/org/astraea/performance/Manager.java
+++ b/app/src/main/java/org/astraea/performance/Manager.java
@@ -46,7 +46,8 @@ public class Manager {
     this.fixedSize = argument.fixedSize;
     this.dataSize = argument.recordSize;
     if (dataSize.greaterThan(DataUnit.Byte.of(Integer.MAX_VALUE)))
-      throw new IllegalArgumentException("record size exceed integer range");
+      throw new IllegalArgumentException(
+          "Record size should be smaller than or equal to 2147483648 (Integer.MAX_VALUE) bytes");
     this.getAssignment = new CountDownLatch(argument.consumers);
     this.producerClosed = new AtomicInteger(argument.producers);
     this.producerMetrics = producerMetrics;

--- a/app/src/main/java/org/astraea/performance/Performance.java
+++ b/app/src/main/java/org/astraea/performance/Performance.java
@@ -243,7 +243,7 @@ public class Performance {
         names = {"--record.size"},
         description = "Integer: size of each record",
         converter = DataSize.Converter.class)
-    DataSize recordSize = DataUnit.of(1024, DataUnit.Byte);
+    DataSize recordSize = DataUnit.Byte.of(1024);
 
     @Parameter(
         names = {"--jmx.servers"},

--- a/app/src/main/java/org/astraea/performance/Performance.java
+++ b/app/src/main/java/org/astraea/performance/Performance.java
@@ -22,6 +22,8 @@ import org.astraea.concurrent.ThreadPool;
 import org.astraea.consumer.Consumer;
 import org.astraea.producer.Producer;
 import org.astraea.topic.TopicAdmin;
+import org.astraea.utils.DataSize;
+import org.astraea.utils.DataUnit;
 
 /**
  * Performance benchmark which includes
@@ -240,8 +242,8 @@ public class Performance {
     @Parameter(
         names = {"--record.size"},
         description = "Integer: size of each record",
-        validateWith = ArgumentUtil.PositiveLong.class)
-    int recordSize = 1024;
+        converter = DataSize.Converter.class)
+    DataSize recordSize = DataUnit.of(1024, DataUnit.Byte);
 
     @Parameter(
         names = {"--jmx.servers"},

--- a/app/src/main/java/org/astraea/performance/Performance.java
+++ b/app/src/main/java/org/astraea/performance/Performance.java
@@ -241,9 +241,9 @@ public class Performance {
 
     @Parameter(
         names = {"--record.size"},
-        description = "Integer: size of each record",
+        description = "DataSize: size of each record. e.g. \"500KiB\"",
         converter = DataSize.Converter.class)
-    DataSize recordSize = DataUnit.Byte.of(1024);
+    DataSize recordSize = DataUnit.KiB.of(1);
 
     @Parameter(
         names = {"--jmx.servers"},

--- a/app/src/main/java/org/astraea/utils/DataSize.java
+++ b/app/src/main/java/org/astraea/utils/DataSize.java
@@ -17,7 +17,7 @@ public class DataSize implements Comparable<DataSize> {
   private final BigInteger bits;
 
   // Parse number and DataUnit
-  private static final Pattern dataSizePattern =
+  private static final Pattern DATA_SIZE_PATTERN =
       Pattern.compile("(?<measurement>[0-9]+)\\s?(?<dataUnit>[a-zA-Z]+)");
 
   DataSize(long volume, DataUnit dataUnit) {
@@ -34,7 +34,7 @@ public class DataSize implements Comparable<DataSize> {
    * <pre>{@code
    * DataSize.parseDataSize("500KB");  // 500 KB  (500 * 1000 bytes)
    * DataSize.parseDataSize("500KiB"); // 500 KiB (500 * 1024 bytes)
-   * DataSize.parseDataSizeof("500Kb");  // 500 Kb  (500 * 1000 bits)
+   * DataSize.parseDataSize("500Kb");  // 500 Kb  (500 * 1000 bits)
    * DataSize.parseDataSize("500Kib"); // 500 Kib (500 * 1024 bits)
    * }</pre>
    *
@@ -42,7 +42,7 @@ public class DataSize implements Comparable<DataSize> {
    * @return a data size object of given measurement under specific data unit.
    */
   public static DataSize parseDataSize(String argument) {
-    Matcher matcher = dataSizePattern.matcher(argument);
+    Matcher matcher = DATA_SIZE_PATTERN.matcher(argument);
     if (matcher.matches()) {
       return DataUnit.valueOf(matcher.group("dataUnit"))
           .of(Long.parseLong(matcher.group("measurement")));

--- a/app/src/main/java/org/astraea/utils/DataSize.java
+++ b/app/src/main/java/org/astraea/utils/DataSize.java
@@ -16,39 +16,12 @@ public class DataSize implements Comparable<DataSize> {
 
   private final BigInteger bits;
 
-  // Parse number and DataUnit
-  private static final Pattern DATA_SIZE_PATTERN =
-      Pattern.compile("(?<measurement>[0-9]+)\\s?(?<dataUnit>[a-zA-Z]+)");
-
   DataSize(long volume, DataUnit dataUnit) {
     this(BigInteger.valueOf(volume).multiply(dataUnit.bits));
   }
 
   DataSize(BigInteger bigInteger) {
     this.bits = bigInteger;
-  }
-
-  /**
-   * Convert string to DataSize.
-   *
-   * <pre>{@code
-   * DataSize.parseDataSize("500KB");  // 500 KB  (500 * 1000 bytes)
-   * DataSize.parseDataSize("500KiB"); // 500 KiB (500 * 1024 bytes)
-   * DataSize.parseDataSize("500Kb");  // 500 Kb  (500 * 1000 bits)
-   * DataSize.parseDataSize("500Kib"); // 500 Kib (500 * 1024 bits)
-   * }</pre>
-   *
-   * @param argument number and the unit. e.g. "500MiB", "9876 KB"
-   * @return a data size object of given measurement under specific data unit.
-   */
-  public static DataSize parseDataSize(String argument) {
-    Matcher matcher = DATA_SIZE_PATTERN.matcher(argument);
-    if (matcher.matches()) {
-      return DataUnit.valueOf(matcher.group("dataUnit"))
-          .of(Long.parseLong(matcher.group("measurement")));
-    } else {
-      throw new IllegalArgumentException("Unknown DataSize \"" + argument + "\"");
-    }
   }
 
   /**
@@ -240,8 +213,32 @@ public class DataSize implements Comparable<DataSize> {
   }
 
   public static class Converter implements IStringConverter<DataSize> {
+    // Parse number and DataUnit
+    private static final Pattern DATA_SIZE_PATTERN =
+        Pattern.compile("(?<measurement>[0-9]+)\\s?(?<dataUnit>[a-zA-Z]+)");
+
+    /**
+     * Convert string to DataSize.
+     *
+     * <pre>{@code
+     * new DataSize.Converter().convert("500KB");  // 500 KB  (500 * 1000 bytes)
+     * new DataSize.Converter().convert("500KiB"); // 500 KiB (500 * 1024 bytes)
+     * new DataSize.Converter().convert("500Kb");  // 500 Kb  (500 * 1000 bits)
+     * new DataSize.Converter().convert("500Kib"); // 500 Kib (500 * 1024 bits)
+     * }</pre>
+     *
+     * @param argument number and the unit. e.g. "500MiB", "9876 KB"
+     * @return a data size object of given measurement under specific data unit.
+     */
+    @Override
     public DataSize convert(String argument) {
-      return DataSize.parseDataSize(argument);
+      Matcher matcher = DATA_SIZE_PATTERN.matcher(argument);
+      if (matcher.matches()) {
+        return DataUnit.valueOf(matcher.group("dataUnit"))
+            .of(Long.parseLong(matcher.group("measurement")));
+      } else {
+        throw new IllegalArgumentException("Unknown DataSize \"" + argument + "\"");
+      }
     }
   }
 }

--- a/app/src/main/java/org/astraea/utils/DataSize.java
+++ b/app/src/main/java/org/astraea/utils/DataSize.java
@@ -16,6 +16,10 @@ public class DataSize implements Comparable<DataSize> {
 
   private final BigInteger bits;
 
+  // Parse number and DataUnit
+  private static final Pattern dataSizePattern =
+      Pattern.compile("(?<measurement>[0-9]+)\\s?(?<dataUnit>[\\w&&[^\\d]]+)");
+
   DataSize(long volume, DataUnit dataUnit) {
     this(BigInteger.valueOf(volume).multiply(dataUnit.bits));
   }
@@ -37,10 +41,7 @@ public class DataSize implements Comparable<DataSize> {
    * @param argument number and the unit. e.g. "500MiB", "9876 KB"
    * @return a data size object of given measurement under specific data unit.
    */
-  public static DataSize of(String argument) {
-    // Parse number and DataUnit
-    Pattern dataSizePattern =
-        Pattern.compile("(?<measurement>[0-9]+)\\s?(?<dataUnit>[\\w&&[^\\d]]+)");
+  public static DataSize parseDataSize(String argument) {
     Matcher matcher = dataSizePattern.matcher(argument);
     if (matcher.find()) {
       return DataUnit.valueOf(matcher.group("dataUnit"))
@@ -240,7 +241,7 @@ public class DataSize implements Comparable<DataSize> {
 
   public static class Converter implements IStringConverter<DataSize> {
     public DataSize convert(String argument) {
-      return DataSize.of(argument);
+      return DataSize.parseDataSize(argument);
     }
   }
 }

--- a/app/src/main/java/org/astraea/utils/DataSize.java
+++ b/app/src/main/java/org/astraea/utils/DataSize.java
@@ -18,7 +18,7 @@ public class DataSize implements Comparable<DataSize> {
 
   // Parse number and DataUnit
   private static final Pattern dataSizePattern =
-      Pattern.compile("(?<measurement>[0-9]+)\\s?(?<dataUnit>[\\w&&[^\\d]]+)");
+      Pattern.compile("(?<measurement>[0-9]+)\\s?(?<dataUnit>[a-zA-Z]+)");
 
   DataSize(long volume, DataUnit dataUnit) {
     this(BigInteger.valueOf(volume).multiply(dataUnit.bits));
@@ -32,10 +32,10 @@ public class DataSize implements Comparable<DataSize> {
    * Convert string to DataSize.
    *
    * <pre>{@code
-   * DataSize.of("500KB");  // 500 KB  (500 * 1000 bytes)
-   * DataSize.of("500KiB"); // 500 KiB (500 * 1024 bytes)
-   * DataSize.of("500Kb");  // 500 Kb  (500 * 1000 bits)
-   * DataSize.of("500Kib"); // 500 Kib (500 * 1024 bits)
+   * DataSize.parseDataSize("500KB");  // 500 KB  (500 * 1000 bytes)
+   * DataSize.parseDataSize("500KiB"); // 500 KiB (500 * 1024 bytes)
+   * DataSize.parseDataSizeof("500Kb");  // 500 Kb  (500 * 1000 bits)
+   * DataSize.parseDataSize("500Kib"); // 500 Kib (500 * 1024 bits)
    * }</pre>
    *
    * @param argument number and the unit. e.g. "500MiB", "9876 KB"
@@ -43,11 +43,11 @@ public class DataSize implements Comparable<DataSize> {
    */
   public static DataSize parseDataSize(String argument) {
     Matcher matcher = dataSizePattern.matcher(argument);
-    if (matcher.find()) {
+    if (matcher.matches()) {
       return DataUnit.valueOf(matcher.group("dataUnit"))
           .of(Long.parseLong(matcher.group("measurement")));
     } else {
-      throw new IllegalArgumentException("Unknown DataSize");
+      throw new IllegalArgumentException("Unknown DataSize \"" + argument + "\"");
     }
   }
 

--- a/app/src/main/java/org/astraea/utils/DataUnit.java
+++ b/app/src/main/java/org/astraea/utils/DataUnit.java
@@ -92,24 +92,6 @@ public enum DataUnit {
   }
 
   /**
-   * Return a {@link DataSize} based on given measurement and unit.
-   *
-   * <pre>{@code
-   * DataUnit.of(500, DataUnit.KB);   // 500 KB  (500 * 1000 bytes)
-   * DataUnit.of(500, DataUnit.KiB);  // 500 KiB (500 * 1024 bytes)
-   * DataUnit.of(500, DataUnit.Kb);   // 500 Kb  (500 * 1000 bits)
-   * DataUnit.of(500, DataUnit.Kib);  // 500 Kib (500 * 1024 bits)
-   * }</pre>
-   *
-   * @param measurement the data size measurement.
-   * @param unit the data unit of given measurement.
-   * @return a size object of given measurement under specific data unit.
-   */
-  public static DataSize of(long measurement, DataUnit unit) {
-    return new DataSize(measurement, unit);
-  }
-
-  /**
    * List of recommended unit for display data, {@link DataSize#toString()} take advantage of this
    * collection to find ideal unit for string formalization.
    */

--- a/app/src/test/java/org/astraea/performance/ManagerTest.java
+++ b/app/src/test/java/org/astraea/performance/ManagerTest.java
@@ -2,6 +2,7 @@ package org.astraea.performance;
 
 import java.util.Arrays;
 import java.util.List;
+import org.astraea.utils.DataUnit;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +32,7 @@ public class ManagerTest {
   void testRandomSize() {
     var argument = new Performance.Argument();
     argument.exeTime = ExeTime.of("3records");
-    argument.recordSize = 102400;
+    argument.recordSize = DataUnit.of(100, DataUnit.KiB);
     var dataManager = new Manager(argument, List.of(), List.of());
     boolean sameSize = dataManager.payload().get().length == dataManager.payload().get().length;
 
@@ -45,7 +46,7 @@ public class ManagerTest {
   void testRandomContent() {
     var argument = new Performance.Argument();
     argument.exeTime = ExeTime.of("2records");
-    argument.recordSize = 102400;
+    argument.recordSize = DataUnit.of(100, DataUnit.KiB);
     var manager = new Manager(argument, List.of(), List.of());
     boolean same = Arrays.equals(manager.payload().get(), manager.payload().get());
 

--- a/app/src/test/java/org/astraea/performance/ManagerTest.java
+++ b/app/src/test/java/org/astraea/performance/ManagerTest.java
@@ -32,7 +32,7 @@ public class ManagerTest {
   void testRandomSize() {
     var argument = new Performance.Argument();
     argument.exeTime = ExeTime.of("3records");
-    argument.recordSize = DataUnit.of(100, DataUnit.KiB);
+    argument.recordSize = DataUnit.KiB.of(100);
     var dataManager = new Manager(argument, List.of(), List.of());
     boolean sameSize = dataManager.payload().get().length == dataManager.payload().get().length;
 
@@ -46,7 +46,7 @@ public class ManagerTest {
   void testRandomContent() {
     var argument = new Performance.Argument();
     argument.exeTime = ExeTime.of("2records");
-    argument.recordSize = DataUnit.of(100, DataUnit.KiB);
+    argument.recordSize = DataUnit.KiB.of(100);
     var manager = new Manager(argument, List.of(), List.of());
     boolean same = Arrays.equals(manager.payload().get(), manager.payload().get());
 

--- a/app/src/test/java/org/astraea/utils/DataSizeTest.java
+++ b/app/src/test/java/org/astraea/utils/DataSizeTest.java
@@ -147,6 +147,54 @@ class DataSizeTest {
   }
 
   @Test
+  void parseDataSize() {
+    assertEquals(DataUnit.Bit.of(100).toString(), DataSize.parseDataSize("100Bit").toString());
+    assertEquals(DataUnit.Kb.of(100).toString(), DataSize.parseDataSize("100 Kb").toString());
+    assertEquals(DataUnit.Mb.of(100).toString(), DataSize.parseDataSize("100 Mb").toString());
+    assertEquals(DataUnit.Gb.of(100).toString(), DataSize.parseDataSize("100 Gb").toString());
+    assertEquals(DataUnit.Tb.of(100).toString(), DataSize.parseDataSize("100 Tb").toString());
+    assertEquals(DataUnit.Pb.of(100).toString(), DataSize.parseDataSize("100 Pb").toString());
+    assertEquals(DataUnit.Eb.of(100).toString(), DataSize.parseDataSize("100 Eb").toString());
+    assertEquals(DataUnit.Zb.of(100).toString(), DataSize.parseDataSize("100 Zb").toString());
+    assertEquals(DataUnit.Yb.of(100).toString(), DataSize.parseDataSize("100 Yb").toString());
+
+    assertEquals(DataUnit.Kib.of(100).toString(), DataSize.parseDataSize("100 Kib").toString());
+    assertEquals(DataUnit.Mib.of(100).toString(), DataSize.parseDataSize("100 Mib").toString());
+    assertEquals(DataUnit.Gib.of(100).toString(), DataSize.parseDataSize("100 Gib").toString());
+    assertEquals(DataUnit.Tib.of(100).toString(), DataSize.parseDataSize("100 Tib").toString());
+    assertEquals(DataUnit.Pib.of(100).toString(), DataSize.parseDataSize("100 Pib").toString());
+    assertEquals(DataUnit.Eib.of(100).toString(), DataSize.parseDataSize("100 Eib").toString());
+    assertEquals(DataUnit.Zib.of(100).toString(), DataSize.parseDataSize("100 Zib").toString());
+    assertEquals(DataUnit.Yib.of(100).toString(), DataSize.parseDataSize("100 Yib").toString());
+
+    assertEquals(DataUnit.Byte.of(100).toString(), DataSize.parseDataSize("100Byte").toString());
+    assertEquals(DataUnit.KB.of(100).toString(), DataSize.parseDataSize("100 KB").toString());
+    assertEquals(DataUnit.MB.of(100).toString(), DataSize.parseDataSize("100 MB").toString());
+    assertEquals(DataUnit.GB.of(100).toString(), DataSize.parseDataSize("100 GB").toString());
+    assertEquals(DataUnit.TB.of(100).toString(), DataSize.parseDataSize("100 TB").toString());
+    assertEquals(DataUnit.PB.of(100).toString(), DataSize.parseDataSize("100 PB").toString());
+    assertEquals(DataUnit.EB.of(100).toString(), DataSize.parseDataSize("100 EB").toString());
+    assertEquals(DataUnit.ZB.of(100).toString(), DataSize.parseDataSize("100 ZB").toString());
+    assertEquals(DataUnit.YB.of(100).toString(), DataSize.parseDataSize("100 YB").toString());
+
+    assertEquals(DataUnit.KiB.of(100).toString(), DataSize.parseDataSize("100 KiB").toString());
+    assertEquals(DataUnit.MiB.of(100).toString(), DataSize.parseDataSize("100 MiB").toString());
+    assertEquals(DataUnit.GiB.of(100).toString(), DataSize.parseDataSize("100 GiB").toString());
+    assertEquals(DataUnit.TiB.of(100).toString(), DataSize.parseDataSize("100 TiB").toString());
+    assertEquals(DataUnit.PiB.of(100).toString(), DataSize.parseDataSize("100 PiB").toString());
+    assertEquals(DataUnit.EiB.of(100).toString(), DataSize.parseDataSize("100 EiB").toString());
+    assertEquals(DataUnit.ZiB.of(100).toString(), DataSize.parseDataSize("100 ZiB").toString());
+    assertEquals(DataUnit.YiB.of(100).toString(), DataSize.parseDataSize("100 YiB").toString());
+
+    assertThrows(IllegalArgumentException.class, () -> DataSize.parseDataSize("5000 MB xxx"));
+    assertThrows(
+        IllegalArgumentException.class, () -> DataSize.parseDataSize("5000 MB per second"));
+    assertThrows(IllegalArgumentException.class, () -> DataSize.parseDataSize("xxx 5000 MB"));
+    assertThrows(IllegalArgumentException.class, () -> DataSize.parseDataSize("5000 MB 400GB"));
+    assertThrows(IllegalArgumentException.class, () -> DataSize.parseDataSize("6.00 MB"));
+  }
+
+  @Test
   void measurement() {
     var value = DataUnit.PB.of(1);
 

--- a/app/src/test/java/org/astraea/utils/DataSizeTest.java
+++ b/app/src/test/java/org/astraea/utils/DataSizeTest.java
@@ -148,50 +148,50 @@ class DataSizeTest {
 
   @Test
   void parseDataSize() {
-    assertEquals(DataUnit.Bit.of(100).toString(), DataSize.parseDataSize("100Bit").toString());
-    assertEquals(DataUnit.Kb.of(100).toString(), DataSize.parseDataSize("100 Kb").toString());
-    assertEquals(DataUnit.Mb.of(100).toString(), DataSize.parseDataSize("100 Mb").toString());
-    assertEquals(DataUnit.Gb.of(100).toString(), DataSize.parseDataSize("100 Gb").toString());
-    assertEquals(DataUnit.Tb.of(100).toString(), DataSize.parseDataSize("100 Tb").toString());
-    assertEquals(DataUnit.Pb.of(100).toString(), DataSize.parseDataSize("100 Pb").toString());
-    assertEquals(DataUnit.Eb.of(100).toString(), DataSize.parseDataSize("100 Eb").toString());
-    assertEquals(DataUnit.Zb.of(100).toString(), DataSize.parseDataSize("100 Zb").toString());
-    assertEquals(DataUnit.Yb.of(100).toString(), DataSize.parseDataSize("100 Yb").toString());
+    var converter = new DataSize.Converter();
+    assertEquals(DataUnit.Bit.of(100).toString(), converter.convert("100Bit").toString());
+    assertEquals(DataUnit.Kb.of(100).toString(), converter.convert("100 Kb").toString());
+    assertEquals(DataUnit.Mb.of(100).toString(), converter.convert("100 Mb").toString());
+    assertEquals(DataUnit.Gb.of(100).toString(), converter.convert("100 Gb").toString());
+    assertEquals(DataUnit.Tb.of(100).toString(), converter.convert("100 Tb").toString());
+    assertEquals(DataUnit.Pb.of(100).toString(), converter.convert("100 Pb").toString());
+    assertEquals(DataUnit.Eb.of(100).toString(), converter.convert("100 Eb").toString());
+    assertEquals(DataUnit.Zb.of(100).toString(), converter.convert("100 Zb").toString());
+    assertEquals(DataUnit.Yb.of(100).toString(), converter.convert("100 Yb").toString());
 
-    assertEquals(DataUnit.Kib.of(100).toString(), DataSize.parseDataSize("100 Kib").toString());
-    assertEquals(DataUnit.Mib.of(100).toString(), DataSize.parseDataSize("100 Mib").toString());
-    assertEquals(DataUnit.Gib.of(100).toString(), DataSize.parseDataSize("100 Gib").toString());
-    assertEquals(DataUnit.Tib.of(100).toString(), DataSize.parseDataSize("100 Tib").toString());
-    assertEquals(DataUnit.Pib.of(100).toString(), DataSize.parseDataSize("100 Pib").toString());
-    assertEquals(DataUnit.Eib.of(100).toString(), DataSize.parseDataSize("100 Eib").toString());
-    assertEquals(DataUnit.Zib.of(100).toString(), DataSize.parseDataSize("100 Zib").toString());
-    assertEquals(DataUnit.Yib.of(100).toString(), DataSize.parseDataSize("100 Yib").toString());
+    assertEquals(DataUnit.Kib.of(100).toString(), converter.convert("100 Kib").toString());
+    assertEquals(DataUnit.Mib.of(100).toString(), converter.convert("100 Mib").toString());
+    assertEquals(DataUnit.Gib.of(100).toString(), converter.convert("100 Gib").toString());
+    assertEquals(DataUnit.Tib.of(100).toString(), converter.convert("100 Tib").toString());
+    assertEquals(DataUnit.Pib.of(100).toString(), converter.convert("100 Pib").toString());
+    assertEquals(DataUnit.Eib.of(100).toString(), converter.convert("100 Eib").toString());
+    assertEquals(DataUnit.Zib.of(100).toString(), converter.convert("100 Zib").toString());
+    assertEquals(DataUnit.Yib.of(100).toString(), converter.convert("100 Yib").toString());
 
-    assertEquals(DataUnit.Byte.of(100).toString(), DataSize.parseDataSize("100Byte").toString());
-    assertEquals(DataUnit.KB.of(100).toString(), DataSize.parseDataSize("100 KB").toString());
-    assertEquals(DataUnit.MB.of(100).toString(), DataSize.parseDataSize("100 MB").toString());
-    assertEquals(DataUnit.GB.of(100).toString(), DataSize.parseDataSize("100 GB").toString());
-    assertEquals(DataUnit.TB.of(100).toString(), DataSize.parseDataSize("100 TB").toString());
-    assertEquals(DataUnit.PB.of(100).toString(), DataSize.parseDataSize("100 PB").toString());
-    assertEquals(DataUnit.EB.of(100).toString(), DataSize.parseDataSize("100 EB").toString());
-    assertEquals(DataUnit.ZB.of(100).toString(), DataSize.parseDataSize("100 ZB").toString());
-    assertEquals(DataUnit.YB.of(100).toString(), DataSize.parseDataSize("100 YB").toString());
+    assertEquals(DataUnit.Byte.of(100).toString(), converter.convert("100Byte").toString());
+    assertEquals(DataUnit.KB.of(100).toString(), converter.convert("100 KB").toString());
+    assertEquals(DataUnit.MB.of(100).toString(), converter.convert("100 MB").toString());
+    assertEquals(DataUnit.GB.of(100).toString(), converter.convert("100 GB").toString());
+    assertEquals(DataUnit.TB.of(100).toString(), converter.convert("100 TB").toString());
+    assertEquals(DataUnit.PB.of(100).toString(), converter.convert("100 PB").toString());
+    assertEquals(DataUnit.EB.of(100).toString(), converter.convert("100 EB").toString());
+    assertEquals(DataUnit.ZB.of(100).toString(), converter.convert("100 ZB").toString());
+    assertEquals(DataUnit.YB.of(100).toString(), converter.convert("100 YB").toString());
 
-    assertEquals(DataUnit.KiB.of(100).toString(), DataSize.parseDataSize("100 KiB").toString());
-    assertEquals(DataUnit.MiB.of(100).toString(), DataSize.parseDataSize("100 MiB").toString());
-    assertEquals(DataUnit.GiB.of(100).toString(), DataSize.parseDataSize("100 GiB").toString());
-    assertEquals(DataUnit.TiB.of(100).toString(), DataSize.parseDataSize("100 TiB").toString());
-    assertEquals(DataUnit.PiB.of(100).toString(), DataSize.parseDataSize("100 PiB").toString());
-    assertEquals(DataUnit.EiB.of(100).toString(), DataSize.parseDataSize("100 EiB").toString());
-    assertEquals(DataUnit.ZiB.of(100).toString(), DataSize.parseDataSize("100 ZiB").toString());
-    assertEquals(DataUnit.YiB.of(100).toString(), DataSize.parseDataSize("100 YiB").toString());
+    assertEquals(DataUnit.KiB.of(100).toString(), converter.convert("100 KiB").toString());
+    assertEquals(DataUnit.MiB.of(100).toString(), converter.convert("100 MiB").toString());
+    assertEquals(DataUnit.GiB.of(100).toString(), converter.convert("100 GiB").toString());
+    assertEquals(DataUnit.TiB.of(100).toString(), converter.convert("100 TiB").toString());
+    assertEquals(DataUnit.PiB.of(100).toString(), converter.convert("100 PiB").toString());
+    assertEquals(DataUnit.EiB.of(100).toString(), converter.convert("100 EiB").toString());
+    assertEquals(DataUnit.ZiB.of(100).toString(), converter.convert("100 ZiB").toString());
+    assertEquals(DataUnit.YiB.of(100).toString(), converter.convert("100 YiB").toString());
 
-    assertThrows(IllegalArgumentException.class, () -> DataSize.parseDataSize("5000 MB xxx"));
-    assertThrows(
-        IllegalArgumentException.class, () -> DataSize.parseDataSize("5000 MB per second"));
-    assertThrows(IllegalArgumentException.class, () -> DataSize.parseDataSize("xxx 5000 MB"));
-    assertThrows(IllegalArgumentException.class, () -> DataSize.parseDataSize("5000 MB 400GB"));
-    assertThrows(IllegalArgumentException.class, () -> DataSize.parseDataSize("6.00 MB"));
+    assertThrows(IllegalArgumentException.class, () -> converter.convert("5000 MB xxx"));
+    assertThrows(IllegalArgumentException.class, () -> converter.convert("5000 MB per second"));
+    assertThrows(IllegalArgumentException.class, () -> converter.convert("xxx 5000 MB"));
+    assertThrows(IllegalArgumentException.class, () -> converter.convert("5000 MB 400GB"));
+    assertThrows(IllegalArgumentException.class, () -> converter.convert("6.00 MB"));
   }
 
   @Test

--- a/app/src/test/java/org/astraea/utils/DataSizeTest.java
+++ b/app/src/test/java/org/astraea/utils/DataSizeTest.java
@@ -227,7 +227,7 @@ class DataSizeTest {
 
   @Test
   void bits() {
-    BigInteger bit5566 = DataUnit.of(5566, DataUnit.Bit).bits();
+    BigInteger bit5566 = DataUnit.Bit.of(5566).bits();
 
     assertEquals(BigInteger.valueOf(5566), bit5566);
   }


### PR DESCRIPTION
為`DataSize`新增字串轉`DataSize`的方法，
並把Performance tool中的參數`--record.size`，改使用`DataSize`表示。(#155)