### PR TITLE
Refactor thread pool

### DIFF
--- a/app/src/main/java/org/astraea/concurrent/Executor.java
+++ b/app/src/main/java/org/astraea/concurrent/Executor.java
@@ -1,0 +1,28 @@
+package org.astraea.concurrent;
+
+@FunctionalInterface
+public interface Executor extends AutoCloseable {
+
+  static Executor of(Runnable runnable) {
+    return () -> {
+      runnable.run();
+      return State.RUNNING;
+    };
+  }
+
+  /**
+   * @return the state of this executor
+   * @throws InterruptedException This is an expected exception if your executor needs to call
+   *     blocking method. This exception is not printed to console.
+   */
+  State execute() throws InterruptedException;
+
+  /** close this executor. */
+  @Override
+  default void close() {}
+
+  /**
+   * If this executor is in blocking mode, this method offers a way to wake up executor to close.
+   */
+  default void wakeup() {}
+}

--- a/app/src/main/java/org/astraea/concurrent/State.java
+++ b/app/src/main/java/org/astraea/concurrent/State.java
@@ -1,0 +1,8 @@
+package org.astraea.concurrent;
+
+public enum State {
+  /** this thread is done. ThreadPool will call close to release the thread. */
+  DONE,
+  /** this thread is running */
+  RUNNING
+}

--- a/app/src/main/java/org/astraea/concurrent/ThreadPool.java
+++ b/app/src/main/java/org/astraea/concurrent/ThreadPool.java
@@ -30,47 +30,10 @@ public interface ThreadPool extends AutoCloseable {
     return new Builder();
   }
 
-  @FunctionalInterface
-  interface Executor extends AutoCloseable {
-
-    enum State {
-      DONE,
-      RUNNING
-    }
-
-    /**
-     * @return the state of this executor
-     * @throws InterruptedException This is an expected exception if your executor needs to call
-     *     blocking method. This exception is not printed to console.
-     */
-    State execute() throws InterruptedException;
-
-    /** close this executor. */
-    default void close() {}
-
-    /**
-     * If this executor is in blocking mode, this method offers a way to wake up executor to close.
-     */
-    default void wakeup() {}
-  }
-
   class Builder {
     private final List<Executor> executors = new ArrayList<>();
 
     private Builder() {}
-
-    public Builder runnable(Runnable runnable) {
-      return executor(
-          () -> {
-            runnable.run();
-            return Executor.State.RUNNING;
-          });
-    }
-
-    public Builder runnables(Collection<Runnable> runnables) {
-      runnables.forEach(this::runnable);
-      return this;
-    }
 
     public Builder executor(Executor executor) {
       return executors(List.of(executor));
@@ -91,7 +54,7 @@ public interface ThreadPool extends AutoCloseable {
                   () -> {
                     try {
                       while (!closed.get()) {
-                        if (executor.execute() == Executor.State.DONE) break;
+                        if (executor.execute() == State.DONE) break;
                       }
                     } catch (InterruptedException e) {
                       // swallow

--- a/app/src/main/java/org/astraea/performance/FileWriter.java
+++ b/app/src/main/java/org/astraea/performance/FileWriter.java
@@ -5,10 +5,11 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.stream.IntStream;
-import org.astraea.concurrent.ThreadPool;
+import org.astraea.concurrent.Executor;
+import org.astraea.concurrent.State;
 import org.astraea.utils.DataUnit;
 
-public class FileWriter implements ThreadPool.Executor {
+public class FileWriter implements Executor {
   private final Manager manager;
   private final Tracker tracker;
   private BufferedWriter writer;
@@ -21,7 +22,7 @@ public class FileWriter implements ThreadPool.Executor {
   }
 
   @Override
-  public ThreadPool.Executor.State execute() throws InterruptedException {
+  public State execute() throws InterruptedException {
     if (logToCSV()) return State.DONE;
     Thread.sleep(1000);
     return State.RUNNING;

--- a/app/src/main/java/org/astraea/performance/Tracker.java
+++ b/app/src/main/java/org/astraea/performance/Tracker.java
@@ -4,11 +4,12 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.astraea.concurrent.ThreadPool;
+import org.astraea.concurrent.Executor;
+import org.astraea.concurrent.State;
 import org.astraea.utils.DataUnit;
 
 /** Print out the given metrics. */
-public class Tracker implements ThreadPool.Executor {
+public class Tracker implements Executor {
   private final List<Metrics> producerData;
   private final List<Metrics> consumerData;
   private final Manager manager;

--- a/app/src/test/java/org/astraea/concurrent/ThreadPoolTest.java
+++ b/app/src/test/java/org/astraea/concurrent/ThreadPoolTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Timeout;
 
 public class ThreadPoolTest {
 
-  private static class CountExecutor implements ThreadPool.Executor {
+  private static class CountExecutor implements Executor {
 
     private final AtomicInteger executeCount = new AtomicInteger();
     private final AtomicInteger closeCount = new AtomicInteger();
@@ -44,7 +44,7 @@ public class ThreadPoolTest {
 
   @Test
   void testWaitAll() {
-    try (var pool = ThreadPool.builder().executor(() -> ThreadPool.Executor.State.DONE).build()) {
+    try (var pool = ThreadPool.builder().executor(() -> State.DONE).build()) {
       pool.waitAll();
     }
   }
@@ -57,7 +57,7 @@ public class ThreadPoolTest {
             .executor(
                 () -> {
                   TimeUnit.SECONDS.sleep(1000);
-                  return ThreadPool.Executor.State.DONE;
+                  return State.DONE;
                 })
             .build();
     pool.close();

--- a/app/src/test/java/org/astraea/consumer/RebalanceListenerTest.java
+++ b/app/src/test/java/org/astraea/consumer/RebalanceListenerTest.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.astraea.Utils;
+import org.astraea.concurrent.State;
 import org.astraea.concurrent.ThreadPool;
 import org.astraea.service.RequireBrokerCluster;
 import org.junit.jupiter.api.Test;
@@ -19,12 +20,12 @@ public class RebalanceListenerTest extends RequireBrokerCluster {
             .topics(Set.of(topicName))
             .consumerRebalanceListener(ignore -> getAssignment.incrementAndGet())
             .build()) {
-      try (ThreadPool threadPool =
+      try (var threadPool =
           ThreadPool.builder()
               .executor(
                   () -> {
                     consumer.poll(Duration.ofSeconds(10));
-                    return ThreadPool.Executor.State.DONE;
+                    return State.DONE;
                   })
               .build()) {
         Utils.waitFor(() -> getAssignment.get() == 1, Duration.ofSeconds(10));

--- a/app/src/test/java/org/astraea/metrics/collector/BeanCollectorTest.java
+++ b/app/src/test/java/org/astraea/metrics/collector/BeanCollectorTest.java
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.astraea.concurrent.Executor;
 import org.astraea.concurrent.ThreadPool;
 import org.astraea.metrics.HasBeanObject;
 import org.astraea.metrics.jmx.MBeanClient;
@@ -128,7 +129,10 @@ public class BeanCollectorTest {
 
     try (var pool =
         ThreadPool.builder()
-            .runnables(IntStream.range(0, 3).mapToObj(i -> runnable).collect(Collectors.toList()))
+            .executors(
+                IntStream.range(0, 3)
+                    .mapToObj(i -> Executor.of(runnable))
+                    .collect(Collectors.toList()))
             .build()) {
       sleep(1);
     }
@@ -164,9 +168,9 @@ public class BeanCollectorTest {
 
     try (var pool =
         ThreadPool.builder()
-            .runnables(
+            .executors(
                 receivers.stream()
-                    .map(receiver -> ((Runnable) receiver::current))
+                    .map(receiver -> Executor.of(receiver::current))
                     .collect(Collectors.toList()))
             .build()) {
       sleep(3);

--- a/app/src/test/java/org/astraea/partitioner/smoothPartitioner/PartitionerTest.java
+++ b/app/src/test/java/org/astraea/partitioner/smoothPartitioner/PartitionerTest.java
@@ -20,6 +20,8 @@ import java.util.stream.IntStream;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.astraea.Utils;
+import org.astraea.concurrent.Executor;
+import org.astraea.concurrent.State;
 import org.astraea.concurrent.ThreadPool;
 import org.astraea.consumer.Consumer;
 import org.astraea.consumer.Deserializer;
@@ -135,7 +137,7 @@ public class PartitionerTest extends RequireBrokerCluster {
     var key = "tainan";
     var timestamp = System.currentTimeMillis() + 10;
     var header = Header.of("a", "b".getBytes());
-    try (ThreadPool threadPool =
+    try (var threadPool =
         ThreadPool.builder()
             .executors(
                 IntStream.range(0, 10)
@@ -216,9 +218,9 @@ public class PartitionerTest extends RequireBrokerCluster {
     Assertions.assertEquals(smoothWeightServer.originalWeight(), -9);
   }
 
-  private ThreadPool.Executor producerExecutor(
+  private Executor producerExecutor(
       Producer<String, byte[]> producer, String topic, String key, Header header, long timeStamp) {
-    return new ThreadPool.Executor() {
+    return new Executor() {
       int i = 0;
 
       @Override

--- a/app/src/test/java/org/astraea/performance/PerformanceTest.java
+++ b/app/src/test/java/org/astraea/performance/PerformanceTest.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.TopicPartition;
 import org.astraea.Utils;
+import org.astraea.concurrent.Executor;
 import org.astraea.concurrent.ThreadPool;
 import org.astraea.consumer.Consumer;
 import org.astraea.producer.Producer;
@@ -34,7 +35,7 @@ public class PerformanceTest extends RequireBrokerCluster {
     param.specifyBroker = List.of(0);
     param.consumers = 0;
     param.partitions = 10;
-    try (ThreadPool.Executor executor =
+    try (var executor =
         Performance.producerExecutor(
             Producer.builder().brokers(bootstrapServers()).build(),
             param,
@@ -77,7 +78,7 @@ public class PerformanceTest extends RequireBrokerCluster {
     param.specifyBroker = List.of(0, 1);
     param.consumers = 0;
     param.partitions = 10;
-    try (ThreadPool.Executor executor =
+    try (Executor executor =
         Performance.producerExecutor(
             Producer.builder().brokers(bootstrapServers()).build(),
             param,
@@ -112,7 +113,7 @@ public class PerformanceTest extends RequireBrokerCluster {
     param.topic = "testProducerExecutor-" + System.currentTimeMillis();
     param.fixedSize = true;
     param.consumers = 0;
-    try (ThreadPool.Executor executor =
+    try (Executor executor =
         Performance.producerExecutor(
             Producer.builder().brokers(bootstrapServers()).build(),
             param,
@@ -132,7 +133,7 @@ public class PerformanceTest extends RequireBrokerCluster {
     var topicName = "testConsumerExecutor-" + System.currentTimeMillis();
     var param = new Performance.Argument();
     param.fixedSize = true;
-    try (ThreadPool.Executor executor =
+    try (Executor executor =
         Performance.consumerExecutor(
             Consumer.builder().topics(Set.of(topicName)).brokers(bootstrapServers()).build(),
             metrics,

--- a/app/src/test/java/org/astraea/performance/TrackerTest.java
+++ b/app/src/test/java/org/astraea/performance/TrackerTest.java
@@ -1,7 +1,7 @@
 package org.astraea.performance;
 
 import java.util.List;
-import org.astraea.concurrent.ThreadPool;
+import org.astraea.concurrent.State;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -16,21 +16,21 @@ public class TrackerTest {
 
     var manager = new Manager(argument, producerData, consumerData);
     try (Tracker tracker = new Tracker(producerData, consumerData, manager)) {
-      Assertions.assertEquals(ThreadPool.Executor.State.RUNNING, tracker.execute());
+      Assertions.assertEquals(State.RUNNING, tracker.execute());
       producerData.get(0).accept(1L, 1L);
       consumerData.get(0).accept(1L, 1L);
       manager.producerClosed();
-      Assertions.assertEquals(ThreadPool.Executor.State.DONE, tracker.execute());
+      Assertions.assertEquals(State.DONE, tracker.execute());
     }
 
     // Zero consumer
     producerData = List.of(new Metrics());
     manager = new Manager(argument, producerData, empty);
     try (Tracker tracker = new Tracker(producerData, empty, manager)) {
-      Assertions.assertEquals(ThreadPool.Executor.State.RUNNING, tracker.execute());
+      Assertions.assertEquals(State.RUNNING, tracker.execute());
       producerData.get(0).accept(1L, 1L);
       manager.producerClosed();
-      Assertions.assertEquals(ThreadPool.Executor.State.DONE, tracker.execute());
+      Assertions.assertEquals(State.DONE, tracker.execute());
     }
 
     // Stop by duration time out
@@ -40,7 +40,7 @@ public class TrackerTest {
     manager = new Manager(argument, producerData, consumerData);
     try (Tracker tracker = new Tracker(producerData, consumerData, manager)) {
       tracker.start = System.currentTimeMillis();
-      Assertions.assertEquals(ThreadPool.Executor.State.RUNNING, tracker.execute());
+      Assertions.assertEquals(State.RUNNING, tracker.execute());
 
       // Mock record producing
       producerData.get(0).accept(1L, 1L);
@@ -48,7 +48,7 @@ public class TrackerTest {
       Thread.sleep(2000);
       manager.producerClosed();
 
-      Assertions.assertEquals(ThreadPool.Executor.State.DONE, tracker.execute());
+      Assertions.assertEquals(State.DONE, tracker.execute());
     }
   }
 }


### PR DESCRIPTION
將會大量使用的介面 (executor and state)抽出來，以避免複雜的import (a.b.c.d)