### PR TITLE
add configs field to Performance tool

### DIFF
--- a/app/src/main/java/org/astraea/performance/Performance.java
+++ b/app/src/main/java/org/astraea/performance/Performance.java
@@ -25,6 +25,7 @@ import org.astraea.argument.NonEmptyStringField;
 import org.astraea.argument.NonNegativeShortField;
 import org.astraea.argument.PositiveLongField;
 import org.astraea.argument.PositiveShortField;
+import org.astraea.argument.StringMapField;
 import org.astraea.concurrent.Executor;
 import org.astraea.concurrent.State;
 import org.astraea.concurrent.ThreadPool;
@@ -298,10 +299,18 @@ public class Performance {
         validateWith = NonEmptyStringField.class)
     String partitioner = DefaultPartitioner.class.getName();
 
+    @Parameter(
+        names = {"--configs"},
+        description = "Map: set the configuration passed to producer/partitioner",
+        converter = StringMapField.class,
+        validateWith = StringMapField.class)
+    Map<String, String> configs = Map.of();
+
     public Map<String, Object> producerProps() {
       var props = props();
       props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, compression.name);
       if (!this.jmxServers.isEmpty()) props.put("jmx_servers", this.jmxServers);
+      props.putAll(configs);
       return props;
     }
 

--- a/app/src/test/java/org/astraea/performance/PerformanceTest.java
+++ b/app/src/test/java/org/astraea/performance/PerformanceTest.java
@@ -182,10 +182,13 @@ public class PerformanceTest extends RequireBrokerCluster {
       "--key.distribution",
       "zipfian",
       "--specify.broker",
-      "1"
+      "1",
+      "--configs",
+      "key=value"
     };
-    Assertions.assertDoesNotThrow(
-        () -> org.astraea.argument.Argument.parse(new Performance.Argument(), arguments1));
+
+    var arg = org.astraea.argument.Argument.parse(new Performance.Argument(), arguments1);
+    Assertions.assertEquals("value", arg.producerProps().get("key").toString());
 
     String[] arguments2 = {"--bootstrap.servers", "localhost:9092", "--topic", ""};
     Assertions.assertThrows(


### PR DESCRIPTION
`--configs`類似`prop.file`，但比較簡單可以直接在命令列指定複數的參數，目前會用於測試不同的`partitioner`。因為各個partitioner所使用的參數可能不相同，使用`--configs`可以避免我們需要將各個partitioner特定的參數通通暴露到performance tool