### PR TITLE
fix AdminClient#listOffsets API timeout error

### DIFF
--- a/app/src/main/java/org/astraea/topic/TopicExplorer.java
+++ b/app/src/main/java/org/astraea/topic/TopicExplorer.java
@@ -73,8 +73,8 @@ public class TopicExplorer {
                     .thenComparing(TopicPartition::partition))
             .collect(Collectors.toUnmodifiableList());
     if (!invalidTopics.isEmpty()) {
-      // The AdminClient#listOffsets API call will time out if any of the requested partitions
-      // has no leader yet.
+      // The metadata request sent by Kafka admin succeeds only if the leaders of all partitions are
+      // alive. Hence, we throw exception here to make consistent behavior with Kafka.
       throw new IllegalStateException("Some partitions have no leader: " + invalidTopics);
     }
 

--- a/app/src/main/java/org/astraea/topic/TopicExplorer.java
+++ b/app/src/main/java/org/astraea/topic/TopicExplorer.java
@@ -63,6 +63,18 @@ public class TopicExplorer {
 
   static Result execute(TopicAdmin admin, Set<String> topics) {
     var replicas = admin.replicas(topics);
+
+    var invalidTopics =
+        replicas.entrySet().stream()
+            .filter(x -> x.getValue().stream().noneMatch(Replica::leader))
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toUnmodifiableList());
+    if (!invalidTopics.isEmpty()) {
+      // The AdminClient#listOffsets API call will time out if any of the requested partitions
+      // has no leader yet.
+      throw new IllegalStateException("Some partitions have no leader: " + invalidTopics);
+    }
+
     var offsets = admin.offsets(topics);
     var consumerGroups = admin.consumerGroup(Set.of());
     var time = LocalDateTime.now();

--- a/app/src/main/java/org/astraea/topic/TopicExplorer.java
+++ b/app/src/main/java/org/astraea/topic/TopicExplorer.java
@@ -68,6 +68,9 @@ public class TopicExplorer {
         replicas.entrySet().stream()
             .filter(x -> x.getValue().stream().noneMatch(Replica::leader))
             .map(Map.Entry::getKey)
+            .sorted(
+                Comparator.comparing(TopicPartition::topic)
+                    .thenComparing(TopicPartition::partition))
             .collect(Collectors.toUnmodifiableList());
     if (!invalidTopics.isEmpty()) {
       // The AdminClient#listOffsets API call will time out if any of the requested partitions

--- a/app/src/test/java/org/astraea/topic/TopicExplorerTest.java
+++ b/app/src/test/java/org/astraea/topic/TopicExplorerTest.java
@@ -1,6 +1,7 @@
 package org.astraea.topic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
@@ -23,6 +24,7 @@ import org.astraea.consumer.Consumer;
 import org.astraea.service.RequireBrokerCluster;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class TopicExplorerTest extends RequireBrokerCluster {
 
@@ -200,5 +202,31 @@ public class TopicExplorerTest extends RequireBrokerCluster {
     assertTrue(output.matches("(?ms).+\\[.*non-synced.*].+"), "descriptor printed");
     assertTrue(output.matches("(?ms).+\\[.*future.*].+"), "descriptor printed");
     assertTrue(output.matches("(?ms).+/tmp/path0.+"), "path printed");
+  }
+
+  @Test
+  void somePartitionsHaveNoLeader() {
+    String topicName0 = "poor_topic0";
+    String topicName1 = "poor_topic1";
+    var payload0 =
+        Map.of(
+            new TopicPartition(topicName0, 0),
+            List.of(new Replica(1000, 0, 0, false, false, false, "?")));
+    var payload1 =
+        Map.of(
+            new TopicPartition(topicName1, 0),
+            List.of(
+                new Replica(1000, 0, 0, false, false, false, "?"),
+                new Replica(1001, 0, 0, false, false, false, "?"),
+                new Replica(1002, 0, 0, false, false, false, "?")));
+    TopicAdmin mock = Mockito.mock(TopicAdmin.class);
+
+    Mockito.when(mock.replicas(Set.of(topicName0))).thenReturn(payload0);
+    Mockito.when(mock.replicas(Set.of(topicName1))).thenReturn(payload1);
+
+    assertThrows(
+        IllegalStateException.class, () -> TopicExplorer.execute(mock, Set.of(topicName0)));
+    assertThrows(
+        IllegalStateException.class, () -> TopicExplorer.execute(mock, Set.of(topicName1)));
   }
 }


### PR DESCRIPTION
resolve #245 

Raise an exception if any of the target topic/partition has no leader.

```
Exception in thread "main" java.lang.IllegalStateException: Some partitions have no leader: [__consumer_offsets-0, __consumer_offsets-1, __consumer_offsets-2, __consumer_offsets-3, __consumer_offsets-4, __consumer_offsets-5, __consumer_offsets-6, __consumer_offsets-7, __consumer_offsets-8, __consumer_offsets-9, __consumer_offsets-10, __consumer_offsets-11, __consumer_offsets-12, __consumer_offsets-13, __consumer_offsets-14, __consumer_offsets-15, __consumer_offsets-16, __consumer_offsets-17, __consumer_offsets-18, __consumer_offsets-19, __consumer_offsets-20, __consumer_offsets-21, __consumer_offsets-22, __consumer_offsets-23, __consumer_offsets-24, __consumer_offsets-25, __consumer_offsets-26, __consumer_offsets-27, __consumer_offsets-28, __consumer_offsets-29, __consumer_offsets-30, __consumer_offsets-31, __consumer_offsets-32, __consumer_offsets-33, __consumer_offsets-34, __consumer_offsets-35, __consumer_offsets-36, __consumer_offsets-37, __consumer_offsets-38, __consumer_offsets-39, __consumer_offsets-40, __consumer_offsets-41, __consumer_offsets-42, __consumer_offsets-43, __consumer_offsets-44, __consumer_offsets-45, __consumer_offsets-46, __consumer_offsets-47, __consumer_offsets-48, __consumer_offsets-49, testPerformance-1646302098577-0, testPerformance-1646302098577-1, testPerformance-1646302098577-2, testPerformance-1646302098577-3, testPerformance-1646302098577-4, testPerformance-1646302098577-5, testPerformance-1646302098577-6, testPerformance-1646302098577-7, testPerformance-1646302098577-8, testPerformance-1646302098577-9, testPerformance-1646302098577-10, testPerformance-1646302098577-11, testPerformance-1646302098577-12, testPerformance-1646302098577-13, testPerformance-1646302098577-14, testPerformance-1646302098577-15]
        at org.astraea.topic.TopicExplorer.execute(TopicExplorer.java:78)
        at org.astraea.topic.TopicExplorer.main(TopicExplorer.java:117)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at org.astraea.App.execute(App.java:53)
        at org.astraea.App.main(App.java:65)
```