### PR TITLE
Introduce maxParallelForks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,4 @@ jobs:
       - name: build
         run: ./gradlew clean build -x test --no-daemon
       - name: unit tests
-        run: ./gradlew clean test --no-daemon --console plain
+        run: ./gradlew clean test --no-daemon --console plain -PmaxParallelForks=1

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,7 +44,7 @@ java {
 }
 
 tasks.named('test') {
-    int numberOfForks = Math.max((int) (Runtime.runtime.availableProcessors() / 2), 1)
+    int numberOfForks = project.hasProperty('maxParallelForks') ? maxParallelForks.toInteger() : Math.max((int) (Runtime.runtime.availableProcessors() / 2), 1)
 
     // Use JUnit Platform for unit tests.
     useJUnitPlatform()


### PR DESCRIPTION
透過該參數可以降低github CI跑測試的平行度，進而降低因為資源問題導致的測試失敗