### PR TITLE
Generate random record by replacing one byte

### DIFF
--- a/app/src/main/java/org/astraea/performance/Manager.java
+++ b/app/src/main/java/org/astraea/performance/Manager.java
@@ -63,7 +63,7 @@ public class Manager {
     if (exeTime.percentage(payloadNum.getAndIncrement(), System.currentTimeMillis() - start)
         >= 100D) return Optional.empty();
 
-    byte[] payload = randomContent.getContent();
+    var payload = randomContent.getContent();
     return Optional.of(payload);
   }
 


### PR DESCRIPTION
若每次record都重新產生隨機內容，發送效率會大幅下降。
![image](https://user-images.githubusercontent.com/26920893/150627442-6d532043-d60c-4aa4-86e7-44a4e0790b1f.png)

為解決random record的負擔，又可以製造random record的結果，改成每次只改一個byte。如此一來，既可以產生不同的record，也可以降低產生訊息所需的時間。
![image](https://user-images.githubusercontent.com/26920893/150627464-9da671c3-d171-41ae-ab96-62f36cafddce.png)
