### PR TITLE
Add script to run astraea by docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ zookeeper.dockerfile
 broker.dockerfile
 kafka_tool.dockerfile
 spark.dockerfile
+astraea.dockerfile
 
 # we don't put binary file to git repo
 gradle-wrapper.jar

--- a/app/src/main/java/org/astraea/App.java
+++ b/app/src/main/java/org/astraea/App.java
@@ -27,13 +27,24 @@ public class App {
     var usage = "Usage: " + mains.keySet() + " [args ...]";
 
     if (args.size() < 1) {
-      throw new IllegalArgumentException(usage);
+      System.err.println(usage);
+      return;
     }
 
     var className = args.get(0);
 
+    if (className.toLowerCase().equals("help")) {
+      System.out.println(usage);
+      return;
+    }
+
     var targetClass = mains.get(className);
-    if (targetClass == null) throw new IllegalArgumentException(usage);
+
+    if (targetClass == null) {
+      System.err.println("the application \"" + className + "\" is nonexistent");
+      System.err.println(usage);
+      return;
+    }
 
     var method = targetClass.getDeclaredMethod("main", String[].class);
     try {

--- a/docker/start_astraea.sh
+++ b/docker/start_astraea.sh
@@ -5,7 +5,7 @@ if [[ "$(which docker)" == "" ]]; then
   exit 2
 fi
 
-docker_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+docker_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 dockerfile=$docker_dir/astraea.dockerfile
 image_name="astraea/astraea:latest"
 
@@ -25,10 +25,10 @@ RUN git clone https://github.com/skiptests/astraea
 # pre-build project to collect all dependencies
 WORKDIR /tmp/astraea
 RUN ./gradlew clean build -x test --no-daemon
-" > "$dockerfile"
+" >"$dockerfile"
 
 # build image only if the image does not exist locally
-if [[ "$(docker images -q $image_name 2> /dev/null)" == "" ]]; then
+if [[ "$(docker images -q $image_name 2>/dev/null)" == "" ]]; then
   docker build -t $image_name -f "$dockerfile" "$docker_dir"
 fi
 
@@ -38,7 +38,6 @@ else
   # shellcheck disable=SC2124
   result="$@"
 fi
-
 
 docker run --rm \
   $image_name \

--- a/docker/start_astraea.sh
+++ b/docker/start_astraea.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+if [[ "$(which docker)" == "" ]]; then
+  echo "you have to install docker"
+  exit 2
+fi
+
+docker_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+dockerfile=$docker_dir/astraea.dockerfile
+image_name="astraea/astraea:latest"
+
+echo "# this dockerfile is generated dynamically
+FROM ubuntu:20.04
+
+# Do not ask for confirmations when running apt-get, etc.
+ENV DEBIAN_FRONTEND noninteractive
+
+# install tools
+RUN apt-get update && apt-get upgrade -y && apt-get install -y openjdk-11-jdk wget git
+
+# clone repo
+WORKDIR /tmp
+RUN git clone https://github.com/skiptests/astraea
+
+# pre-build project to collect all dependencies
+WORKDIR /tmp/astraea
+RUN ./gradlew clean build -x test --no-daemon
+" > "$dockerfile"
+
+# build image only if the image does not exist locally
+if [[ "$(docker images -q $image_name 2> /dev/null)" == "" ]]; then
+  docker build -t $image_name -f "$dockerfile" "$docker_dir"
+fi
+
+if [[ -z "$1" ]]; then
+  result="help"
+else
+  # shellcheck disable=SC2124
+  result="$@"
+fi
+
+
+docker run --rm \
+  $image_name \
+  /bin/bash -c "./gradlew run --args=\"$result\""


### PR DESCRIPTION
這種腳本可以提供兩個好處:

1. 使用者只需要有docker就可以使用astraea的各種功能
2. 我們可以將所有東西封裝在docker image裡面，這樣使用者可以在無對外網路下使用astraea