### PR TITLE
Reduce zookeeper, broker, spark and astraea image size

### DIFF
--- a/docker/start_broker.sh
+++ b/docker/start_broker.sh
@@ -83,17 +83,17 @@ function requireProperty() {
 
 function generateDockerfileBySource() {
   echo "# this dockerfile is generated dynamically
-FROM ubuntu:20.04
+FROM ubuntu:20.04 AS build
 
 # install tools
-RUN apt-get update && apt-get upgrade -y && DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-11-jdk wget git curl
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-11-jdk wget git curl
 
 # add user
 RUN groupadd $USER && useradd -ms /bin/bash -g $USER $USER
 
 # download jmx exporter
-RUN mkdir /tmp/jmx_exporter
-WORKDIR /tmp/jmx_exporter
+RUN mkdir /opt/jmx_exporter
+WORKDIR /opt/jmx_exporter
 RUN wget https://raw.githubusercontent.com/prometheus/jmx_exporter/master/example_configs/kafka-2_0_0.yml
 RUN wget https://REPO1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${EXPORTER_VERSION}/jmx_prometheus_javaagent-${EXPORTER_VERSION}.jar
 
@@ -104,30 +104,39 @@ RUN git checkout $VERSION
 RUN ./gradlew clean releaseTarGz
 RUN mkdir /opt/kafka
 RUN tar -zxvf \$(find ./core/build/distributions/ -maxdepth 1 -type f -name kafka_*SNAPSHOT.tgz) -C /opt/kafka --strip-components=1
-WORKDIR /opt/kafka
 
-# export ENV
-ENV KAFKA_HOME /opt/kafka
+FROM ubuntu:20.04
+
+# install tools
+RUN apt-get update && apt-get install -y openjdk-11-jre
+
+# copy kafka
+COPY --from=build /opt/jmx_exporter /opt/jmx_exporter
+COPY --from=build /opt/kafka /opt/kafka
+
+# add user
+RUN groupadd $USER && useradd -ms /bin/bash -g $USER $USER
 
 # change user
 RUN chown -R $USER:$USER /opt/kafka
 USER $USER
+
+# export ENV
+ENV KAFKA_HOME /opt/kafka
+WORKDIR /opt/kafka
 " >"$DOCKERFILE"
 }
 
 function generateDockerfileByVersion() {
   echo "# this dockerfile is generated dynamically
-FROM ubuntu:20.04
+FROM ubuntu:20.04 AS build
 
 # install tools
-RUN apt-get update && apt-get upgrade -y && apt-get install -y openjdk-11-jdk wget
-
-# add user
-RUN groupadd $USER && useradd -ms /bin/bash -g $USER $USER
+RUN apt-get update && apt-get install -y wget
 
 # download jmx exporter
-RUN mkdir /tmp/jmx_exporter
-WORKDIR /tmp/jmx_exporter
+RUN mkdir /opt/jmx_exporter
+WORKDIR /opt/jmx_exporter
 RUN wget https://raw.githubusercontent.com/prometheus/jmx_exporter/master/example_configs/kafka-2_0_0.yml
 RUN wget https://REPO1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${EXPORTER_VERSION}/jmx_prometheus_javaagent-${EXPORTER_VERSION}.jar
 
@@ -138,12 +147,25 @@ RUN mkdir /opt/kafka
 RUN tar -zxvf kafka_2.13-${VERSION}.tgz -C /opt/kafka --strip-components=1
 WORKDIR /opt/kafka
 
-# export ENV
-ENV KAFKA_HOME /opt/kafka
+FROM ubuntu:20.04
+
+# install tools
+RUN apt-get update && apt-get install -y openjdk-11-jre
+
+# copy kafka
+COPY --from=build /opt/jmx_exporter /opt/jmx_exporter
+COPY --from=build /opt/kafka /opt/kafka
+
+# add user
+RUN groupadd $USER && useradd -ms /bin/bash -g $USER $USER
 
 # change user
 RUN chown -R $USER:$USER /opt/kafka
 USER $USER
+
+# export ENV
+ENV KAFKA_HOME /opt/kafka
+WORKDIR /opt/kafka
 " >"$DOCKERFILE"
 }
 
@@ -299,7 +321,7 @@ docker run -d --init \
   --name $CONTAINER_NAME \
   -e KAFKA_HEAP_OPTS="$HEAP_OPTS" \
   -e KAFKA_JMX_OPTS="$JMX_OPTS" \
-  -e KAFKA_OPTS="-javaagent:/tmp/jmx_exporter/jmx_prometheus_javaagent-${EXPORTER_VERSION}.jar=$EXPORTER_PORT:/tmp/jmx_exporter/kafka-2_0_0.yml" \
+  -e KAFKA_OPTS="-javaagent:/opt/jmx_exporter/jmx_prometheus_javaagent-${EXPORTER_VERSION}.jar=$EXPORTER_PORT:/opt/jmx_exporter/kafka-2_0_0.yml" \
   -v $BROKER_PROPERTIES:/tmp/broker.properties:ro \
   $(generateMountCommand) \
   -p $BROKER_PORT:9092 \

--- a/docker/start_spark.sh
+++ b/docker/start_spark.sh
@@ -24,8 +24,6 @@ function showHelp() {
   echo "    master-url=spar://node00:1111    start a spark worker. Or start a spark master if master-url is not defined"
   echo "ENV: "
   echo "    VERSION=3.1.2                    set version of spark distribution"
-  echo "    DELTA_VERSION=1.0.0              set version of delta distribution"
-  echo "    PYTHON_KAFKA_VERSION=1.7.0       set version of confluent kafka distribution"
   echo "    BUILD=false                      set true if you want to build image locally"
   echo "    RUN=false                        set false if you want to build/pull image only"
   echo "    PYTHON_DEPS=delta-spark=1.0.0    set the python dependencies which are pre-installed in the docker image"
@@ -65,16 +63,10 @@ function checkConflictContainer() {
 
 function generateDockerfileByVersion() {
   echo "# this dockerfile is generated dynamically
-FROM ubuntu:20.04
-
-# Do not ask for confirmations when running apt-get, etc.
-ENV DEBIAN_FRONTEND noninteractive
+FROM ubuntu:20.04 AS build
 
 # install tools
-RUN apt-get update && apt-get upgrade -y && apt-get install -y openjdk-11-jdk wget python3 python3-pip unzip tini
-
-# add user
-RUN groupadd $USER && useradd -ms /bin/bash -g $USER $USER
+RUN apt-get update && apt-get install -y wget unzip
 
 # download spark
 WORKDIR /tmp
@@ -82,49 +74,70 @@ RUN wget https://archive.apache.org/dist/spark/spark-${VERSION}/spark-${VERSION}
 RUN mkdir /opt/spark
 RUN tar -zxvf spark-${VERSION}-bin-hadoop3.2.tgz -C /opt/spark --strip-components=1
 
-# export ENV
-ENV SPARK_HOME /opt/spark
-
-# change user
-RUN chown -R $USER:$USER /opt/spark
-USER $USER
-
-WORKDIR /opt/spark
-" >"$DOCKERFILE"
-}
-
-function generateDockerfileBySource() {
-  echo "# this dockerfile is generated dynamically
 FROM ubuntu:20.04
 
 # Do not ask for confirmations when running apt-get, etc.
 ENV DEBIAN_FRONTEND noninteractive
 
 # install tools
-RUN apt-get update && apt-get upgrade -y && apt-get install -y openjdk-11-jdk python3 python3-pip git curl
+RUN apt-get update && apt-get install -y openjdk-11-jre python3 python3-pip
 
-# install python dependencies
-RUN pip3 install confluent-kafka==$PYTHON_KAFKA_VERSION
+# copy spark
+COPY --from=build /opt/spark /opt/spark
 
 # add user
 RUN groupadd $USER && useradd -ms /bin/bash -g $USER $USER
-
-# build spark from source code
-RUN git clone https://github.com/apache/spark /tmp/spark
-WORKDIR /tmp/spark
-RUN git checkout $VERSION
-RUN ./dev/make-distribution.sh --pip --tgz
-RUN mkdir /opt/spark
-RUN tar -zxvf \$(find ./ -maxdepth 1 -type f -name spark-*SNAPSHOT*.tgz) -C /opt/spark --strip-components=1
-RUN ./build/mvn install -DskipTests
-
-# export ENV
-ENV SPARK_HOME /opt/spark
 
 # change user
 RUN chown -R $USER:$USER /opt/spark
 USER $USER
 
+# export ENV
+ENV SPARK_HOME /opt/spark
+WORKDIR /opt/spark
+" >"$DOCKERFILE"
+}
+
+function generateDockerfileBySource() {
+  echo "# this dockerfile is generated dynamically
+FROM ubuntu:20.04 AS build
+
+# Do not ask for confirmations when running apt-get, etc.
+ENV DEBIAN_FRONTEND noninteractive
+
+# install tools
+RUN apt-get update && apt-get install -y openjdk-11-jdk python3 python3-pip git curl
+
+# build spark from source code
+RUN git clone https://github.com/apache/spark /tmp/spark
+WORKDIR /tmp/spark
+RUN git checkout $VERSION
+ENV MAVEN_OPTS=\"-Xmx3g\"
+RUN ./dev/make-distribution.sh --pip --tgz
+RUN mkdir /opt/spark
+RUN tar -zxvf \$(find ./ -maxdepth 1 -type f -name spark-*SNAPSHOT*.tgz) -C /opt/spark --strip-components=1
+RUN ./build/mvn install -DskipTests
+
+FROM ubuntu:20.04
+
+# Do not ask for confirmations when running apt-get, etc.
+ENV DEBIAN_FRONTEND noninteractive
+
+# install tools
+RUN apt-get update && apt-get install -y openjdk-11-jre python3 python3-pip
+
+# copy spark
+COPY --from=build /opt/spark /opt/spark
+
+# add user
+RUN groupadd $USER && useradd -ms /bin/bash -g $USER $USER
+
+# change user
+RUN chown -R $USER:$USER /opt/spark
+USER $USER
+
+# export ENV
+ENV SPARK_HOME /opt/spark
 WORKDIR /opt/spark
 " >"$DOCKERFILE"
 }


### PR DESCRIPTION
This PR address following tasks to reduce the image size.
1. use multi-stages to avoid unused files to be cached
2. replace `JDK` by `JRE` in runtime