### PR TITLE
Record performance result into a file

### DIFF
--- a/app/src/test/java/org/astraea/performance/TrackerTest.java
+++ b/app/src/test/java/org/astraea/performance/TrackerTest.java
@@ -1,11 +1,16 @@
 package org.astraea.performance;
 
+import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 import org.astraea.concurrent.ThreadPool;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TrackerTest {
+  static List<String> createdFiles = new ArrayList<>();
+
   @Test
   public void testTerminate() throws InterruptedException {
     var producerData = List.of(new Metrics());
@@ -16,6 +21,7 @@ public class TrackerTest {
 
     var manager = new Manager(argument, producerData, consumerData);
     try (Tracker tracker = new Tracker(producerData, consumerData, manager)) {
+      createdFiles.add(tracker.CSVName());
       Assertions.assertEquals(ThreadPool.Executor.State.RUNNING, tracker.execute());
       producerData.get(0).accept(1L, 1L);
       consumerData.get(0).accept(1L, 1L);
@@ -27,6 +33,7 @@ public class TrackerTest {
     producerData = List.of(new Metrics());
     manager = new Manager(argument, producerData, empty);
     try (Tracker tracker = new Tracker(producerData, empty, manager)) {
+      createdFiles.add(tracker.CSVName());
       Assertions.assertEquals(ThreadPool.Executor.State.RUNNING, tracker.execute());
       producerData.get(0).accept(1L, 1L);
       manager.producerClosed();
@@ -39,6 +46,7 @@ public class TrackerTest {
     consumerData = List.of(new Metrics());
     manager = new Manager(argument, producerData, consumerData);
     try (Tracker tracker = new Tracker(producerData, consumerData, manager)) {
+      createdFiles.add(tracker.CSVName());
       tracker.start = System.currentTimeMillis();
       Assertions.assertEquals(ThreadPool.Executor.State.RUNNING, tracker.execute());
 
@@ -50,5 +58,10 @@ public class TrackerTest {
 
       Assertions.assertEquals(ThreadPool.Executor.State.DONE, tracker.execute());
     }
+  }
+
+  @AfterAll
+  static void deleteCreatedFiles() {
+    createdFiles.forEach(fileName -> new File(fileName).delete());
   }
 }


### PR DESCRIPTION
如#172 所述。

下表是Performance tool輸出檔案以後會長成的格式：

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">

<html>

<body>


Time \ Name | Output throughput (MiB/sec) | Input throughput (MiB/sec) | Publish max latency (ms) | Publish min latency (ms) | End-to-end max latency (ms) | End-to-end min latency (ms) | Producer[0] average throughput (MB/sec) | Producer[0] average publish latency (ms) | Producer[1] average throughput (MB/sec) | Producer[1] average publish latency (ms) | Consumer[0] average throughput (MB/sec) | Consumer[0] average ene-to-end latency (ms) | Consumer[1] average throughput (MB/sec) | Consumer[1] average ene-to-end latency (ms) | Consumer[2] average throughput (MB/sec) | Consumer[2] average ene-to-end latency (ms) 
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
0h0m1s | 6.08759593963623 | 3.62850570678711 | 754 | 15 | 753 | 21 | 3.17322540283203 | 261.508580343214 | 2.9143705368042 | 290.101154107264 | 0.682624816894531 | 351.233576642336 | 1.70933151245117 | 578.575547866206 | 1.23654937744141 | 468.623015873016 
0h0m2s | 5.39944362640381 | 5.26212596893311 | 1743 | 15 | 1747 | 21 | 2.60952949523926 | 647.102777252974 | 2.78991317749023 | 727.425817860301 | 1.79415321350098 | 942.397956365645 | 1.66773223876953 | 827.639708029197 | 1.8002405166626 | 894.878921298843 
0h0m3s | 5.22609519958496 | 5.20098781585693 | 2714 | 15 | 2700 | 21 | 2.62790107727051 | 1184.98296231812 | 2.59819316864014 | 1166.75473843821 | 1.72470378875732 | 1343.46588954711 | 1.74323654174805 | 1328.57796799405 | 1.73304748535156 | 1314.7491967492 
0h0m4s | 5.22846221923828 | 5.17915058135986 | 3688 | 15 | 3684 | 21 | 2.48097991943359 | 1601.2933582972 | 2.74748229980469 | 1780.81811703928 | 1.7236385345459 | 1822.00441155543 | 1.72826194763184 | 1785.39535211268 | 1.72725009918213 | 1782.64532159591 
0h0m5s | 5.12305355072022 | 5.10611915588379 | 4668 | 15 | 4637 | 21 | 2.37517166137695 | 2008.10892312763 | 2.74788188934326 | 2233.67806511363 | 1.69643306732178 | 2244.45814114391 | 1.7082052230835 | 2220.17615516259 | 1.7014799118042 | 2207.61758267081
0h0m6s | 4.99299335479736 | 4.98812294006348 | 5618 | 15 | 5623 | 21 | 2.37849044799805 | 2531.09120164327 | 2.61450290679932 | 2596.70770477496 | 1.66104888916016 | 2683.80967741935 | 1.66432571411133 | 2637.64611626772 | 1.66274642944336 | 2635.15763111373


</body>

</html>

已在windows上測試，並可以順利產生檔案。