### PR TITLE
Fix consumerDone() false when no consumer

### DIFF
--- a/app/src/main/java/org/astraea/performance/Manager.java
+++ b/app/src/main/java/org/astraea/performance/Manager.java
@@ -100,7 +100,8 @@ public class Manager {
 
   /** Check if we should keep consuming record. */
   public boolean consumedDone() {
-    return producedDone() && consumedRecords() >= producedRecords();
+    return producedDone()
+        && (consumerMetrics.size() == 0 || consumedRecords() >= producedRecords());
   }
 
   /** Randomly choose a key according to the distribution. */

--- a/app/src/test/java/org/astraea/performance/ManagerTest.java
+++ b/app/src/test/java/org/astraea/performance/ManagerTest.java
@@ -74,4 +74,56 @@ public class ManagerTest {
     manager = new Manager(argument, List.of(), List.of());
     Assertions.assertTrue(manager.getKey().isEmpty());
   }
+
+  @Test
+  void testConsumerDone() {
+    var argument = new Performance.Argument();
+    var producerMetrics = List.of(new Metrics());
+    var consumerMetrics = List.of(new Metrics());
+
+    argument.exeTime = ExeTime.of("1records");
+    var manager = new Manager(argument, producerMetrics, consumerMetrics);
+    Assertions.assertFalse(manager.consumedDone());
+
+    // Produce one record
+    producerMetrics.get(0).accept(0L, 0L);
+    Assertions.assertFalse(manager.consumedDone());
+
+    // Consume one record
+    consumerMetrics.get(0).accept(0L, 0L);
+    Assertions.assertFalse(manager.consumedDone());
+
+    manager.producerClosed();
+    Assertions.assertTrue(manager.consumedDone());
+
+    // Test zero consumer. (run for one record)
+    producerMetrics = List.of(new Metrics());
+    consumerMetrics = List.of();
+    manager = new Manager(argument, producerMetrics, consumerMetrics);
+    Assertions.assertFalse(manager.consumedDone());
+
+    // Produce one record
+    producerMetrics.get(0).accept(0L, 0L);
+    Assertions.assertFalse(manager.consumedDone());
+
+    manager.producerClosed();
+    Assertions.assertTrue(manager.consumedDone());
+  }
+
+  @Test
+  void testProducerDone() {
+    var argument = new Performance.Argument();
+    argument.exeTime = ExeTime.of("1records");
+    var producerMetrics = List.of(new Metrics());
+    var consumerMetrics = List.of(new Metrics());
+    var manager = new Manager(new Performance.Argument(), producerMetrics, consumerMetrics);
+
+    Assertions.assertFalse(manager.producedDone());
+
+    producerMetrics.get(0).accept(0L, 0L);
+    Assertions.assertFalse(manager.producedDone());
+
+    manager.producerClosed();
+    Assertions.assertTrue(manager.producedDone());
+  }
 }


### PR DESCRIPTION
#209 

> `Manager#consumedDone` is always `false` when there is no consumer ...

Fixed by adding check on number of consumers.