### PR TITLE
Rewrite `SmoothWeightPartitioner`

### DIFF
--- a/app/src/main/java/org/astraea/cost/LoadCost.java
+++ b/app/src/main/java/org/astraea/cost/LoadCost.java
@@ -1,0 +1,180 @@
+package org.astraea.cost;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.astraea.metrics.HasBeanObject;
+import org.astraea.metrics.collector.Fetcher;
+import org.astraea.metrics.kafka.BrokerTopicMetricsResult;
+import org.astraea.metrics.kafka.KafkaMetrics;
+import org.astraea.partitioner.nodeLoadMetric.PartitionerUtils;
+
+public class LoadCost implements CostFunction {
+  private final Map<Integer, BrokerMetric> brokersMetric = new HashMap<>();
+  private final Map<String, Double> metricNameAndWeight =
+      Map.of(
+          KafkaMetrics.BrokerTopic.BytesInPerSec.metricName(),
+          0.5,
+          KafkaMetrics.BrokerTopic.BytesOutPerSec.metricName(),
+          0.5);
+
+  /** Do "Poisson" and "weightPoisson" calculation on "load". And change output to double. */
+  @Override
+  public Map<Integer, Double> cost(ClusterInfo clusterInfo) {
+    var load = computeLoad(clusterInfo.allBeans());
+
+    // Poisson calculation (-> Poisson -> throughputAbility -> to double)
+    return PartitionerUtils.allPoisson(load).entrySet().stream()
+        .map(e -> Map.entry(e.getKey(), PartitionerUtils.weightPoisson(e.getValue(), 1.0)))
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> (double) e.getValue()));
+  }
+
+  /**
+   * The result is computed by "BytesInPerSec.count" and "BytesOutPerSec.count".
+   *
+   * <ol>
+   *   <li>We normalize the two metric (by divide sum of each metric).
+   *   <li>We compute the sum on the two metric with a specific weight.
+   *   <li>Compare the weighted sum with two boundary(0.5*avg and 1.5*avg) to get the "load" {0,1,2}
+   *   <li>Sum up the historical "load" and divide by 20 the get the score.
+   * </ol>
+   *
+   * <p>e.g. We have 3 brokers with information:<br>
+   * broker1: BytesInPerSec.count=50, BytesOutPerSec.count=15 (<1,50000,21000>)<br>
+   * broker2: BytesInPerSec.count=100, BytesOutPerSec.count=2 (<2,100000,2000>)<br>
+   * broker3: BytesInPerSec.count=200, BytesOutPerSec.count=1 (<3,200000,1000>)<br>
+   *
+   * <ol>
+   *   <li>Normalize: about <1, 1/7, 7/8> <2, 2/7, 1/12> <3, 4/7, 1/24>
+   *   <li>WeightedSum: about <1, 57/112> <2, 31/168> <3, 103/336>
+   *   <li>Load:<1,2><2,1><3,1>
+   * </ol>
+   *
+   * broker1 score: 2<br>
+   * broker2 score: 1<br>
+   * broker3 score: 1<br>
+   *
+   * @return brokerID with "(sum of load)".
+   */
+  Map<Integer, Integer> computeLoad(Map<Integer, Collection<HasBeanObject>> allBeans) {
+    // Store mbean data into local stat("brokersMetric").
+    allBeans.forEach(
+        (brokerID, value) -> {
+          if (!brokersMetric.containsKey(brokerID))
+            brokersMetric.put(brokerID, new BrokerMetric(brokerID));
+          value.stream()
+              .filter(hasBeanObject -> hasBeanObject instanceof BrokerTopicMetricsResult)
+              .map(hasBeanObject -> (BrokerTopicMetricsResult) hasBeanObject)
+              .forEach(
+                  result ->
+                      brokersMetric
+                          .get(brokerID)
+                          .updateCount(
+                              result.beanObject().getProperties().get("name"), result.count()));
+        });
+
+    // Sum all count with the same mbean name
+    var total =
+        brokersMetric.values().stream()
+            .map(brokerMetric -> brokerMetric.currentCount)
+            .reduce(
+                new HashMap<>(),
+                (accumulate, currentCount) -> {
+                  currentCount.forEach(
+                      (name, count) ->
+                          accumulate.put(name, accumulate.getOrDefault(name, 0L) + count));
+                  return accumulate;
+                });
+
+    // Reduce all count for all brokers' mbean current count by "divide total" (current/total). And
+    // then get the weighted sum according to predefined wights "metricNameAndWeight".
+    // It is called "brokerSituation" in original name.
+    var weightedSum =
+        brokersMetric.entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey,
+                    entry ->
+                        entry.getValue().currentCount.entrySet().stream()
+                            .mapToDouble(
+                                nameAndCount ->
+                                    (double) (nameAndCount.getValue() + 1)
+                                        / (total.getOrDefault(nameAndCount.getKey(), 1L) + 1)
+                                        * metricNameAndWeight.getOrDefault(
+                                            nameAndCount.getKey(), 0.0))
+                            .sum()));
+
+    var avgWeightedSum =
+        weightedSum.values().stream().mapToDouble(d -> d).sum() / brokersMetric.size();
+
+    // Record the "load" into local stat("brokersMetric").
+    weightedSum.forEach(
+        (brokerID, theWeightedSum) -> {
+          if (theWeightedSum < avgWeightedSum * 0.5) brokersMetric.get(brokerID).updateLoad(0);
+          else if (theWeightedSum < avgWeightedSum * 1.5) brokersMetric.get(brokerID).updateLoad(1);
+          else brokersMetric.get(brokerID).updateLoad(2);
+        });
+
+    // The sum of historical and current load.
+    return brokersMetric.entrySet().stream()
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey, entry -> entry.getValue().load.stream().mapToInt(i -> i).sum()));
+  }
+
+  /** @return the metrics getters. Those getters are used to fetch mbeans. */
+  @Override
+  public Fetcher fetcher() {
+    return client ->
+        List.of(
+            KafkaMetrics.BrokerTopic.BytesInPerSec.fetch(client),
+            KafkaMetrics.BrokerTopic.BytesOutPerSec.fetch(client));
+  }
+
+  private static class BrokerMetric {
+    private final int brokerID;
+
+    // mbean data. They are:
+    // ("BytesInPerSec", BytesInPerSec.count), ("BytesOutPerSec", ByteOutPerSec.count)
+    private final Map<String, Long> accumulateCount = new HashMap<>();
+    private final Map<String, Long> currentCount = new HashMap<>();
+
+    // Record the latest 10 numbers only.
+    private final List<Integer> load =
+        IntStream.range(0, 10).mapToObj(i -> 0).collect(Collectors.toList());
+    private int loadIndex = 0;
+
+    BrokerMetric(int brokerID) {
+      this.brokerID = brokerID;
+    }
+
+    /**
+     * This method records the difference between last update and current given "count" e.g.
+     *
+     * <p>At time 1: updateCount("ByteInPerSec", 100);<br>
+     * At time 3: updateCount("ByteOutPerSec", 20);<br>
+     * At time 20: updateCount("ByteInPerSec", 150);<br>
+     * At time 22: updateCount("ByteOutPerSec", 90);<br>
+     * At time 35: updateCount("ByteInPerSec", 170)<br>
+     * Then in time [20, 35), currentCount.get("ByteInPerSec") is 50
+     *
+     * <p>
+     */
+    void updateCount(String domainName, Long count) {
+      currentCount.put(domainName, count - accumulateCount.getOrDefault(domainName, 0L));
+      accumulateCount.put(domainName, count);
+    }
+
+    /**
+     * This method record input data into a list. This list contains the latest 10 record. Each time
+     * it is called, the current index, "loadIndex", is increased by 1.
+     */
+    void updateLoad(Integer load) {
+      this.load.set(loadIndex, load);
+      loadIndex = (loadIndex + 1) % 10;
+    }
+  }
+}

--- a/app/src/main/java/org/astraea/cost/MemoryWarningCost.java
+++ b/app/src/main/java/org/astraea/cost/MemoryWarningCost.java
@@ -1,0 +1,46 @@
+package org.astraea.cost;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.astraea.Utils;
+import org.astraea.metrics.collector.Fetcher;
+import org.astraea.metrics.java.HasJvmMemory;
+import org.astraea.metrics.kafka.KafkaMetrics;
+
+/** Warning on heap usage >= 80%. */
+public class MemoryWarningCost implements CostFunction {
+  private final long constructTime = System.currentTimeMillis();
+
+  /** @return 1 if the heap usage >= 80%, 0 otherwise. */
+  @Override
+  public Map<Integer, Double> cost(ClusterInfo clusterInfo) {
+    return clusterInfo.allBeans().entrySet().stream()
+        .map(
+            e ->
+                Map.entry(
+                    e.getKey(),
+                    e.getValue().stream()
+                        .filter(beanObject -> beanObject instanceof HasJvmMemory)
+                        .map(beanObject -> (HasJvmMemory) beanObject)
+                        .map(
+                            hasJvmMemory -> {
+                              if (Utils.overSecond(constructTime, 10)
+                                  && (hasJvmMemory.heapMemoryUsage().getUsed() + 0.0)
+                                          / (hasJvmMemory.heapMemoryUsage().getMax() + 1)
+                                      >= 0.8) {
+                                return 1.0;
+                              } else {
+                                return 0.0;
+                              }
+                            })
+                        .findAny()
+                        .orElseThrow()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Override
+  public Fetcher fetcher() {
+    return client -> List.of(KafkaMetrics.Host.jvmMemory(client));
+  }
+}

--- a/app/src/main/java/org/astraea/partitioner/nodeLoadMetric/NodeLoadClient.java
+++ b/app/src/main/java/org/astraea/partitioner/nodeLoadMetric/NodeLoadClient.java
@@ -184,7 +184,7 @@ public class NodeLoadClient {
           broker.output =
               Integer.parseInt(String.valueOf((currentOutput - broker.lastOutPut) / 1024));
           broker.lastOutPut = currentOutput;
-          broker.input = Integer.parseInt(String.valueOf((currentInput - broker.lastInput) / 1024));
+          broker.input = (int) ((currentInput - broker.lastInput) / 1024);
           broker.lastInput = currentInput;
           Objects.requireNonNull(broker.metrics.get("Memory"));
           broker.jvm =

--- a/app/src/main/java/org/astraea/partitioner/nodeLoadMetric/PartitionerUtils.java
+++ b/app/src/main/java/org/astraea/partitioner/nodeLoadMetric/PartitionerUtils.java
@@ -10,7 +10,7 @@ import java.util.Properties;
 public class PartitionerUtils {
   private PartitionerUtils() {}
 
-  public static HashMap<Integer, Double> allPoisson(Map<Integer, Integer> overLoadCount) {
+  public static Map<Integer, Double> allPoisson(Map<Integer, Integer> overLoadCount) {
     var poissonMap = new HashMap<Integer, Double>();
     var lambda = avgLoadCount(overLoadCount);
     overLoadCount.forEach((nodeID, count) -> poissonMap.put(nodeID, doPoisson(lambda, count)));

--- a/app/src/main/java/org/astraea/partitioner/smoothPartitioner/SmoothWeight.java
+++ b/app/src/main/java/org/astraea/partitioner/smoothPartitioner/SmoothWeight.java
@@ -1,0 +1,47 @@
+package org.astraea.partitioner.smoothPartitioner;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Given initial key-score pair, it will output a preferred key with higher score. The score of the
+ * chosen key will decrease. And the other score will increment by its original score. It may result
+ * in "higher score with higher chosen rate".
+ */
+public final class SmoothWeight {
+  private Map<Integer, Integer> load;
+  private int loadSum;
+  public Map<Integer, Integer> weight;
+
+  public SmoothWeight() {}
+
+  public SmoothWeight(Map<Integer, Integer> load) {
+    init(load);
+  }
+
+  public synchronized void init(Map<Integer, Integer> load) {
+    this.load = new HashMap<>(load);
+    this.weight = new HashMap<>(load);
+    this.loadSum = load.values().stream().mapToInt(d -> d).sum();
+  }
+
+  /**
+   * Get the preferred ID, and update the state.
+   *
+   * @return the preferred ID
+   */
+  public int getAndChoose() {
+    Objects.requireNonNull(this.weight);
+
+    this.weight.replaceAll((ID, value) -> value + this.load.get(ID));
+    var maxID =
+        this.weight.entrySet().stream()
+            .max(Comparator.comparingDouble(Map.Entry::getValue))
+            .orElseGet(() -> Map.entry(0, 0))
+            .getKey();
+    this.weight.computeIfPresent(maxID, (ID, value) -> value - loadSum);
+    return maxID;
+  }
+}

--- a/app/src/main/java/org/astraea/partitioner/smoothPartitioner/SmoothWeightDispatcher.java
+++ b/app/src/main/java/org/astraea/partitioner/smoothPartitioner/SmoothWeightDispatcher.java
@@ -1,0 +1,155 @@
+package org.astraea.partitioner.smoothPartitioner;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Random;
+import java.util.TreeMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+import org.astraea.Utils;
+import org.astraea.cost.ClusterInfo;
+import org.astraea.cost.CostFunction;
+import org.astraea.cost.LoadCost;
+import org.astraea.cost.MemoryWarningCost;
+import org.astraea.metrics.collector.BeanCollector;
+import org.astraea.metrics.collector.Fetcher;
+import org.astraea.metrics.collector.Receiver;
+import org.astraea.partitioner.Configuration;
+import org.astraea.partitioner.Dispatcher;
+
+/**
+ * Based on the jmx metrics obtained from Kafka, it records the load status of the node over a
+ * period of time. Predict the future status of each node through the poisson of the load status.
+ * Finally, the result of poisson is used as the weight to perform smooth weighted RoundRobin.
+ */
+public class SmoothWeightDispatcher implements Dispatcher {
+  public static final String JMX_PORT = "jmx.port";
+  private final BeanCollector beanCollector =
+      BeanCollector.builder().interval(Duration.ofSeconds(1)).build();
+  private Optional<Integer> jmxPortDefault = Optional.empty();
+  private final Map<Integer, Integer> jmxPorts = new TreeMap<>();
+  private final Map<Integer, Receiver> receivers = new TreeMap<>();
+
+  private final Collection<CostFunction> functions =
+      List.of(new LoadCost(), new MemoryWarningCost());
+  // Memory warning can dominate the score.
+  private final Map<Object, Double> costFraction =
+      Map.of(LoadCost.class, 1.0, MemoryWarningCost.class, -100.0);
+
+  private final SmoothWeight smoothWeightCal = new SmoothWeight();
+  private final Random random = new Random();
+  // Fetch data every n seconds
+  private long lastFetchTime = 0L;
+  private final Lock lock = new ReentrantLock();
+
+  @Override
+  public int partition(String topic, byte[] key, byte[] value, ClusterInfo clusterInfo) {
+    var partitions = clusterInfo.availablePartitions(topic);
+    // just return first partition if there is no available partitions
+    if (partitions.isEmpty()) return 0;
+
+    // just return the only one available partition
+    if (partitions.size() == 1) return partitions.iterator().next().partition();
+
+    if (Utils.overSecond(lastFetchTime, 1) && lock.tryLock()) {
+      try {
+        // add new receivers for new brokers
+        partitions.stream()
+            .filter(p -> !receivers.containsKey(p.leader().id()))
+            .forEach(
+                p ->
+                    receivers.put(
+                        p.leader().id(), receiver(p.leader().host(), jmxPort(p.leader().id()))));
+
+        // fetch the latest beans for each node
+        var beans =
+            receivers.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().current()));
+
+        var compoundScore =
+            functions.stream()
+                .map(
+                    f -> {
+                      var map = f.cost(ClusterInfo.of(clusterInfo, beans));
+                      map.replaceAll((k, v) -> v * costFraction.get(f.getClass()));
+                      return map;
+                    })
+                .reduce(new HashMap<>(), SmoothWeightDispatcher::costCompound)
+                .entrySet()
+                .stream()
+                .map(e -> Map.entry(e.getKey(), (int) (double) e.getValue()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        smoothWeightCal.init(compoundScore);
+      } finally {
+        lastFetchTime = System.currentTimeMillis();
+        lock.unlock();
+      }
+    }
+
+    // Make "smooth weight choosing" on the score.
+    var targetBroker = smoothWeightCal.getAndChoose();
+    var targetPartitions =
+        partitions.stream()
+            .filter(p -> p.leader().id() == targetBroker)
+            .collect(Collectors.toList());
+
+    return targetPartitions.get(random.nextInt(targetPartitions.size())).partition();
+  }
+
+  // Just add all cost function score together
+  static Map<Integer, Double> costCompound(
+      Map<Integer, Double> identity, Map<Integer, Double> cost) {
+    cost.forEach((ID, value) -> identity.computeIfPresent(ID, (k, v) -> v + value));
+    cost.forEach(identity::putIfAbsent);
+    return identity;
+  }
+
+  Receiver receiver(String host, int port) {
+    return beanCollector
+        .register()
+        .host(host)
+        .port(port)
+        .fetcher(
+            Fetcher.of(
+                functions.stream()
+                    .map(CostFunction::fetcher)
+                    .collect(Collectors.toUnmodifiableList())))
+        .build();
+  }
+
+  @Override
+  public void configure(Configuration config) {
+    jmxPortDefault = config.integer(JMX_PORT);
+
+    // seeks for custom jmx ports.
+    config.entrySet().stream()
+        .filter(e -> e.getKey().startsWith("broker."))
+        .filter(e -> e.getKey().endsWith(JMX_PORT))
+        .map(
+            e ->
+                Map.entry(
+                    e.getKey().replaceAll("^broker[.]", "").replaceAll("[.]" + JMX_PORT + "$", ""),
+                    e.getValue()))
+        .forEach(e -> jmxPorts.put(Integer.parseInt(e.getKey()), Integer.parseInt(e.getValue())));
+  }
+
+  // visible for testing
+  int jmxPort(int id) {
+    if (jmxPorts.containsKey(id)) return jmxPorts.get(id);
+    return jmxPortDefault.orElseThrow(
+        () -> new NoSuchElementException("broker: " + id + " does not have jmx port"));
+  }
+
+  @Override
+  public void close() {
+    receivers.values().forEach(Utils::close);
+    receivers.clear();
+  }
+}

--- a/app/src/test/java/org/astraea/cost/FakeClusterInfo.java
+++ b/app/src/test/java/org/astraea/cost/FakeClusterInfo.java
@@ -1,0 +1,33 @@
+package org.astraea.cost;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.astraea.metrics.HasBeanObject;
+
+public class FakeClusterInfo implements ClusterInfo {
+  @Override
+  public List<NodeInfo> nodes() {
+    return List.of();
+  }
+
+  @Override
+  public List<PartitionInfo> availablePartitions(String topic) {
+    return List.of();
+  }
+
+  @Override
+  public List<PartitionInfo> partitions(String topic) {
+    return List.of();
+  }
+
+  @Override
+  public Collection<HasBeanObject> beans(int brokerId) {
+    return List.of();
+  }
+
+  @Override
+  public Map<Integer, Collection<HasBeanObject>> allBeans() {
+    return Map.of();
+  }
+}

--- a/app/src/test/java/org/astraea/cost/LoadCostTest.java
+++ b/app/src/test/java/org/astraea/cost/LoadCostTest.java
@@ -1,0 +1,60 @@
+package org.astraea.cost;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.astraea.metrics.HasBeanObject;
+import org.astraea.metrics.jmx.BeanObject;
+import org.astraea.metrics.kafka.BrokerTopicMetricsResult;
+import org.astraea.metrics.kafka.KafkaMetrics;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class LoadCostTest {
+  @Test
+  void testComputeLoad() {
+    var loadCostFunction = new LoadCost();
+    var allBeans = exampleClusterInfo().allBeans();
+    var load = loadCostFunction.computeLoad(allBeans);
+
+    Assertions.assertEquals(2, load.get(1));
+    Assertions.assertEquals(1, load.get(2));
+    Assertions.assertEquals(1, load.get(3));
+
+    load = loadCostFunction.computeLoad(allBeans);
+
+    // count does not change so all broker get one more score
+    Assertions.assertEquals(3, load.get(1));
+    Assertions.assertEquals(2, load.get(2));
+    Assertions.assertEquals(2, load.get(3));
+  }
+
+  private ClusterInfo exampleClusterInfo() {
+    var BytesInPerSec1 = mockResult(KafkaMetrics.BrokerTopic.BytesInPerSec.metricName(), 50000L);
+    var BytesInPerSec2 = mockResult(KafkaMetrics.BrokerTopic.BytesInPerSec.metricName(), 100000L);
+    var BytesInPerSec3 = mockResult(KafkaMetrics.BrokerTopic.BytesInPerSec.metricName(), 200000L);
+    var BytesOutPerSec1 = mockResult(KafkaMetrics.BrokerTopic.BytesOutPerSec.metricName(), 210L);
+    var BytesOutPerSec2 = mockResult(KafkaMetrics.BrokerTopic.BytesOutPerSec.metricName(), 20L);
+    var BytesOutPerSec3 = mockResult(KafkaMetrics.BrokerTopic.BytesOutPerSec.metricName(), 10L);
+
+    Collection<HasBeanObject> broker1 = List.of(BytesInPerSec1, BytesOutPerSec1);
+    Collection<HasBeanObject> broker2 = List.of(BytesInPerSec2, BytesOutPerSec2);
+    Collection<HasBeanObject> broker3 = List.of(BytesInPerSec3, BytesOutPerSec3);
+    return new FakeClusterInfo() {
+      @Override
+      public Map<Integer, Collection<HasBeanObject>> allBeans() {
+        return Map.of(1, broker1, 2, broker2, 3, broker3);
+      }
+    };
+  }
+
+  private BrokerTopicMetricsResult mockResult(String name, long count) {
+    var result = Mockito.mock(BrokerTopicMetricsResult.class);
+    var bean = Mockito.mock(BeanObject.class);
+    Mockito.when(result.beanObject()).thenReturn(bean);
+    Mockito.when(bean.getProperties()).thenReturn(Map.of("name", name));
+    Mockito.when(result.count()).thenReturn(count);
+    return result;
+  }
+}

--- a/app/src/test/java/org/astraea/cost/MemoryWarningCostTest.java
+++ b/app/src/test/java/org/astraea/cost/MemoryWarningCostTest.java
@@ -1,0 +1,53 @@
+package org.astraea.cost;
+
+import java.lang.management.MemoryUsage;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.astraea.metrics.HasBeanObject;
+import org.astraea.metrics.java.HasJvmMemory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class MemoryWarningCostTest {
+  @Test
+  void testCost() throws InterruptedException {
+    var jvmMemory1 = mockResult(50L, 100L);
+    var jvmMemory2 = mockResult(81L, 100L);
+    var jvmMemory3 = mockResult(80L, 150L);
+
+    Collection<HasBeanObject> broker1 = List.of(jvmMemory1);
+    Collection<HasBeanObject> broker2 = List.of(jvmMemory2);
+    Collection<HasBeanObject> broker3 = List.of(jvmMemory3);
+    ClusterInfo clusterInfo =
+        new FakeClusterInfo() {
+          @Override
+          public Map<Integer, Collection<HasBeanObject>> allBeans() {
+            return Map.of(1, broker1, 2, broker2, 3, broker3);
+          }
+        };
+
+    var memoryWarning = new MemoryWarningCost();
+    var scores = memoryWarning.cost(clusterInfo);
+    Assertions.assertEquals(0.0, scores.get(1));
+    Assertions.assertEquals(0.0, scores.get(2));
+    Assertions.assertEquals(0.0, scores.get(3));
+
+    Thread.sleep(10000);
+
+    scores = memoryWarning.cost(clusterInfo);
+    Assertions.assertEquals(0.0, scores.get(1));
+    Assertions.assertEquals(1.0, scores.get(2));
+    Assertions.assertEquals(0.0, scores.get(3));
+  }
+
+  private HasJvmMemory mockResult(long used, long max) {
+    var jvmMemory = Mockito.mock(HasJvmMemory.class);
+    var memoryUsage = Mockito.mock(MemoryUsage.class);
+    Mockito.when(jvmMemory.heapMemoryUsage()).thenReturn(memoryUsage);
+    Mockito.when(memoryUsage.getUsed()).thenReturn(used);
+    Mockito.when(memoryUsage.getMax()).thenReturn(max);
+    return jvmMemory;
+  }
+}

--- a/app/src/test/java/org/astraea/partitioner/nodeLoadMetric/PartitionerUtilsTest.java
+++ b/app/src/test/java/org/astraea/partitioner/nodeLoadMetric/PartitionerUtilsTest.java
@@ -7,6 +7,7 @@ import static org.astraea.partitioner.nodeLoadMetric.PartitionerUtils.weightPois
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +34,7 @@ public class PartitionerUtilsTest {
     testNodesLoadCount.put(1, 5);
     testNodesLoadCount.put(2, 8);
 
-    HashMap<Integer, Double> poissonMap;
+    Map<Integer, Double> poissonMap;
     HashMap<Integer, Double> testPoissonMap = new HashMap<>();
     testPoissonMap.put(0, 0.12465201948308113);
     testPoissonMap.put(1, 0.6159606548330632);

--- a/app/src/test/java/org/astraea/partitioner/smoothPartitioner/SmoothWeightTest.java
+++ b/app/src/test/java/org/astraea/partitioner/smoothPartitioner/SmoothWeightTest.java
@@ -1,0 +1,20 @@
+package org.astraea.partitioner.smoothPartitioner;
+
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SmoothWeightTest {
+  @Test
+  public void testGetAndChoose() {
+    var smoothWeight = new SmoothWeight(Map.of(1, 5, 2, 3, 3, 1));
+
+    Assertions.assertEquals(1, smoothWeight.getAndChoose());
+    Assertions.assertEquals(2, smoothWeight.getAndChoose());
+    Assertions.assertEquals(1, smoothWeight.getAndChoose());
+    Assertions.assertEquals(1, smoothWeight.getAndChoose());
+    Assertions.assertEquals(2, smoothWeight.getAndChoose());
+    Assertions.assertEquals(1, smoothWeight.getAndChoose());
+    Assertions.assertEquals(3, smoothWeight.getAndChoose());
+  }
+}


### PR DESCRIPTION
此PR重構了原來的`SmoothWeightPartitioner`，使用`CostFunction`實做。並做了些許的變動：

1. 省去部份初始判斷(`lastTime==-1...`)
2. 把時間判斷集中(原本是`NodeLoadClient`, `SmoothWeightPartitioner`分別做"1秒1更新")
3. 省去還未實做的功能(如：`throughputAbility`, `standardDeviation`...等功能)
4. 算法切分不同，所以unit test另外寫了一份。

另外改寫的過程中發現了很多問題：

1. 現在算法結果難以使用0~1表示
2. 許多型別轉換(是否必要)
3. 參數重複參考(是否必要)
4. `CostFunction`回傳值的 "意義"

@wycccccc 看看算法是否須要再做調整？
