### PR TITLE
Add created timestamp to all bean objects

### DIFF
--- a/app/src/main/java/org/astraea/metrics/HasBeanObject.java
+++ b/app/src/main/java/org/astraea/metrics/HasBeanObject.java
@@ -4,4 +4,8 @@ import org.astraea.metrics.jmx.BeanObject;
 
 public interface HasBeanObject {
   BeanObject beanObject();
+
+  default long createdTimestamp() {
+    return beanObject().createdTimestamp();
+  }
 }

--- a/app/src/main/java/org/astraea/metrics/collector/BeanCollector.java
+++ b/app/src/main/java/org/astraea/metrics/collector/BeanCollector.java
@@ -141,7 +141,11 @@ public class BeanCollector {
                       if (objects.size() + beans.size() <= numberOfObjectsPerNode) break;
                       objects.remove(t);
                     }
-                    long now = System.currentTimeMillis();
+                    long now =
+                        beans.stream()
+                            .mapToLong(HasBeanObject::createdTimestamp)
+                            .min()
+                            .orElse(System.currentTimeMillis());
                     for (var bean : beans) objects.put(now++, bean);
                   } finally {
                     node.lock.unlock();

--- a/app/src/main/java/org/astraea/metrics/jmx/BeanObject.java
+++ b/app/src/main/java/org/astraea/metrics/jmx/BeanObject.java
@@ -12,6 +12,7 @@ public class BeanObject {
   private final String domainName;
   private final Map<String, String> properties;
   private final Map<String, Object> attributes;
+  private final long createdTimestamp = System.currentTimeMillis();
 
   /**
    * construct a {@link BeanObject}
@@ -54,6 +55,10 @@ public class BeanObject {
 
   public Map<String, Object> getAttributes() {
     return attributes;
+  }
+
+  public long createdTimestamp() {
+    return createdTimestamp;
   }
 
   @Override


### PR DESCRIPTION
新增`createdTimestamp`給所有bean objects，同時該timestamp將用作`BeanCollector`內部的時間淘汰選擇