### PR TITLE
Add Isolation and Compression to simplify builder

### DIFF
--- a/app/src/main/java/org/astraea/argument/CompressionField.java
+++ b/app/src/main/java/org/astraea/argument/CompressionField.java
@@ -4,17 +4,18 @@ import com.beust.jcommander.ParameterException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.kafka.common.record.CompressionType;
+import org.astraea.topic.Compression;
 
-public class CompressionField extends Field<CompressionType> {
+public class CompressionField extends Field<Compression> {
   /**
    * @param value Name of compression type. Accept lower-case name only ("none", "gzip", "snappy",
    *     "lz4", "zstd").
    */
   @Override
-  public CompressionType convert(String value) {
+  public Compression convert(String value) {
     try {
       // `CompressionType#forName` accept lower-case name only.
-      return CompressionType.forName(value);
+      return Compression.of(value);
     } catch (IllegalArgumentException e) {
       throw new ParameterException(
           "the "

--- a/app/src/main/java/org/astraea/consumer/Consumer.java
+++ b/app/src/main/java/org/astraea/consumer/Consumer.java
@@ -29,7 +29,7 @@ public interface Consumer<Key, Value> extends AutoCloseable {
     return builder().brokers(brokers).build();
   }
 
-  static Consumer<byte[], byte[]> of(Map<String, Object> configs) {
+  static Consumer<byte[], byte[]> of(Map<String, String> configs) {
     return builder().configs(configs).build();
   }
 }

--- a/app/src/main/java/org/astraea/consumer/Isolation.java
+++ b/app/src/main/java/org/astraea/consumer/Isolation.java
@@ -1,0 +1,17 @@
+package org.astraea.consumer;
+
+import java.util.Locale;
+
+public enum Isolation {
+  READ_UNCOMMITTED,
+  READ_COMMITTED;
+
+  public static Isolation of(String name) {
+    return Isolation.valueOf(name.toUpperCase(Locale.ROOT));
+  }
+
+  /** @return the name parsed by kafka */
+  public String nameOfKafka() {
+    return name().toLowerCase(Locale.ROOT);
+  }
+}

--- a/app/src/main/java/org/astraea/producer/Builder.java
+++ b/app/src/main/java/org/astraea/producer/Builder.java
@@ -17,6 +17,7 @@ import org.apache.kafka.common.errors.AuthorizationException;
 import org.apache.kafka.common.errors.OutOfOrderSequenceException;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.astraea.consumer.Header;
+import org.astraea.topic.Compression;
 
 public class Builder<Key, Value> {
   private final Map<String, Object> configs = new HashMap<>();
@@ -37,20 +38,27 @@ public class Builder<Key, Value> {
     return (Builder<Key, NewValue>) this;
   }
 
-  public Builder<Key, Value> configs(Map<String, Object> configs) {
+  public Builder<Key, Value> config(String key, String value) {
+    this.configs.put(key, value);
+    return this;
+  }
+
+  public Builder<Key, Value> configs(Map<String, String> configs) {
     this.configs.putAll(configs);
     return this;
   }
 
   public Builder<Key, Value> brokers(String brokers) {
-    this.configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, Objects.requireNonNull(brokers));
-    return this;
+    return config(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, Objects.requireNonNull(brokers));
   }
 
   public Builder<Key, Value> partitionClassName(String partitionClassName) {
-    this.configs.put(
+    return config(
         ProducerConfig.PARTITIONER_CLASS_CONFIG, Objects.requireNonNull(partitionClassName));
-    return this;
+  }
+
+  public Builder<Key, Value> compression(Compression compression) {
+    return config(ProducerConfig.COMPRESSION_TYPE_CONFIG, compression.nameOfKafka());
   }
 
   private static <Key, Value> CompletionStage<Metadata> doSend(

--- a/app/src/main/java/org/astraea/producer/Producer.java
+++ b/app/src/main/java/org/astraea/producer/Producer.java
@@ -21,7 +21,7 @@ public interface Producer<Key, Value> extends AutoCloseable {
     return builder().brokers(brokers).build();
   }
 
-  static Producer<byte[], byte[]> of(Map<String, Object> configs) {
+  static Producer<byte[], byte[]> of(Map<String, String> configs) {
     return builder().configs(configs).build();
   }
 }

--- a/app/src/main/java/org/astraea/topic/Builder.java
+++ b/app/src/main/java/org/astraea/topic/Builder.java
@@ -399,6 +399,12 @@ public class Builder {
     }
 
     @Override
+    public Creator config(String key, String value) {
+      this.configs.put(key, value);
+      return this;
+    }
+
+    @Override
     public Creator configs(Map<String, String> configs) {
       this.configs.putAll(configs);
       return this;

--- a/app/src/main/java/org/astraea/topic/Compression.java
+++ b/app/src/main/java/org/astraea/topic/Compression.java
@@ -1,0 +1,20 @@
+package org.astraea.topic;
+
+import java.util.Locale;
+
+public enum Compression {
+  NONE,
+  GZIP,
+  SNAPPY,
+  LZ4,
+  ZSTD;
+
+  public static Compression of(String name) {
+    return Compression.valueOf(name.toUpperCase(Locale.ROOT));
+  }
+
+  /** @return the name parsed by kafka */
+  public String nameOfKafka() {
+    return name().toLowerCase(Locale.ROOT);
+  }
+}

--- a/app/src/main/java/org/astraea/topic/Creator.java
+++ b/app/src/main/java/org/astraea/topic/Creator.java
@@ -17,7 +17,7 @@ public interface Creator {
    * @return this creator
    */
   default Creator compacted() {
-    return configs(Map.of(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT));
+    return config(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT);
   }
 
   /**
@@ -28,9 +28,14 @@ public interface Creator {
    */
   default Creator compactionMaxLag(Duration value) {
     return compacted()
-        .configs(
-            Map.of(TopicConfig.MAX_COMPACTION_LAG_MS_CONFIG, String.valueOf(value.toMillis())));
+        .config(TopicConfig.MAX_COMPACTION_LAG_MS_CONFIG, String.valueOf(value.toMillis()));
   }
+
+  default Creator compression(Compression compression) {
+    return config(TopicConfig.COMPRESSION_TYPE_CONFIG, compression.nameOfKafka());
+  }
+
+  Creator config(String key, String value);
 
   /**
    * @param configs used to create new topic

--- a/app/src/test/java/org/astraea/argument/CompressionFieldTest.java
+++ b/app/src/test/java/org/astraea/argument/CompressionFieldTest.java
@@ -3,7 +3,7 @@ package org.astraea.argument;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import java.util.stream.Stream;
-import org.apache.kafka.common.record.CompressionType;
+import org.astraea.topic.Compression;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -14,14 +14,14 @@ public class CompressionFieldTest {
         names = {"--field"},
         converter = CompressionField.class,
         validateWith = CompressionField.class)
-    public CompressionType value;
+    public Compression value;
   }
 
   @Test
   void testConversion() {
     var arg = new CompressionField();
-    Stream.of(CompressionType.values())
-        .forEach(type -> Assertions.assertEquals(type, arg.convert(type.name)));
+    Stream.of(Compression.values())
+        .forEach(type -> Assertions.assertEquals(type, arg.convert(type.name())));
     Assertions.assertThrows(ParameterException.class, () -> arg.convert("aaa"));
   }
 
@@ -29,6 +29,6 @@ public class CompressionFieldTest {
   void testParse() {
     var arg =
         org.astraea.argument.Argument.parse(new FakeParameter(), new String[] {"--field", "gzip"});
-    Assertions.assertEquals(CompressionType.GZIP, arg.value);
+    Assertions.assertEquals(Compression.GZIP, arg.value);
   }
 }

--- a/app/src/test/java/org/astraea/partitioner/smoothPartitioner/PartitionerTest.java
+++ b/app/src/test/java/org/astraea/partitioner/smoothPartitioner/PartitionerTest.java
@@ -100,7 +100,8 @@ public class PartitionerTest extends RequireBrokerCluster {
             .keySerializer(Serializer.STRING)
             .configs(
                 initProConfig().entrySet().stream()
-                    .collect(Collectors.toMap(e -> e.getKey().toString(), Map.Entry::getValue)))
+                    .collect(
+                        Collectors.toMap(e -> e.getKey().toString(), e -> e.getValue().toString())))
             .build()) {
       var i = 0;
       while (i < 300) {
@@ -166,7 +167,7 @@ public class PartitionerTest extends RequireBrokerCluster {
                                             .collect(
                                                 Collectors.toMap(
                                                     e -> e.getKey().toString(),
-                                                    Map.Entry::getValue)))
+                                                    e -> e.getValue().toString())))
                                     .build(),
                                 topicName,
                                 key,
@@ -265,7 +266,8 @@ public class PartitionerTest extends RequireBrokerCluster {
             .keySerializer(Serializer.STRING)
             .configs(
                 props.entrySet().stream()
-                    .collect(Collectors.toMap(e -> e.getKey().toString(), Map.Entry::getValue)))
+                    .collect(
+                        Collectors.toMap(e -> e.getKey().toString(), e -> e.getValue().toString())))
             .build()) {
       var metadata =
           producer

--- a/app/src/test/java/org/astraea/performance/PerformanceTest.java
+++ b/app/src/test/java/org/astraea/performance/PerformanceTest.java
@@ -12,6 +12,7 @@ import org.astraea.Utils;
 import org.astraea.concurrent.Executor;
 import org.astraea.concurrent.ThreadPool;
 import org.astraea.consumer.Consumer;
+import org.astraea.consumer.Isolation;
 import org.astraea.producer.Producer;
 import org.astraea.service.RequireBrokerCluster;
 import org.astraea.topic.TopicAdmin;
@@ -160,9 +161,9 @@ public class PerformanceTest extends RequireBrokerCluster {
   @Test
   void testTransactionSet() {
     var argument = new Performance.Argument();
-    Assertions.assertFalse(argument.transaction());
+    Assertions.assertEquals(Isolation.READ_UNCOMMITTED, argument.isolation());
     argument.transactionSize = 3;
-    Assertions.assertTrue(argument.transaction());
+    Assertions.assertEquals(Isolation.READ_COMMITTED, argument.isolation());
   }
 
   @Test
@@ -197,7 +198,7 @@ public class PerformanceTest extends RequireBrokerCluster {
     };
 
     var arg = org.astraea.argument.Argument.parse(new Performance.Argument(), arguments1);
-    Assertions.assertEquals("value", arg.producerProps().get("key").toString());
+    Assertions.assertEquals("value", arg.configs.get("key"));
 
     String[] arguments2 = {"--bootstrap.servers", "localhost:9092", "--topic", ""};
     Assertions.assertThrows(

--- a/app/src/test/java/org/astraea/producer/ProducerTest.java
+++ b/app/src/test/java/org/astraea/producer/ProducerTest.java
@@ -3,13 +3,12 @@ package org.astraea.producer;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.astraea.consumer.Consumer;
 import org.astraea.consumer.Deserializer;
 import org.astraea.consumer.Header;
+import org.astraea.consumer.Isolation;
 import org.astraea.service.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -81,14 +80,13 @@ public class ProducerTest extends RequireBrokerCluster {
       producer.transaction(senders);
     }
 
-    Map<String, Object> prop = Map.of(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
     try (var consumer =
         Consumer.builder()
             .brokers(bootstrapServers())
             .fromBeginning()
             .topics(Set.of(topicName))
             .keyDeserializer(Deserializer.STRING)
-            .configs(prop)
+            .isolation(Isolation.READ_COMMITTED)
             .build()) {
       var records = consumer.poll(Duration.ofSeconds(10));
       Assertions.assertEquals(3, records.size());

--- a/app/src/test/java/org/astraea/topic/CompressionTest.java
+++ b/app/src/test/java/org/astraea/topic/CompressionTest.java
@@ -1,0 +1,19 @@
+package org.astraea.topic;
+
+import java.util.Arrays;
+import org.apache.kafka.common.record.CompressionType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class CompressionTest {
+
+  @Test
+  void testNameOfKafka() {
+    Assertions.assertEquals(Compression.values().length, CompressionType.values().length);
+    Arrays.stream(Compression.values())
+        .forEach(
+            c ->
+                Assertions.assertEquals(
+                    c.nameOfKafka(), CompressionType.forName(c.nameOfKafka()).name));
+  }
+}


### PR DESCRIPTION
一些重構，包含：
1) 新增`Compression` and `Isolation` 來避免直接使用kafka參數
2) 重構一些較長的函示