### PR TITLE
fix incorrect metric type of "kafka_server_kafkarequesthandlerpool_requesthandleravgidle_percent"

### DIFF
--- a/config/kafka_jmx_exporter.yml
+++ b/config/kafka_jmx_exporter.yml
@@ -1,0 +1,114 @@
+lowercaseOutputName: true
+
+rules:
+# Special cases and very specific rules
+- pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value
+  name: kafka_server_$1_$2
+  type: GAUGE
+  labels:
+    clientId: "$3"
+    topic: "$4"
+    partition: "$5"
+- pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>Value
+  name: kafka_server_$1_$2
+  type: GAUGE
+  labels:
+    clientId: "$3"
+    broker: "$4:$5"
+- pattern : kafka.coordinator.(\w+)<type=(.+), name=(.+)><>Value
+  name: kafka_coordinator_$1_$2_$3
+  type: GAUGE
+
+# Generic per-second counters with 0-2 key/value pairs
+- pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+), (.+)=(.+)><>Count
+  name: kafka_$1_$2_$3_total
+  type: COUNTER
+  labels:
+    "$4": "$5"
+    "$6": "$7"
+- pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+)><>Count
+  name: kafka_$1_$2_$3_total
+  type: COUNTER
+  labels:
+    "$4": "$5"
+- pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*><>Count
+  name: kafka_$1_$2_$3_total
+  type: COUNTER
+
+- pattern: kafka.server<type=(.+), client-id=(.+)><>([a-z-]+)
+  name: kafka_server_quota_$3
+  type: GAUGE
+  labels:
+    resource: "$1"
+    clientId: "$2"
+
+- pattern: kafka.server<type=(.+), user=(.+), client-id=(.+)><>([a-z-]+)
+  name: kafka_server_quota_$4
+  type: GAUGE
+  labels:
+    resource: "$1"
+    user: "$2"
+    clientId: "$3"
+
+# Generic gauges with 0-2 key/value pairs
+- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Value
+  name: kafka_$1_$2_$3
+  type: GAUGE
+  labels:
+    "$4": "$5"
+    "$6": "$7"
+- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Value
+  name: kafka_$1_$2_$3
+  type: GAUGE
+  labels:
+    "$4": "$5"
+- pattern: kafka.(\w+)<type=(.+), name=(.+)><>Value
+  name: kafka_$1_$2_$3
+  type: GAUGE
+
+# Emulate Prometheus 'Summary' metrics for the exported 'Histogram's.
+#
+# Note that these are missing the '_sum' metric!
+- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Count
+  name: kafka_$1_$2_$3_count
+  type: COUNTER
+  labels:
+    "$4": "$5"
+    "$6": "$7"
+- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*), (.+)=(.+)><>(\d+)thPercentile
+  name: kafka_$1_$2_$3
+  type: GAUGE
+  labels:
+    "$4": "$5"
+    "$6": "$7"
+    quantile: "0.$8"
+- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Count
+  name: kafka_$1_$2_$3_count
+  type: COUNTER
+  labels:
+    "$4": "$5"
+- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*)><>(\d+)thPercentile
+  name: kafka_$1_$2_$3
+  type: GAUGE
+  labels:
+    "$4": "$5"
+    quantile: "0.$6"
+- pattern: kafka.(\w+)<type=(.+), name=(.+)><>Count
+  name: kafka_$1_$2_$3_count
+  type: COUNTER
+- pattern: kafka.(\w+)<type=(.+), name=(.+)><>(\d+)thPercentile
+  name: kafka_$1_$2_$3
+  type: GAUGE
+  labels:
+    quantile: "0.$4"
+- pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*><>MeanRate
+  name: kafka_$1_$2_$3_percent
+  type: GAUGE
+- pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*><>Value
+  name: kafka_$1_$2_$3_percent
+  type: GAUGE
+- pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*, (.+)=(.+)><>Value
+  name: kafka_$1_$2_$3_percent
+  type: GAUGE
+  labels:
+    "$4": "$5"

--- a/docker/start_broker.sh
+++ b/docker/start_broker.sh
@@ -94,7 +94,7 @@ RUN groupadd $USER && useradd -ms /bin/bash -g $USER $USER
 # download jmx exporter
 RUN mkdir /tmp/jmx_exporter
 WORKDIR /tmp/jmx_exporter
-RUN wget https://raw.githubusercontent.com/prometheus/jmx_exporter/master/example_configs/kafka-2_0_0.yml
+RUN wget https://gist.githubusercontent.com/garyparrot/1f2a3715dd2edbe40c560426cda775e4/raw/5b98c5cdc7673c9a6fb440ffad07d6cfc378b0a1/kafka_jmx_exporter.yml
 RUN wget https://REPO1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${EXPORTER_VERSION}/jmx_prometheus_javaagent-${EXPORTER_VERSION}.jar
 
 # build kafka from source code
@@ -128,7 +128,7 @@ RUN groupadd $USER && useradd -ms /bin/bash -g $USER $USER
 # download jmx exporter
 RUN mkdir /tmp/jmx_exporter
 WORKDIR /tmp/jmx_exporter
-RUN wget https://raw.githubusercontent.com/prometheus/jmx_exporter/master/example_configs/kafka-2_0_0.yml
+RUN wget https://gist.githubusercontent.com/garyparrot/1f2a3715dd2edbe40c560426cda775e4/raw/5b98c5cdc7673c9a6fb440ffad07d6cfc378b0a1/kafka_jmx_exporter.yml
 RUN wget https://REPO1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${EXPORTER_VERSION}/jmx_prometheus_javaagent-${EXPORTER_VERSION}.jar
 
 # download kafka
@@ -299,7 +299,7 @@ docker run -d --init \
   --name $CONTAINER_NAME \
   -e KAFKA_HEAP_OPTS="$HEAP_OPTS" \
   -e KAFKA_JMX_OPTS="$JMX_OPTS" \
-  -e KAFKA_OPTS="-javaagent:/tmp/jmx_exporter/jmx_prometheus_javaagent-${EXPORTER_VERSION}.jar=$EXPORTER_PORT:/tmp/jmx_exporter/kafka-2_0_0.yml" \
+  -e KAFKA_OPTS="-javaagent:/tmp/jmx_exporter/jmx_prometheus_javaagent-${EXPORTER_VERSION}.jar=$EXPORTER_PORT:/tmp/jmx_exporter/kafka_jmx_exporter.yml" \
   -v $BROKER_PROPERTIES:/tmp/broker.properties:ro \
   $(generateMountCommand) \
   -p $BROKER_PORT:9092 \

--- a/docker/start_broker.sh
+++ b/docker/start_broker.sh
@@ -94,7 +94,7 @@ RUN groupadd $USER && useradd -ms /bin/bash -g $USER $USER
 # download jmx exporter
 RUN mkdir /tmp/jmx_exporter
 WORKDIR /tmp/jmx_exporter
-RUN wget https://gist.githubusercontent.com/garyparrot/1f2a3715dd2edbe40c560426cda775e4/raw/5b98c5cdc7673c9a6fb440ffad07d6cfc378b0a1/kafka_jmx_exporter.yml
+ADD --chown=$USER:$USER kafka_jmx_exporter.yml /tmp/jmx_exporter/
 RUN wget https://REPO1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${EXPORTER_VERSION}/jmx_prometheus_javaagent-${EXPORTER_VERSION}.jar
 
 # build kafka from source code
@@ -102,8 +102,6 @@ RUN git clone https://github.com/apache/kafka /tmp/kafka
 WORKDIR /tmp/kafka
 RUN git checkout $VERSION
 RUN ./gradlew clean releaseTarGz
-RUN mkdir /opt/kafka
-RUN tar -zxvf \$(find ./core/build/distributions/ -maxdepth 1 -type f -name kafka_*SNAPSHOT.tgz) -C /opt/kafka --strip-components=1
 WORKDIR /opt/kafka
 
 # export ENV
@@ -128,7 +126,7 @@ RUN groupadd $USER && useradd -ms /bin/bash -g $USER $USER
 # download jmx exporter
 RUN mkdir /tmp/jmx_exporter
 WORKDIR /tmp/jmx_exporter
-RUN wget https://gist.githubusercontent.com/garyparrot/1f2a3715dd2edbe40c560426cda775e4/raw/5b98c5cdc7673c9a6fb440ffad07d6cfc378b0a1/kafka_jmx_exporter.yml
+ADD --chown=$USER:$USER kafka_jmx_exporter.yml /tmp/jmx_exporter/
 RUN wget https://REPO1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${EXPORTER_VERSION}/jmx_prometheus_javaagent-${EXPORTER_VERSION}.jar
 
 # download kafka
@@ -168,7 +166,7 @@ function buildImageIfNeed() {
     fi
     if [[ "$needToBuild" == "true" ]]; then
       generateDockerfile
-      docker build --no-cache -t "$IMAGE_NAME" -f "$DOCKERFILE" "$DOCKER_FOLDER"
+      docker build --no-cache -t "$IMAGE_NAME" -f "$DOCKERFILE" "$(realpath $DOCKER_FOLDER/../config)"
       if [[ "$?" != "0" ]]; then
         exit 2
       fi


### PR DESCRIPTION
Upon debugging some performance issues. I discover the metric `kafka_server_kafkarequesthandlerpool_requesthandleravgidle_percent` exposed by the JMX exporter from Kafka broker, is acting very strange. It supposes to be a percentage value between `1` to `0`. But the value Is much higher than that.

![image](https://user-images.githubusercontent.com/39105714/151192078-cb052edc-e681-4f8d-a274-29a063362c89.png)

After some research, it feels like the issue is related to the configuration of the JMX exporter. The following raw exported value says it is a "counter" type metric.

```
# HELP kafka_server_brokertopicmetrics_replicationbytesin_total Attribute exposed for management (kafka.server<type=BrokerTopicMetrics, name=ReplicationBytesInPerSec><>Count)
# TYPE kafka_server_brokertopicmetrics_replicationbytesin_total counter
kafka_server_brokertopicmetrics_replicationbytesin_total 0.0
# HELP kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent_count_total Attribute exposed for management (kafka.server<type=KafkaRequestHandlerPool, name=RequestHandlerAvgIdlePercent><>Count)
# TYPE kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent_count_total counter
kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent_count 6.042946917454E12
```

This metric should be a `gauge` type metric since the value it provides reflect the current state of that metric. Instead of a value increment over time like what `counter` did.

This PR hack this issue by using a new JMX exporter configuration. Now request handler idleness percentage will become `gauge` type metric.

```
# HELP kafka_server_kafkarequesthandlerpool_requesthandleravgidle_percent Attribute exposed for management (kafka.server<type=KafkaRequestHandlerPool, name=RequestHandlerAvgIdlePercent><>MeanRate)
# TYPE kafka_server_kafkarequesthandlerpool_requesthandleravgidle_percent gauge
kafka_server_kafkarequesthandlerpool_requesthandleravgidle_percent 0.9997302370377151
```

The new metric looks like this

![image](https://user-images.githubusercontent.com/39105714/151193591-5124e267-3387-405d-a44b-8f922dc4bdd8.png)
