### PR TITLE
Don't show help message when running kafka-tool

### DIFF
--- a/docker/start_kafka_tool.sh
+++ b/docker/start_kafka_tool.sh
@@ -88,8 +88,8 @@ if [[ "$RUN" != "true" ]]; then
 fi
 
 if [[ -n "$1" ]]; then
-  showHelp
   runContainer "$*"
 else
+  showHelp
   runContainer "help"
 fi


### PR DESCRIPTION
當正確執行的時候不應該顯示help messages