### PR TITLE
fix rejectProperty funtion in `start_broker.sh`

### DIFF
--- a/docker/start_broker.sh
+++ b/docker/start_broker.sh
@@ -66,7 +66,7 @@ function checkNetwork() {
 }
 
 function rejectProperty() {
-  local key=$1c
+  local key=$1
   if [[ -f "$BROKER_PROPERTIES" ]] && [[ "$(cat $BROKER_PROPERTIES | grep $key)" != "" ]]; then
     echo "$key is NOT configurable"
     exit 2


### PR DESCRIPTION
修正rejectProperty() 使其可以正常的拒絕設定特定的property
修正前:
```
$ ./start_broker.sh zookeeper.connect=192.168.103.141:19316 sean@sean:~/Documents/astraea/docker$ ./start_broker.sh zookeeper.connect=192.168.103.141:19316 broker.id=10
b03cc9d48844ee2d5b509f850d6a1ea76264aebf825d720153a5ecd57e037f38
=================================================
broker id: 10
broker address: 192.168.103.39:10667
jmx address: 192.168.103.39:14630
exporter address: 192.168.103.39:15784
=================================================
```
修正後:
```
./start_broker.sh zookeeper.connect=192.168.103.141:19316 sean@sean:~/Documents/astraea/docker$ ./start_broker.sh zookeeper.connect=192.168.103.141:19316 broker.id=10
broker.id is NOT configurable

```