### PR TITLE
Add docker resource constraint flags for `start_broker.sh`

### DIFF
--- a/docker/start_broker.sh
+++ b/docker/start_broker.sh
@@ -243,6 +243,15 @@ function setLogDirs() {
   echo $logConfigs >>"$BROKER_PROPERTIES"
 }
 
+function generateResourceConstraintCommand() {
+    if [[ -n "$MEMORY" ]]; then
+        echo "--memory=$MEMORY"
+    fi
+    if [[ -n "$CPUS" ]]; then
+        echo "--cpus=$CPUS"
+    fi
+}
+
 function generateJmxConfigMountCommand() {
     if [[ "$JMX_CONFIG_FILE" != "" ]]; then
         echo "--mount type=bind,source=$JMX_CONFIG_FILE,target=$JMX_CONFIG_FILE_IN_CONTAINER_PATH"
@@ -345,6 +354,7 @@ docker run -d --init \
   -e KAFKA_JMX_OPTS="$JMX_OPTS" \
   -e KAFKA_OPTS="-javaagent:/opt/jmx_exporter/jmx_prometheus_javaagent-${EXPORTER_VERSION}.jar=$EXPORTER_PORT:$JMX_CONFIG_FILE_IN_CONTAINER_PATH" \
   -v $BROKER_PROPERTIES:/tmp/broker.properties:ro \
+  $(generateResourceConstraintCommand) \
   $(generateJmxConfigMountCommand) \
   $(generateDataFolderMountCommand) \
   -p $BROKER_PORT:9092 \


### PR DESCRIPTION
This PR adds support for applying resource constraints to `start_broker.sh`.

The following resources are implemented.

* CPU
* Memory

These flags can be used to create a lightweight container-based testing environment. Doing resource isolation without the cost of an actual VM.

Noted that even though there is support for [Block IO bandwidth constraint](https://docs.docker.com/engine/reference/run/#block-io-bandwidth-blkio-constraint). We don't intend to add these flags to the script.
I have tested these `blkio` constraint flags, It feels like Kafka passed these bandwidth limits in some way. Maybe the operating system still uses the memory as a buffer so it doesn't limit the bandwidth (in time at least, I have set IOPS to a very low number and see the broker stall for a few seconds).

