### PR TITLE
Optimization Partitioner

### DIFF
--- a/app/src/main/java/org/astraea/Utils.java
+++ b/app/src/main/java/org/astraea/Utils.java
@@ -137,5 +137,9 @@ public final class Utils {
     return value;
   }
 
+  public static boolean overOneSecond(long lastTime) {
+    return lastTime + Duration.ofSeconds(1).toMillis() <= System.currentTimeMillis();
+  }
+
   private Utils() {}
 }

--- a/app/src/main/java/org/astraea/Utils.java
+++ b/app/src/main/java/org/astraea/Utils.java
@@ -137,8 +137,8 @@ public final class Utils {
     return value;
   }
 
-  public static boolean overOneSecond(long lastTime) {
-    return lastTime + Duration.ofSeconds(1).toMillis() <= System.currentTimeMillis();
+  public static boolean overSecond(long lastTime, int second) {
+    return (lastTime + Duration.ofSeconds(second).toMillis()) < System.currentTimeMillis();
   }
 
   private Utils() {}

--- a/app/src/main/java/org/astraea/partitioner/nodeLoadMetric/NodeLoadClient.java
+++ b/app/src/main/java/org/astraea/partitioner/nodeLoadMetric/NodeLoadClient.java
@@ -1,6 +1,6 @@
 package org.astraea.partitioner.nodeLoadMetric;
 
-import static org.astraea.Utils.overOneSecond;
+import static org.astraea.Utils.overSecond;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -53,7 +53,7 @@ public class NodeLoadClient {
    * @return each node load count in preset time
    */
   public Map<Integer, Integer> loadSituation(Cluster cluster) throws UnknownHostException {
-    if (overOneSecond(lastTime) && notInMethod) {
+    if (overSecond(lastTime,1) && notInMethod) {
       notInMethod = false;
       nodesOverLoad(cluster);
       notInMethod = true;

--- a/app/src/main/java/org/astraea/partitioner/nodeLoadMetric/NodeLoadClient.java
+++ b/app/src/main/java/org/astraea/partitioner/nodeLoadMetric/NodeLoadClient.java
@@ -312,13 +312,12 @@ public class NodeLoadClient {
       this.maxThoughPut = Math.max(maxThoughPut, input + output);
     }
 
+    // TODO Algorithms adapted to computers of different specifications
     private void thoughPutComparison(double referenceThoughPut) {
       if (count >= 20) {
-        this.thoughPutComparison =
-            (maxThoughPut - referenceThoughPut) / (referenceThoughPut + 1) + 1;
+        this.thoughPutComparison = 1;
       } else if (count >= 10) {
-        this.thoughPutComparison =
-            (maxThoughPut - referenceThoughPut) / (referenceThoughPut + 1) / 2 + 1;
+        this.thoughPutComparison = 1;
       } else if (count >= 0) {
         this.thoughPutComparison = 1;
       }

--- a/app/src/main/java/org/astraea/partitioner/nodeLoadMetric/NodeLoadClient.java
+++ b/app/src/main/java/org/astraea/partitioner/nodeLoadMetric/NodeLoadClient.java
@@ -53,7 +53,7 @@ public class NodeLoadClient {
    * @return each node load count in preset time
    */
   public Map<Integer, Integer> loadSituation(Cluster cluster) throws UnknownHostException {
-    if (overSecond(lastTime,1) && notInMethod) {
+    if (overSecond(lastTime, 1) && notInMethod) {
       notInMethod = false;
       nodesOverLoad(cluster);
       notInMethod = true;

--- a/app/src/main/java/org/astraea/partitioner/nodeLoadMetric/PartitionerUtils.java
+++ b/app/src/main/java/org/astraea/partitioner/nodeLoadMetric/PartitionerUtils.java
@@ -4,17 +4,16 @@ import java.util.HashMap;
 import java.util.Map;
 
 /** do poisson for node's load situation */
-public class LoadPoisson {
+public class PartitionerUtils {
 
-  public HashMap<Integer, Double> allPoisson(Map<Integer, Integer> overLoadCount) {
+  public static HashMap<Integer, Double> allPoisson(Map<Integer, Integer> overLoadCount) {
     var poissonMap = new HashMap<Integer, Double>();
     var lambda = avgLoadCount(overLoadCount);
     overLoadCount.forEach((nodeID, count) -> poissonMap.put(nodeID, doPoisson(lambda, count)));
     return poissonMap;
   }
 
-  // visible for test
-  double doPoisson(int lambda, int x) {
+  public static double doPoisson(int lambda, int x) {
     var Probability = 0.0;
     var ans = 0.0;
     var i = 0;
@@ -29,13 +28,12 @@ public class LoadPoisson {
     return ans;
   }
 
-  // visible for test
-  long factorial(long number) {
+  public static long factorial(long number) {
     if (number <= 1) return 1;
     else return number * factorial(number - 1);
   }
 
-  private int avgLoadCount(Map<Integer, Integer> overLoadCount) {
+  private static int avgLoadCount(Map<Integer, Integer> overLoadCount) {
     var avgLoadCount =
         overLoadCount.values().stream().mapToDouble(Integer::doubleValue).average().orElse(0);
     return (int) avgLoadCount;

--- a/app/src/main/java/org/astraea/partitioner/nodeLoadMetric/PartitionerUtils.java
+++ b/app/src/main/java/org/astraea/partitioner/nodeLoadMetric/PartitionerUtils.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 /** do poisson for node's load situation */
 public class PartitionerUtils {
+  private PartitionerUtils() {}
 
   public static HashMap<Integer, Double> allPoisson(Map<Integer, Integer> overLoadCount) {
     var poissonMap = new HashMap<Integer, Double>();
@@ -13,7 +14,7 @@ public class PartitionerUtils {
     return poissonMap;
   }
 
-  public static double doPoisson(int lambda, int x) {
+  static double doPoisson(int lambda, int x) {
     var Probability = 0.0;
     var ans = 0.0;
     var i = 0;
@@ -28,7 +29,7 @@ public class PartitionerUtils {
     return ans;
   }
 
-  public static long factorial(long number) {
+  static long factorial(long number) {
     if (number <= 1) return 1;
     else return number * factorial(number - 1);
   }

--- a/app/src/main/java/org/astraea/partitioner/smoothPartitioner/SmoothWeightPartitioner.java
+++ b/app/src/main/java/org/astraea/partitioner/smoothPartitioner/SmoothWeightPartitioner.java
@@ -52,7 +52,6 @@ public class SmoothWeightPartitioner implements Partitioner {
       lastTime = System.currentTimeMillis();
     }
     AtomicReference<Map.Entry<Integer, int[]>> maxWeightServer = new AtomicReference<>();
-    var allWeight = allNodesWeight();
     brokersWeight.forEach(
         (nodeID, weight) -> {
           if (maxWeightServer.get() == null || weight[1] > maxWeightServer.get().getValue()[1]) {
@@ -64,7 +63,8 @@ public class SmoothWeightPartitioner implements Partitioner {
     brokersWeight.put(
         maxWeightServer.get().getKey(),
         new int[] {
-          maxWeightServer.get().getValue()[0], maxWeightServer.get().getValue()[1] - allWeight
+          maxWeightServer.get().getValue()[0],
+          maxWeightServer.get().getValue()[1] - allNodesWeight()
         });
     brokersWeight
         .keySet()

--- a/app/src/main/java/org/astraea/partitioner/smoothPartitioner/SmoothWeightPartitioner.java
+++ b/app/src/main/java/org/astraea/partitioner/smoothPartitioner/SmoothWeightPartitioner.java
@@ -36,11 +36,6 @@ public class SmoothWeightPartitioner implements Partitioner {
   private final LoadPoisson loadPoisson = new LoadPoisson();
 
   @Override
-  public void onNewBatch(String topic, Cluster cluster, int prevPartition) {
-    Partitioner.super.onNewBatch(topic, cluster, prevPartition);
-  }
-
-  @Override
   public int partition(
       String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes, Cluster cluster) {
     Map<Integer, Integer> loadCount;

--- a/app/src/main/java/org/astraea/partitioner/smoothPartitioner/SmoothWeightPartitioner.java
+++ b/app/src/main/java/org/astraea/partitioner/smoothPartitioner/SmoothWeightPartitioner.java
@@ -114,17 +114,18 @@ public class SmoothWeightPartitioner implements Partitioner {
         });
   }
 
-  void updateWeightIfNeed(Map<Integer,Integer> loadCount) {
-    var bool = overSecond(lastTime,1);
+  void updateWeightIfNeed(Map<Integer, Integer> loadCount) {
+    var bool = overSecond(lastTime, 1);
     if (bool) {
       brokersWeight(allPoisson(loadCount));
       lastTime = System.currentTimeMillis();
     }
   }
 
-  Map<Integer, int[]> brokersWeight(){
+  Map<Integer, int[]> brokersWeight() {
     return this.brokersWeight;
   }
+
   private void subBrokerWeight(int brokerID, int subNumber) {
     brokersWeight.put(
         brokerID,

--- a/app/src/main/java/org/astraea/partitioner/smoothPartitioner/SmoothWeightPartitioner.java
+++ b/app/src/main/java/org/astraea/partitioner/smoothPartitioner/SmoothWeightPartitioner.java
@@ -115,15 +115,14 @@ public class SmoothWeightPartitioner implements Partitioner {
   }
 
   void updateWeightIfNeed(Map<Integer, Integer> loadCount) {
-    var bool = overSecond(lastTime, 1);
-    if (bool) {
+    if (overSecond(lastTime, 1)) {
       brokersWeight(allPoisson(loadCount));
       lastTime = System.currentTimeMillis();
     }
   }
 
   Map<Integer, int[]> brokersWeight() {
-    return this.brokersWeight;
+    return brokersWeight;
   }
 
   private void subBrokerWeight(int brokerID, int subNumber) {

--- a/app/src/test/java/org/astraea/partitioner/nodeLoadMetric/PartitionerUtilsTest.java
+++ b/app/src/test/java/org/astraea/partitioner/nodeLoadMetric/PartitionerUtilsTest.java
@@ -1,28 +1,25 @@
 package org.astraea.partitioner.nodeLoadMetric;
 
+import static org.astraea.partitioner.nodeLoadMetric.PartitionerUtils.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
 import org.junit.jupiter.api.Test;
 
-public class LoadPoissonTest {
+public class PartitionerUtilsTest {
 
   @Test
   void testFactorial() {
-    LoadPoisson loadPoisson = new LoadPoisson();
-
-    assertEquals(loadPoisson.factorial(3), 6);
-    assertEquals(loadPoisson.factorial(5), 120);
+    assertEquals(factorial(3), 6);
+    assertEquals(factorial(5), 120);
   }
 
   @Test
   void testDoPoisson() {
-    LoadPoisson loadPoisson = new LoadPoisson();
-
-    assertEquals(loadPoisson.doPoisson(10, 15), 0.9512595966960214);
-    assertEquals(loadPoisson.doPoisson(5, 5), 0.6159606548330632);
-    assertEquals(loadPoisson.doPoisson(5, 8), 0.9319063652781515);
-    assertEquals(loadPoisson.doPoisson(5, 2), 0.12465201948308113);
+    assertEquals(doPoisson(10, 15), 0.9512595966960214);
+    assertEquals(doPoisson(5, 5), 0.6159606548330632);
+    assertEquals(doPoisson(5, 8), 0.9319063652781515);
+    assertEquals(doPoisson(5, 2), 0.12465201948308113);
   }
 
   @Test
@@ -38,9 +35,7 @@ public class LoadPoissonTest {
     testPoissonMap.put(1, 0.6159606548330632);
     testPoissonMap.put(2, 0.9319063652781515);
 
-    LoadPoisson loadPoisson = new LoadPoisson();
-
-    poissonMap = loadPoisson.allPoisson(testNodesLoadCount);
+    poissonMap = allPoisson(testNodesLoadCount);
 
     assertEquals(poissonMap, testPoissonMap);
   }

--- a/app/src/test/java/org/astraea/partitioner/smoothPartitioner/PartitionerTest.java
+++ b/app/src/test/java/org/astraea/partitioner/smoothPartitioner/PartitionerTest.java
@@ -24,7 +24,6 @@ import org.astraea.consumer.Consumer;
 import org.astraea.consumer.Deserializer;
 import org.astraea.consumer.Header;
 import org.astraea.partitioner.nodeLoadMetric.NodeLoadClient;
-import org.astraea.partitioner.smoothPartitioner.SmoothWeightPartitioner;
 import org.astraea.producer.Producer;
 import org.astraea.producer.Serializer;
 import org.astraea.service.RequireBrokerCluster;
@@ -187,25 +186,25 @@ public class PartitionerTest extends RequireBrokerCluster {
   @Test
   void teatUpdateWeightIfNeed() throws NoSuchFieldException, IllegalAccessException {
     SmoothWeightPartitioner smoothWeightPartitioner = new SmoothWeightPartitioner();
-    var loadCount = new HashMap<Integer,Integer>();
-    loadCount.put(0,10);
-    loadCount.put(1,12);
+    var loadCount = new HashMap<Integer, Integer>();
+    loadCount.put(0, 10);
+    loadCount.put(1, 12);
     var nodeLoadClient = mock(NodeLoadClient.class);
     var field = smoothWeightPartitioner.getClass().getDeclaredField("nodeLoadClient");
     field.setAccessible(true);
-    field.set(smoothWeightPartitioner,nodeLoadClient);
+    field.set(smoothWeightPartitioner, nodeLoadClient);
     when(nodeLoadClient.thoughPutComparison(anyInt())).thenReturn(1.0);
     smoothWeightPartitioner.updateWeightIfNeed(loadCount);
     var firstBrokersWeight = smoothWeightPartitioner.brokersWeight().get(0)[0];
     smoothWeightPartitioner.updateWeightIfNeed(loadCount);
     var secondBrokersWeight = smoothWeightPartitioner.brokersWeight().get(0)[0];
-    Assertions.assertEquals(firstBrokersWeight,secondBrokersWeight);
-    loadCount.put(0,6);
-    loadCount.put(2,5);
+    Assertions.assertEquals(firstBrokersWeight, secondBrokersWeight);
+    loadCount.put(0, 6);
+    loadCount.put(2, 5);
     sleep(1);
     smoothWeightPartitioner.updateWeightIfNeed(loadCount);
     var thirdBrokersWeight = smoothWeightPartitioner.brokersWeight();
-    Assertions.assertNotEquals(secondBrokersWeight,thirdBrokersWeight.get(2)[0]);
+    Assertions.assertNotEquals(secondBrokersWeight, thirdBrokersWeight.get(2)[0]);
   }
 
   private ThreadPool.Executor producerExecutor(

--- a/app/src/test/java/org/astraea/partitioner/smoothPartitioner/PartitionerTest.java
+++ b/app/src/test/java/org/astraea/partitioner/smoothPartitioner/PartitionerTest.java
@@ -3,8 +3,7 @@ package org.astraea.partitioner.smoothPartitioner;
 import static org.astraea.Utils.requireField;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Field;
 import java.time.Duration;
@@ -184,7 +183,7 @@ public class PartitionerTest extends RequireBrokerCluster {
   }
 
   @Test
-  void teatUpdateWeightIfNeed() throws NoSuchFieldException, IllegalAccessException {
+  void testUpdateWeightIfNeed() throws NoSuchFieldException, IllegalAccessException {
     SmoothWeightPartitioner smoothWeightPartitioner = new SmoothWeightPartitioner();
     var loadCount = new HashMap<Integer, Integer>();
     loadCount.put(0, 10);
@@ -199,12 +198,12 @@ public class PartitionerTest extends RequireBrokerCluster {
     smoothWeightPartitioner.updateWeightIfNeed(loadCount);
     var secondBrokersWeight = smoothWeightPartitioner.brokersWeight().get(0)[0];
     Assertions.assertEquals(firstBrokersWeight, secondBrokersWeight);
-    loadCount.put(0, 6);
+    loadCount.put(0, 5);
     loadCount.put(2, 5);
-    sleep(1);
+    sleep(2);
     smoothWeightPartitioner.updateWeightIfNeed(loadCount);
-    var thirdBrokersWeight = smoothWeightPartitioner.brokersWeight();
-    Assertions.assertNotEquals(secondBrokersWeight, thirdBrokersWeight.get(2)[0]);
+    var thirdBrokersWeight = smoothWeightPartitioner.brokersWeight().get(0)[0];
+    Assertions.assertNotEquals(secondBrokersWeight, thirdBrokersWeight);
   }
 
   private ThreadPool.Executor producerExecutor(


### PR DESCRIPTION
優化Partitioner效能，現在在10KiB的record.size下也能保持一定的效能。
右邊爲改善過後的astraea partitioner的數據，原先的數據結果大概爲30min avg=500MB/s
![Screenshot from 2022-02-18 20-25-17](https://user-images.githubusercontent.com/43372856/154685915-a6ab6538-bb36-4b45-a46d-f32edbc40c40.png)

主要的改善點爲減少不必要的該方法`brokersWeight`調用。JMC告訴我該方法佔了整個程式12%的cpu使用量。
而如果metrics不變這個方法的結果就不會改變。metrics最快也是1s更新一次，所以改爲超過1s再進行一次計算。

