### PR TITLE
Refactor ProducerExecutor

### DIFF
--- a/app/src/main/java/org/astraea/Utils.java
+++ b/app/src/main/java/org/astraea/Utils.java
@@ -141,5 +141,29 @@ public final class Utils {
     return (lastTime + Duration.ofSeconds(second).toMillis()) < System.currentTimeMillis();
   }
 
+  public static void sleep(Duration duration) {
+    try {
+      TimeUnit.MILLISECONDS.sleep(duration.toMillis());
+    } catch (InterruptedException ignored) {
+    }
+  }
+
+  public static String randomString(int len) {
+    StringBuilder string = new StringBuilder(randomString());
+    while (string.length() < len) {
+      string.append(string).append(randomString());
+    }
+    return string.substring(0, len);
+  }
+
+  /**
+   * a random string based on uuid without "-"
+   *
+   * @return random string
+   */
+  public static String randomString() {
+    return java.util.UUID.randomUUID().toString().replaceAll("-", "");
+  }
+
   private Utils() {}
 }

--- a/app/src/main/java/org/astraea/concurrent/ThreadPool.java
+++ b/app/src/main/java/org/astraea/concurrent/ThreadPool.java
@@ -14,6 +14,26 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public interface ThreadPool extends AutoCloseable {
 
+  // nothing to run.
+  ThreadPool EMPTY =
+      new ThreadPool() {
+        @Override
+        public void close() {}
+
+        @Override
+        public void waitAll() {}
+
+        @Override
+        public boolean isClosed() {
+          return true;
+        }
+
+        @Override
+        public int size() {
+          return 0;
+        }
+      };
+
   /** close all running threads. */
   @Override
   void close();
@@ -45,6 +65,7 @@ public interface ThreadPool extends AutoCloseable {
     }
 
     public ThreadPool build() {
+      if (executors.isEmpty()) return EMPTY;
       var closed = new AtomicBoolean(false);
       var latch = new CountDownLatch(executors.size());
       var service = Executors.newFixedThreadPool(executors.size());

--- a/app/src/main/java/org/astraea/concurrent/ThreadPool.java
+++ b/app/src/main/java/org/astraea/concurrent/ThreadPool.java
@@ -39,7 +39,7 @@ public interface ThreadPool extends AutoCloseable {
       return executors(List.of(executor));
     }
 
-    public Builder executors(Collection<Executor> executors) {
+    public Builder executors(Collection<? extends Executor> executors) {
       this.executors.addAll(Objects.requireNonNull(executors));
       return this;
     }

--- a/app/src/main/java/org/astraea/performance/DataSupplier.java
+++ b/app/src/main/java/org/astraea/performance/DataSupplier.java
@@ -1,0 +1,152 @@
+package org.astraea.performance;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+import org.astraea.utils.DataSize;
+import org.astraea.utils.DataUnit;
+
+@FunctionalInterface
+interface DataSupplier extends Supplier<DataSupplier.Data> {
+
+  static Data data(byte[] key, byte[] value) {
+    return new Data() {
+      @Override
+      public boolean done() {
+        return false;
+      }
+
+      @Override
+      public boolean throttled() {
+        return false;
+      }
+
+      @Override
+      public byte[] key() {
+        return key;
+      }
+
+      @Override
+      public byte[] value() {
+        return value;
+      }
+    };
+  }
+
+  Data NO_MORE_DATA =
+      new Data() {
+        @Override
+        public boolean done() {
+          return true;
+        }
+
+        @Override
+        public boolean throttled() {
+          return false;
+        }
+
+        @Override
+        public byte[] key() {
+          throw new IllegalStateException("there is no data");
+        }
+
+        @Override
+        public byte[] value() {
+          throw new IllegalStateException("there is no data");
+        }
+      };
+
+  Data THROTTLED_DATA =
+      new Data() {
+        @Override
+        public boolean done() {
+          return false;
+        }
+
+        @Override
+        public boolean throttled() {
+          return true;
+        }
+
+        @Override
+        public byte[] key() {
+          throw new IllegalStateException("it is throttled");
+        }
+
+        @Override
+        public byte[] value() {
+          throw new IllegalStateException("it is throttled");
+        }
+      };
+
+  interface Data {
+
+    /** @return true if there is no data. */
+    boolean done();
+
+    /** @return true if there are some data, but it is throttled now. */
+    boolean throttled();
+
+    /** @return true if there is accessible data */
+    default boolean hasData() {
+      return !done() && !throttled();
+    }
+
+    /** @return key or throw exception if there is no data, or it is throttled now */
+    byte[] key();
+
+    /** @return value or throw exception if there is no data, or it is throttled now */
+    byte[] value();
+  }
+
+  static DataSupplier of(
+      ExeTime exeTime,
+      Supplier<Long> keyDistribution,
+      DataSize valueSize,
+      Supplier<Long> valueDistribution,
+      DataSize throughput) {
+    return new DataSupplier() {
+      private final long start = System.currentTimeMillis();
+      private final Random rand = new Random();
+      private final byte[] content = new byte[valueSize.measurement(DataUnit.Byte).intValue()];
+      private final AtomicLong dataCount = new AtomicLong(0);
+      private long intervalStart = 0;
+      private long payloadBytes;
+
+      synchronized boolean checkAndAdd(int payloadLength) {
+        if (System.currentTimeMillis() - intervalStart > 1000) {
+          intervalStart = System.currentTimeMillis();
+          payloadBytes = payloadLength;
+          return true;
+        } else if (payloadBytes < throughput.measurement(DataUnit.Byte).longValue()) {
+          payloadBytes += payloadLength;
+          return true;
+        } else {
+          return false;
+        }
+      }
+
+      byte[] value() {
+        // Randomly change one position of the content;
+        content[rand.nextInt(content.length)] = (byte) rand.nextInt(256);
+        return Arrays.copyOfRange(
+            content, (int) (valueDistribution.get() % content.length), content.length);
+      }
+
+      public byte[] key() {
+        return (String.valueOf(keyDistribution.get())).getBytes();
+      }
+
+      @Override
+      public Data get() {
+        if (exeTime.percentage(dataCount.getAndIncrement(), System.currentTimeMillis() - start)
+            >= 100D) return NO_MORE_DATA;
+        var key = key();
+        var value = value();
+        if (checkAndAdd(value.length)) return data(key, value);
+        return THROTTLED_DATA;
+      }
+    };
+  }
+}

--- a/app/src/main/java/org/astraea/performance/Manager.java
+++ b/app/src/main/java/org/astraea/performance/Manager.java
@@ -1,15 +1,7 @@
 package org.astraea.performance;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
-import java.util.Random;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
-import org.astraea.Utils;
-import org.astraea.utils.DataSize;
 import org.astraea.utils.DataUnit;
 
 /**
@@ -19,17 +11,8 @@ import org.astraea.utils.DataUnit;
  */
 public class Manager {
   private final ExeTime exeTime;
-  private final CountDownLatch getAssignment;
-  private final AtomicInteger producerClosed;
-
   private final List<Metrics> producerMetrics, consumerMetrics;
-  private final long start = System.currentTimeMillis();
-  private final AtomicLong payloadNum = new AtomicLong(0);
   private final Supplier<Long> keyDistribution;
-  private final RandomContent randomContent;
-  private long intervalStart = System.currentTimeMillis();
-  private long payloadBytes = 0L;
-  private final DataSize throughput;
 
   /**
    * Used to manage producing/consuming.
@@ -51,49 +34,10 @@ public class Manager {
     if (argument.recordSize.greaterThan(DataUnit.Byte.of(Integer.MAX_VALUE)))
       throw new IllegalArgumentException(
           "Record size should be smaller than or equal to 2147483648 (Integer.MAX_VALUE) bytes");
-    this.getAssignment = new CountDownLatch(argument.consumers);
-    this.producerClosed = new AtomicInteger(argument.producers);
     this.producerMetrics = producerMetrics;
     this.consumerMetrics = consumerMetrics;
     this.exeTime = argument.exeTime;
-    this.throughput = argument.throughput;
     this.keyDistribution = argument.keyDistributionType.create(100000);
-    this.randomContent =
-        new RandomContent(
-            argument.recordSize,
-            argument.sizeDistributionType.create(
-                argument.recordSize.measurement(DataUnit.Byte).intValue()));
-  }
-
-  /**
-   * Generate random byte array in random/fixed length. Warning: This method will block when the
-   * throughput (content generating rate) is higher than the given number (argument.throughput).
-   *
-   * @return random byte array. When no payload should be generated, Optional.empty() is generated.
-   *     Whether the payload should be generated is determined in construct time. "Number of
-   *     records" and "execution time" are considered.
-   */
-  public Optional<byte[]> payload() {
-    if (exeTime.percentage(payloadNum.getAndIncrement(), System.currentTimeMillis() - start)
-        >= 100D) return Optional.empty();
-
-    var payload = randomContent.getContent();
-
-    Utils.waitFor(() -> checkAndAdd(payload.length));
-    return Optional.of(payload);
-  }
-
-  synchronized boolean checkAndAdd(int payloadLength) {
-    if (System.currentTimeMillis() - intervalStart > 1000) {
-      intervalStart = System.currentTimeMillis();
-      payloadBytes = payloadLength;
-      return true;
-    } else if (payloadBytes < throughput.measurement(DataUnit.Byte).longValue()) {
-      payloadBytes += payloadLength;
-      return true;
-    } else {
-      return false;
-    }
   }
 
   public long producedRecords() {
@@ -104,64 +48,17 @@ public class Manager {
     return consumerMetrics.stream().mapToLong(Metrics::num).sum();
   }
 
-  /** Used in "consumerRebalanceListener" callback. To */
-  public void countDownGetAssignment() {
-    this.getAssignment.countDown();
-  }
-
-  /** Called after producer is closed. For informing consumers there will be no new records */
-  public void producerClosed() {
-    this.producerClosed.decrementAndGet();
-  }
-
-  public void awaitPartitionAssignment() throws InterruptedException {
-    getAssignment.await();
-  }
-
   public ExeTime exeTime() {
     return exeTime;
   }
 
-  /** Check if all producer are closed. */
-  public boolean producedDone() {
-    return producerClosed.get() == 0;
-  }
-
   /** Check if we should keep consuming record. */
   public boolean consumedDone() {
-    return producedDone()
-        && (consumerMetrics.size() == 0 || consumedRecords() >= producedRecords());
+    return consumerMetrics.size() == 0 || consumedRecords() >= producedRecords();
   }
 
   /** Randomly choose a key according to the distribution. */
   public byte[] getKey() {
     return (String.valueOf(keyDistribution.get())).getBytes();
-  }
-
-  /** Randomly generate content before {@link #getContent()} is called. */
-  private static class RandomContent {
-    private final Random rand = new Random();
-    private final DataSize dataSize;
-    private final Supplier<Long> distribution;
-    private final byte[] content;
-
-    /**
-     * @param dataSize The size of each random generated content in bytes.
-     * @param distribution Determine whether to fix the size of random generated content or random
-     *     size with specified distribution
-     */
-    public RandomContent(DataSize dataSize, Supplier<Long> distribution) {
-      this.dataSize = dataSize;
-      this.distribution = distribution;
-      content = new byte[dataSize.measurement(DataUnit.Byte).intValue()];
-    }
-
-    public byte[] getContent() {
-      // Randomly change one position of the content;
-      content[rand.nextInt(dataSize.measurement(DataUnit.Byte).intValue())] =
-          (byte) rand.nextInt(256);
-      return Arrays.copyOfRange(
-          content, (int) (distribution.get() % content.length), content.length);
-    }
   }
 }

--- a/app/src/main/java/org/astraea/performance/Performance.java
+++ b/app/src/main/java/org/astraea/performance/Performance.java
@@ -8,11 +8,11 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
@@ -32,7 +32,6 @@ import org.astraea.concurrent.ThreadPool;
 import org.astraea.consumer.Consumer;
 import org.astraea.consumer.Isolation;
 import org.astraea.producer.Producer;
-import org.astraea.producer.TransactionalProducer;
 import org.astraea.topic.Compression;
 import org.astraea.topic.TopicAdmin;
 import org.astraea.utils.DataSize;
@@ -71,6 +70,16 @@ public class Performance {
     execute(org.astraea.argument.Argument.parse(new Argument(), args));
   }
 
+  private static DataSupplier dataSupplier(Performance.Argument argument) {
+    return DataSupplier.of(
+        argument.exeTime,
+        argument.keyDistributionType.create(10000),
+        argument.recordSize,
+        argument.sizeDistributionType.create(
+            argument.recordSize.measurement(DataUnit.Byte).intValue()),
+        argument.throughput);
+  }
+
   public static Result execute(final Argument param)
       throws InterruptedException, IOException, ExecutionException {
     List<Integer> partitions;
@@ -96,14 +105,53 @@ public class Performance {
             .collect(Collectors.toUnmodifiableList());
 
     var manager = new Manager(param, producerMetrics, consumerMetrics);
-    var tracker = new Tracker(producerMetrics, consumerMetrics, manager);
+    var groupId = "groupId-" + System.currentTimeMillis();
+    var consumerBalancerLatch = new CountDownLatch(param.consumers);
+    var dataSupplier = dataSupplier(param);
+    Supplier<Integer> partitionSupplier =
+        () -> partitions.isEmpty() ? -1 : partitions.get((int) (Math.random() * partitions.size()));
+
+    var producerExecutors =
+        IntStream.range(0, param.producers)
+            .mapToObj(
+                index ->
+                    param.transactionSize > 0
+                        ? ProducerExecutor.of(
+                            param.topic,
+                            param.transactionSize,
+                            Producer.builder()
+                                .configs(param.configs)
+                                .compression(param.compression)
+                                .partitionClassName(param.partitioner)
+                                .buildTransactional(),
+                            producerMetrics.get(index),
+                            partitionSupplier,
+                            dataSupplier)
+                        : ProducerExecutor.of(
+                            param.topic,
+                            Producer.builder()
+                                .configs(param.configs)
+                                .compression(param.compression)
+                                .partitionClassName(param.partitioner)
+                                .build(),
+                            producerMetrics.get(index),
+                            partitionSupplier,
+                            dataSupplier))
+            .collect(Collectors.toUnmodifiableList());
+
+    Supplier<Boolean> producerDone =
+        () -> producerExecutors.stream().allMatch(ProducerExecutor::closed);
+
+    var tracker = new Tracker(producerMetrics, consumerMetrics, manager, producerDone);
+
     Collection<Executor> fileWriter =
         (param.CSVPath != null)
             ? List.of(
-                ReportFormat.createFileWriter(param.reportFormat, param.CSVPath, manager, tracker))
+                ReportFormat.createFileWriter(
+                    param.reportFormat, param.CSVPath, manager, producerDone, tracker))
             : List.of();
-    var groupId = "groupId-" + System.currentTimeMillis();
-    try (var threadPool =
+
+    try (var consumersPool =
         ThreadPool.builder()
             .executors(
                 IntStream.range(0, param.consumers)
@@ -117,41 +165,34 @@ public class Performance {
                                     .configs(param.configs)
                                     .isolation(param.isolation())
                                     .consumerRebalanceListener(
-                                        ignore -> manager.countDownGetAssignment())
+                                        ignore -> consumerBalancerLatch.countDown())
                                     .build(),
                                 consumerMetrics.get(i),
-                                manager))
+                                manager,
+                                producerDone))
                     .collect(Collectors.toUnmodifiableList()))
-            .executors(
-                IntStream.range(0, param.producers)
-                    .mapToObj(
-                        i ->
-                            producerExecutor(
-                                Producer.builder()
-                                    .configs(param.configs)
-                                    .compression(param.compression)
-                                    .partitionClassName(param.partitioner)
-                                    .build(),
-                                Producer.builder()
-                                    .configs(param.configs)
-                                    .compression(param.compression)
-                                    .partitionClassName(param.partitioner)
-                                    .buildTransactional(),
-                                param,
-                                producerMetrics.get(i),
-                                partitions,
-                                manager))
-                    .collect(Collectors.toUnmodifiableList()))
-            .executor(tracker)
-            .executors(fileWriter)
             .build()) {
-      threadPool.waitAll();
-      return new Result(param.topic);
+      // make sure all consumers get their partition assignment
+      consumerBalancerLatch.await();
+
+      try (var threadPool =
+          ThreadPool.builder()
+              .executors(producerExecutors)
+              .executor(tracker)
+              .executors(fileWriter)
+              .build()) {
+        threadPool.waitAll();
+        consumersPool.waitAll();
+        return new Result(param.topic);
+      }
     }
   }
 
   static Executor consumerExecutor(
-      Consumer<byte[], byte[]> consumer, BiConsumer<Long, Long> observer, Manager manager) {
+      Consumer<byte[], byte[]> consumer,
+      BiConsumer<Long, Long> observer,
+      Manager manager,
+      Supplier<Boolean> producerDone) {
     return new Executor() {
       @Override
       public State execute() {
@@ -167,7 +208,7 @@ public class Performance {
                         (long) record.serializedKeySize() + record.serializedValueSize());
                   });
           // Consumer reached the record upperbound or consumed all the record producer produced.
-          return manager.consumedDone() ? State.DONE : State.RUNNING;
+          return producerDone.get() && manager.consumedDone() ? State.DONE : State.RUNNING;
         } catch (WakeupException ignore) {
           // Stop polling and being ready to clean up
           return State.DONE;
@@ -182,92 +223,6 @@ public class Performance {
       @Override
       public void close() {
         consumer.close();
-      }
-    };
-  }
-
-  static Executor producerExecutor(
-      Producer<byte[], byte[]> producer,
-      TransactionalProducer<byte[], byte[]> transactionalProducer,
-      Argument param,
-      BiConsumer<Long, Long> observer,
-      List<Integer> partitions,
-      Manager manager) {
-    return new Executor() {
-
-      private State doTransaction() {
-        var rand = new Random();
-        var senders =
-            IntStream.range(0, param.transactionSize)
-                .mapToObj(i -> manager.payload())
-                .filter(Optional::isPresent)
-                .map(
-                    p ->
-                        producer
-                            .sender()
-                            .topic(param.topic)
-                            .partition(partitions.get(rand.nextInt(partitions.size())))
-                            .key(manager.getKey())
-                            .value(p.get())
-                            .timestamp(System.currentTimeMillis()))
-                .collect(Collectors.toList());
-
-        // No records to send
-        if (senders.isEmpty()) return State.DONE;
-        transactionalProducer
-            .transaction(senders)
-            .forEach(
-                future ->
-                    future.whenComplete(
-                        (m, e) ->
-                            observer.accept(
-                                System.currentTimeMillis() - m.timestamp(),
-                                m.serializedValueSize())));
-        return State.RUNNING;
-      }
-
-      private State doSend() {
-        var rand = new Random();
-        var payload = manager.payload();
-        if (payload.isEmpty()) return State.DONE;
-
-        long start = System.currentTimeMillis();
-        producer
-            .sender()
-            .topic(param.topic)
-            .partition(partitions.get(rand.nextInt(partitions.size())))
-            .key(manager.getKey())
-            .value(payload.get())
-            .timestamp(start)
-            .run()
-            .whenComplete(
-                (m, e) ->
-                    observer.accept(System.currentTimeMillis() - start, m.serializedValueSize()));
-        return State.RUNNING;
-      }
-
-      @Override
-      public State execute() throws InterruptedException {
-        // Wait for all consumers get assignment.
-        manager.awaitPartitionAssignment();
-        // Do transactional send.
-        switch (param.isolation()) {
-          case READ_COMMITTED:
-            return doTransaction();
-          case READ_UNCOMMITTED:
-            return doSend();
-          default:
-            return State.RUNNING;
-        }
-      }
-
-      @Override
-      public void close() {
-        try {
-          producer.close();
-        } finally {
-          manager.producerClosed();
-        }
       }
     };
   }

--- a/app/src/main/java/org/astraea/performance/ProducerExecutor.java
+++ b/app/src/main/java/org/astraea/performance/ProducerExecutor.java
@@ -168,10 +168,6 @@ abstract class ProducerExecutor implements Executor {
     return closed.get();
   }
 
-  void flush() {
-    producer.flush();
-  }
-
   @Override
   public void close() {
     try {

--- a/app/src/main/java/org/astraea/performance/ProducerExecutor.java
+++ b/app/src/main/java/org/astraea/performance/ProducerExecutor.java
@@ -1,0 +1,183 @@
+package org.astraea.performance;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.astraea.Utils;
+import org.astraea.concurrent.Executor;
+import org.astraea.concurrent.State;
+import org.astraea.producer.Producer;
+import org.astraea.producer.Sender;
+import org.astraea.producer.TransactionalProducer;
+
+abstract class ProducerExecutor implements Executor {
+
+  static ProducerExecutor of(
+      String topic,
+      int transactionSize,
+      TransactionalProducer<byte[], byte[]> producer,
+      BiConsumer<Long, Long> observer,
+      Supplier<Integer> partitionSupplier,
+      DataSupplier dataSupplier) {
+    return new ProducerExecutor(topic, producer, partitionSupplier, observer, dataSupplier) {
+
+      @Override
+      public State execute() {
+        var data =
+            IntStream.range(0, transactionSize)
+                .mapToObj(i -> dataSupplier.get())
+                .collect(Collectors.toUnmodifiableList());
+
+        // no more data
+        if (data.stream().allMatch(DataSupplier.Data::done)) return State.DONE;
+
+        // no data due to throttle
+        // TODO: we should return a precise sleep time
+        if (data.stream().allMatch(DataSupplier.Data::throttled)) {
+          Utils.sleep(Duration.ofSeconds(1));
+          return State.RUNNING;
+        }
+        return doSend(
+            senders(
+                data.stream()
+                    .filter(DataSupplier.Data::hasData)
+                    .collect(Collectors.toUnmodifiableList())));
+      }
+
+      List<Sender<byte[], byte[]>> senders(List<DataSupplier.Data> data) {
+        return data.stream()
+            .map(
+                d ->
+                    producer
+                        .sender()
+                        .topic(topic)
+                        .partition(partitionSupplier.get())
+                        .key(d.key())
+                        .value(d.value())
+                        .timestamp(System.currentTimeMillis()))
+            .collect(Collectors.toList());
+      }
+
+      State doSend(List<Sender<byte[], byte[]>> senders) {
+        producer
+            .transaction(senders)
+            .forEach(
+                future ->
+                    future.whenComplete(
+                        (m, e) ->
+                            observer.accept(
+                                System.currentTimeMillis() - m.timestamp(),
+                                m.serializedValueSize())));
+        return State.RUNNING;
+      }
+    };
+  }
+
+  static ProducerExecutor of(
+      String topic,
+      Producer<byte[], byte[]> producer,
+      BiConsumer<Long, Long> observer,
+      Supplier<Integer> partitionSupplier,
+      DataSupplier dataSupplier) {
+    return new ProducerExecutor(topic, producer, partitionSupplier, observer, dataSupplier) {
+
+      @Override
+      public State execute() {
+        var data = dataSupplier.get();
+        if (data.done()) return State.DONE;
+
+        // no data due to throttle
+        // TODO: we should return a precise sleep time
+        if (data.throttled()) {
+          Utils.sleep(Duration.ofSeconds(1));
+          return State.RUNNING;
+        }
+        return doSend(data.key(), data.value());
+      }
+
+      Sender<byte[], byte[]> sender(byte[] key, byte[] value) {
+        return producer
+            .sender()
+            .topic(topic)
+            .partition(partitionSupplier.get())
+            .key(key)
+            .value(value)
+            .timestamp(System.currentTimeMillis());
+      }
+
+      State doSend(byte[] key, byte[] value) {
+        sender(key, value)
+            .run()
+            .whenComplete(
+                (m, e) ->
+                    observer.accept(
+                        System.currentTimeMillis() - m.timestamp(), m.serializedValueSize()));
+        return State.RUNNING;
+      }
+    };
+  }
+
+  private final String topic;
+  private final Producer<byte[], byte[]> producer;
+  private final Supplier<Integer> partitionSupplier;
+  private final BiConsumer<Long, Long> observer;
+  private final DataSupplier dataSupplier;
+
+  ProducerExecutor(
+      String topic,
+      Producer<byte[], byte[]> producer,
+      Supplier<Integer> partitionSupplier,
+      BiConsumer<Long, Long> observer,
+      DataSupplier dataSupplier) {
+    this.topic = topic;
+    this.producer = producer;
+    this.partitionSupplier = partitionSupplier;
+    this.observer = observer;
+    this.dataSupplier = dataSupplier;
+  }
+
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+
+  String topic() {
+    return topic;
+  }
+
+  Supplier<Integer> partitionSupplier() {
+    return partitionSupplier;
+  }
+
+  BiConsumer<Long, Long> observer() {
+    return observer;
+  }
+
+  DataSupplier dataSupplier() {
+    return dataSupplier;
+  }
+
+  /** @return true if the producer in this executor is transactional. */
+  boolean transactional() {
+    return producer instanceof TransactionalProducer;
+  }
+
+  /** @return true if this executor is closed. otherwise, false */
+  public boolean closed() {
+    return closed.get();
+  }
+
+  void flush() {
+    producer.flush();
+  }
+
+  @Override
+  public void close() {
+    try {
+      producer.close();
+    } finally {
+      closed.set(true);
+    }
+  }
+}

--- a/app/src/main/java/org/astraea/producer/Sender.java
+++ b/app/src/main/java/org/astraea/producer/Sender.java
@@ -14,7 +14,7 @@ public interface Sender<Key, Value> {
   /**
    * define the data route if you don't want to partitioner to decide the target.
    *
-   * @param partition target partition
+   * @param partition target partition. negative value is ignored
    * @return this sender
    */
   Sender<Key, Value> partition(int partition);

--- a/app/src/test/java/org/astraea/concurrent/ThreadPoolTest.java
+++ b/app/src/test/java/org/astraea/concurrent/ThreadPoolTest.java
@@ -63,4 +63,13 @@ public class ThreadPoolTest {
     pool.close();
     Assertions.assertTrue(pool.isClosed());
   }
+
+  @Test
+  void testEmpty() {
+    try (var empty = ThreadPool.builder().build()) {
+      Assertions.assertEquals(ThreadPool.EMPTY, empty);
+      Assertions.assertEquals(0, empty.size());
+      Assertions.assertTrue(empty.isClosed());
+    }
+  }
 }

--- a/app/src/test/java/org/astraea/performance/DataSupplierTest.java
+++ b/app/src/test/java/org/astraea/performance/DataSupplierTest.java
@@ -1,0 +1,100 @@
+package org.astraea.performance;
+
+import java.util.concurrent.TimeUnit;
+import org.astraea.utils.DataUnit;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DataSupplierTest {
+
+  @Test
+  void testDuration() throws InterruptedException {
+    var dataSupplier =
+        DataSupplier.of(
+            ExeTime.of("2s"),
+            DistributionType.FIXED.create(10),
+            DataUnit.KiB.of(100),
+            DistributionType.FIXED.create(10),
+            DataUnit.KiB.of(100));
+    Assertions.assertTrue(dataSupplier.get().hasData());
+    TimeUnit.SECONDS.sleep(3);
+    Assertions.assertFalse(dataSupplier.get().hasData());
+  }
+
+  @Test
+  void testRecordLimit() {
+    var dataSupplier =
+        DataSupplier.of(
+            ExeTime.of("2records"),
+            DistributionType.FIXED.create(10),
+            DataUnit.KiB.of(100),
+            DistributionType.FIXED.create(10),
+            DataUnit.KiB.of(100));
+    Assertions.assertTrue(dataSupplier.get().hasData());
+    Assertions.assertTrue(dataSupplier.get().hasData());
+    Assertions.assertFalse(dataSupplier.get().hasData());
+  }
+
+  @Test
+  void testKeySize() {
+    var dataSupplier =
+        DataSupplier.of(
+            ExeTime.of("10s"),
+            DistributionType.FIXED.create(9),
+            DataUnit.KiB.of(100),
+            DistributionType.FIXED.create(10),
+            DataUnit.KiB.of(100));
+    var data = dataSupplier.get();
+    Assertions.assertTrue(data.hasData());
+    // key content is fixed to "9", so the size is 1 byte
+    Assertions.assertEquals(1, data.key().length);
+  }
+
+  @Test
+  void testFixedValueSize() {
+    var dataSupplier =
+        DataSupplier.of(
+            ExeTime.of("10s"),
+            DistributionType.FIXED.create(10),
+            DataUnit.KiB.of(100),
+            DistributionType.FIXED.create(0),
+            DataUnit.KiB.of(100));
+    var data = dataSupplier.get();
+    Assertions.assertTrue(data.hasData());
+    // initial value size is 100KB and the distributed is fixed to zero, so the final size is 102400
+    Assertions.assertEquals(102400, data.value().length);
+  }
+
+  @Test
+  void testDistributedValueSize() {
+    var dataSupplier =
+        DataSupplier.of(
+            ExeTime.of("10s"),
+            DistributionType.FIXED.create(10),
+            DataUnit.KiB.of(100),
+            DistributionType.FIXED.create(10),
+            DataUnit.KiB.of(100));
+    var data = dataSupplier.get();
+    Assertions.assertTrue(data.hasData());
+    // initial value size is 100KB and the distributed is fixed to 10, so the final size is between
+    // (102400 - 10, 102400 + 10)
+    Assertions.assertTrue(data.value().length >= 102400 - 10 && data.value().length <= 102400 + 10);
+  }
+
+  @Test
+  void testThrottle() {
+    var dataSupplier =
+        DataSupplier.of(
+            ExeTime.of("10s"),
+            DistributionType.FIXED.create(10),
+            DataUnit.KiB.of(100),
+            DistributionType.FIXED.create(0),
+            DataUnit.KiB.of(150));
+    // total: 100KB, limit: 150KB -> no throttle
+    Assertions.assertTrue(dataSupplier.get().hasData());
+    // total: 200KB, limit: 150KB -> will throttle next data
+    Assertions.assertTrue(dataSupplier.get().hasData());
+    // throttled
+    Assertions.assertFalse(dataSupplier.get().hasData());
+  }
+}

--- a/app/src/test/java/org/astraea/performance/ManagerTest.java
+++ b/app/src/test/java/org/astraea/performance/ManagerTest.java
@@ -1,58 +1,10 @@
 package org.astraea.performance;
 
-import java.util.Arrays;
 import java.util.List;
-import org.astraea.utils.DataUnit;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ManagerTest {
-  @Test
-  void testReturnNull() throws InterruptedException {
-    var argument = new Performance.Argument();
-    var producerMetric = new Metrics();
-    argument.exeTime = ExeTime.of("1records");
-    var manager = new Manager(argument, List.of(producerMetric), List.of());
-
-    Assertions.assertTrue(manager.payload().isPresent());
-    producerMetric.accept(1L, 1L);
-    Assertions.assertTrue(manager.payload().isEmpty());
-
-    producerMetric = new Metrics();
-    argument.exeTime = ExeTime.of("50ms");
-    manager = new Manager(argument, List.of(producerMetric), List.of());
-
-    Assertions.assertTrue(manager.payload().isPresent());
-    producerMetric.accept(1L, 1L);
-    Thread.sleep(50);
-    Assertions.assertTrue(manager.payload().isEmpty());
-  }
-
-  @Test
-  void testRandomSize() {
-    var argument = new Performance.Argument();
-    argument.exeTime = ExeTime.of("3records");
-    argument.recordSize = DataUnit.KiB.of(100);
-    var dataManager = new Manager(argument, List.of(), List.of());
-    boolean sameSize = dataManager.payload().get().length == dataManager.payload().get().length;
-
-    // Assertion failed with probability 1/102400 ~ 0.001%
-    Assertions.assertFalse(sameSize);
-
-    Assertions.assertTrue(dataManager.payload().get().length <= 102400);
-  }
-
-  @Test
-  void testRandomContent() {
-    var argument = new Performance.Argument();
-    argument.exeTime = ExeTime.of("2records");
-    argument.recordSize = DataUnit.KiB.of(100);
-    var manager = new Manager(argument, List.of(), List.of());
-    boolean same = Arrays.equals(manager.payload().get(), manager.payload().get());
-
-    // Assertion failed with probability < 1/102400
-    Assertions.assertFalse(same);
-  }
 
   @Test
   void testGetKey() {
@@ -78,69 +30,22 @@ public class ManagerTest {
   @Test
   void testConsumerDone() {
     var argument = new Performance.Argument();
-    var producerMetrics = List.of(new Metrics());
-    var consumerMetrics = List.of(new Metrics());
+    var producerMetrics = new Metrics();
+    var consumerMetrics = new Metrics();
 
     argument.exeTime = ExeTime.of("1records");
-    var manager = new Manager(argument, producerMetrics, consumerMetrics);
-    Assertions.assertFalse(manager.consumedDone());
+    var manager = new Manager(argument, List.of(producerMetrics), List.of(consumerMetrics));
 
     // Produce one record
-    producerMetrics.get(0).accept(0L, 0L);
+    producerMetrics.accept(0L, 0L);
     Assertions.assertFalse(manager.consumedDone());
 
     // Consume one record
-    consumerMetrics.get(0).accept(0L, 0L);
-    Assertions.assertFalse(manager.consumedDone());
-
-    manager.producerClosed();
+    consumerMetrics.accept(0L, 0L);
     Assertions.assertTrue(manager.consumedDone());
 
     // Test zero consumer. (run for one record)
-    producerMetrics = List.of(new Metrics());
-    consumerMetrics = List.of();
-    manager = new Manager(argument, producerMetrics, consumerMetrics);
-    Assertions.assertFalse(manager.consumedDone());
-
-    // Produce one record
-    producerMetrics.get(0).accept(0L, 0L);
-    Assertions.assertFalse(manager.consumedDone());
-
-    manager.producerClosed();
+    manager = new Manager(argument, List.of(producerMetrics), List.of());
     Assertions.assertTrue(manager.consumedDone());
-  }
-
-  @Test
-  void testProducerDone() {
-    var argument = new Performance.Argument();
-    argument.exeTime = ExeTime.of("1records");
-    var producerMetrics = List.of(new Metrics());
-    var consumerMetrics = List.of(new Metrics());
-    var manager = new Manager(new Performance.Argument(), producerMetrics, consumerMetrics);
-
-    Assertions.assertFalse(manager.producedDone());
-
-    producerMetrics.get(0).accept(0L, 0L);
-    Assertions.assertFalse(manager.producedDone());
-
-    manager.producerClosed();
-    Assertions.assertTrue(manager.producedDone());
-  }
-
-  @Test
-  void testCheckAndAdd() throws InterruptedException {
-    var argument = new Performance.Argument();
-    argument.throughput = DataUnit.KiB.of(3);
-    var recordSize = DataUnit.KiB.of(1).measurement(DataUnit.Byte).intValue();
-    var manager = new Manager(argument, List.of(), List.of());
-
-    Assertions.assertTrue(manager.checkAndAdd(recordSize));
-    Assertions.assertTrue(manager.checkAndAdd(recordSize));
-    Assertions.assertTrue(manager.checkAndAdd(recordSize));
-    Assertions.assertFalse(manager.checkAndAdd(recordSize));
-
-    Thread.sleep(1001);
-
-    Assertions.assertTrue(manager.checkAndAdd(recordSize));
   }
 }

--- a/app/src/test/java/org/astraea/performance/PerformanceTest.java
+++ b/app/src/test/java/org/astraea/performance/PerformanceTest.java
@@ -1,136 +1,18 @@
 package org.astraea.performance;
 
-import static org.astraea.performance.Performance.partition;
-
 import com.beust.jcommander.ParameterException;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import org.apache.kafka.common.TopicPartition;
-import org.astraea.Utils;
 import org.astraea.concurrent.Executor;
-import org.astraea.concurrent.ThreadPool;
 import org.astraea.consumer.Consumer;
 import org.astraea.consumer.Isolation;
 import org.astraea.producer.Producer;
 import org.astraea.service.RequireBrokerCluster;
-import org.astraea.topic.TopicAdmin;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class PerformanceTest extends RequireBrokerCluster {
-
-  @Test
-  void testSpecifyBrokerProducerExecutor() {
-    var admin = TopicAdmin.of(bootstrapServers());
-    var topicName = "testConsumerExecutor-" + System.currentTimeMillis();
-    admin.creator().topic(topicName).numberOfPartitions(10).create();
-    Utils.waitFor(() -> admin.publicTopicNames().contains(topicName));
-
-    var metrics = new Metrics();
-    var param = new Performance.Argument();
-    param.brokers = bootstrapServers();
-    param.topic = topicName;
-    param.sizeDistributionType = DistributionType.FIXED;
-    param.exeTime = ExeTime.of("100records");
-    param.specifyBroker = List.of(0);
-    param.consumers = 0;
-    param.partitions = 10;
-    try (var executor =
-        Performance.producerExecutor(
-            Producer.builder().brokers(bootstrapServers()).build(),
-            Producer.builder().brokers(bootstrapServers()).buildTransactional(),
-            param,
-            metrics,
-            partition(param, admin),
-            new Manager(param, List.of(), List.of()))) {
-      ThreadPool threadPool = ThreadPool.builder().executor(executor).build();
-      threadPool.waitAll();
-      threadPool.close();
-
-      Utils.waitFor(() -> metrics.num() == 100);
-      var offsets = admin.offsets(Set.of(topicName));
-      var partitions =
-          offsets.entrySet().stream()
-              .filter(entry -> entry.getValue().latest() > 0)
-              .map(entry -> entry.getKey().partition())
-              .collect(Collectors.toList());
-      var partitionsOfBrokers =
-          admin.partitionsOfBrokers(Set.of(topicName), Set.of(0)).stream()
-              .map(TopicPartition::partition)
-              .collect(Collectors.toSet());
-      partitions.forEach(
-          partition -> Assertions.assertTrue(partitionsOfBrokers.contains(partition)));
-    }
-  }
-
-  @Test
-  void testMultipleSpecifyBrokersProducerExecutor() {
-    var admin = TopicAdmin.of(bootstrapServers());
-    var topicName = "testConsumerExecutor-" + System.currentTimeMillis();
-    admin.creator().topic(topicName).numberOfPartitions(10).create();
-    Utils.waitFor(() -> admin.publicTopicNames().contains(topicName));
-
-    var metrics = new Metrics();
-    var param = new Performance.Argument();
-    param.brokers = bootstrapServers();
-    param.topic = topicName;
-    param.sizeDistributionType = DistributionType.FIXED;
-    param.exeTime = ExeTime.of("100records");
-    param.specifyBroker = List.of(0, 1);
-    param.consumers = 0;
-    param.partitions = 10;
-    try (Executor executor =
-        Performance.producerExecutor(
-            Producer.builder().brokers(bootstrapServers()).build(),
-            Producer.builder().brokers(bootstrapServers()).buildTransactional(),
-            param,
-            metrics,
-            partition(param, admin),
-            new Manager(param, List.of(), List.of()))) {
-      ThreadPool threadPool = ThreadPool.builder().executor(executor).build();
-      threadPool.waitAll();
-      threadPool.close();
-
-      Utils.waitFor(() -> metrics.num() == 100);
-      var offsets = admin.offsets(Set.of(topicName));
-      var partitions =
-          offsets.entrySet().stream()
-              .filter(entry -> entry.getValue().latest() > 0)
-              .map(entry -> entry.getKey().partition())
-              .collect(Collectors.toList());
-      var partitionsOfBrokers =
-          admin.partitionsOfBrokers(Set.of(topicName), Set.of(0, 1)).stream()
-              .map(TopicPartition::partition)
-              .collect(Collectors.toSet());
-      partitions.forEach(
-          partition -> Assertions.assertTrue(partitionsOfBrokers.contains(partition)));
-    }
-  }
-
-  @Test
-  void testProducerExecutor() throws InterruptedException {
-    var metrics = new Metrics();
-    var param = new Performance.Argument();
-    param.brokers = bootstrapServers();
-    param.topic = "testProducerExecutor-" + System.currentTimeMillis();
-    param.sizeDistributionType = DistributionType.FIXED;
-    param.consumers = 0;
-    try (Executor executor =
-        Performance.producerExecutor(
-            Producer.builder().brokers(bootstrapServers()).build(),
-            Producer.builder().brokers(bootstrapServers()).buildTransactional(),
-            param,
-            metrics,
-            List.of(-1),
-            new Manager(param, List.of(), List.of()))) {
-      executor.execute();
-
-      Utils.waitFor(() -> metrics.num() == 1);
-      Assertions.assertEquals(1024, metrics.bytes());
-    }
-  }
 
   @Test
   void testConsumerExecutor() throws InterruptedException, ExecutionException {
@@ -142,7 +24,8 @@ public class PerformanceTest extends RequireBrokerCluster {
         Performance.consumerExecutor(
             Consumer.builder().topics(Set.of(topicName)).brokers(bootstrapServers()).build(),
             metrics,
-            new Manager(param, List.of(), List.of()))) {
+            new Manager(param, List.of(), List.of()),
+            () -> false)) {
       executor.execute();
 
       Assertions.assertEquals(0, metrics.num());

--- a/app/src/test/java/org/astraea/performance/ProducerExecutorTest.java
+++ b/app/src/test/java/org/astraea/performance/ProducerExecutorTest.java
@@ -67,9 +67,10 @@ public class ProducerExecutorTest extends RequireBrokerCluster {
       TimeUnit.SECONDS.sleep(2);
       // only specified partition gets value
       // for normal producer, there is only one record
-      // for transactional producer, the size of transaction is 10
+      // for transactional producer, the size of transaction is 10 and there is one transaction
+      // control marker
       Assertions.assertEquals(
-          executor.transactional() ? 10 : 1,
+          executor.transactional() ? 11 : 1,
           admin
               .offsets(Set.of(executor.topic()))
               .get(new TopicPartition(executor.topic(), specifiedPartition))

--- a/app/src/test/java/org/astraea/performance/ProducerExecutorTest.java
+++ b/app/src/test/java/org/astraea/performance/ProducerExecutorTest.java
@@ -1,0 +1,158 @@
+package org.astraea.performance;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.apache.kafka.common.TopicPartition;
+import org.astraea.Utils;
+import org.astraea.concurrent.State;
+import org.astraea.producer.Producer;
+import org.astraea.service.RequireBrokerCluster;
+import org.astraea.topic.TopicAdmin;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class ProducerExecutorTest extends RequireBrokerCluster {
+
+  private static ProducerExecutor ofProducer(
+      String topic,
+      Supplier<Integer> partitionSupplier,
+      BiConsumer<Long, Long> observer,
+      DataSupplier dataSupplier) {
+    return ProducerExecutor.of(
+        topic,
+        Producer.builder().brokers(bootstrapServers()).build(),
+        observer,
+        partitionSupplier,
+        dataSupplier);
+  }
+
+  private static ProducerExecutor ofTransactionalProducer(
+      String topic,
+      Supplier<Integer> partitionSupplier,
+      BiConsumer<Long, Long> observer,
+      DataSupplier dataSupplier) {
+    return ProducerExecutor.of(
+        topic,
+        10,
+        Producer.builder().brokers(bootstrapServers()).buildTransactional(),
+        observer,
+        partitionSupplier,
+        dataSupplier);
+  }
+
+  @ParameterizedTest
+  @MethodSource("offsetProducerExecutors")
+  void testSpecifiedPartition(ProducerExecutor executor) throws InterruptedException {
+    var specifiedPartition = 1;
+    ((MyPartitionSupplier) executor.partitionSupplier()).partition = specifiedPartition;
+    try (var admin = TopicAdmin.of(bootstrapServers())) {
+      admin.creator().topic(executor.topic()).numberOfPartitions(specifiedPartition + 1).create();
+      // wait for topic creation
+      TimeUnit.SECONDS.sleep(2);
+      admin
+          .offsets(Set.of(executor.topic()))
+          .values()
+          .forEach(o -> Assertions.assertEquals(0, o.latest()));
+      Assertions.assertEquals(State.RUNNING, executor.execute());
+      // only specified partition gets value
+      // for normal producer, there is only one record
+      // for transactional producer, the size of transaction is 10
+      Assertions.assertEquals(
+          executor.transactional() ? 10 : 1,
+          admin
+              .offsets(Set.of(executor.topic()))
+              .get(new TopicPartition(executor.topic(), specifiedPartition))
+              .latest());
+      // other partitions have no data
+      admin.offsets(Set.of(executor.topic())).entrySet().stream()
+          .filter(e -> !e.getKey().equals(new TopicPartition(executor.topic(), specifiedPartition)))
+          .forEach(e -> Assertions.assertEquals(0, e.getValue().latest()));
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("offsetProducerExecutors")
+  void testDone(ProducerExecutor executor) throws InterruptedException {
+    ((MyDataSupplier) executor.dataSupplier()).data = DataSupplier.NO_MORE_DATA;
+    Assertions.assertEquals(State.DONE, executor.execute());
+  }
+
+  @ParameterizedTest
+  @MethodSource("offsetProducerExecutors")
+  void testClose(ProducerExecutor executor) {
+    executor.close();
+    Assertions.assertTrue(executor.closed());
+  }
+
+  @ParameterizedTest
+  @MethodSource("offsetProducerExecutors")
+  void testObserver(ProducerExecutor executor) throws InterruptedException {
+    Assertions.assertEquals(State.RUNNING, executor.execute());
+    // wait for async call
+    TimeUnit.SECONDS.sleep(2);
+    Assertions.assertEquals(
+        executor.transactional() ? 10 : 1, ((Observer) executor.observer()).recordsHook.size());
+    Assertions.assertEquals(
+        executor.transactional() ? 10 : 1, ((Observer) executor.observer()).elapsedHook.size());
+  }
+
+  private static class Observer implements BiConsumer<Long, Long> {
+    private final BlockingQueue<Long> recordsHook = new LinkedBlockingDeque<>();
+    private final BlockingQueue<Long> elapsedHook = new LinkedBlockingDeque<>();
+
+    @Override
+    public void accept(Long records, Long elapsed) {
+      Assertions.assertTrue(recordsHook.offer(records));
+      Assertions.assertTrue(elapsedHook.offer(elapsed));
+    }
+  }
+
+  private static class MyDataSupplier implements DataSupplier {
+
+    private Data data =
+        DataSupplier.data(
+            "key".getBytes(StandardCharsets.UTF_8), "value".getBytes(StandardCharsets.UTF_8));
+
+    @Override
+    public Data get() {
+      return data;
+    }
+  }
+
+  private static class MyPartitionSupplier implements Supplier<Integer> {
+    private int partition = -1;
+
+    @Override
+    public Integer get() {
+      return partition;
+    }
+  }
+
+  private static Stream<Arguments> offsetProducerExecutors() {
+    var normalTopic = Utils.randomString(10);
+    var transactionalTopic = Utils.randomString(10);
+    return Stream.of(
+        Arguments.of(
+            Named.of(
+                "normal producer for topic: " + normalTopic,
+                ofProducer(
+                    normalTopic, new MyPartitionSupplier(), new Observer(), new MyDataSupplier()))),
+        Arguments.of(
+            Named.of(
+                "transactional producer for topic: " + transactionalTopic,
+                ofTransactionalProducer(
+                    transactionalTopic,
+                    new MyPartitionSupplier(),
+                    new Observer(),
+                    new MyDataSupplier()))));
+  }
+}

--- a/app/src/test/java/org/astraea/performance/ProducerExecutorTest.java
+++ b/app/src/test/java/org/astraea/performance/ProducerExecutorTest.java
@@ -63,6 +63,8 @@ public class ProducerExecutorTest extends RequireBrokerCluster {
           .values()
           .forEach(o -> Assertions.assertEquals(0, o.latest()));
       Assertions.assertEquals(State.RUNNING, executor.execute());
+      // wait for syncing data
+      TimeUnit.SECONDS.sleep(2);
       // only specified partition gets value
       // for normal producer, there is only one record
       // for transactional producer, the size of transaction is 10


### PR DESCRIPTION
改善了以下幾個點：
1. 避免`Manager`涵蓋太多功能導致難以測試，原本的`Manager`掌管了producer/consuemr的資料量、也掌管了如何產生資料、更掌管了什麼時候要停止各個consumer/producer
2. throttle的使用方式改善，原本的方式是直接卡著等到可以回傳資料，但這樣會導致呼叫者只能乾等，這隻PR增加了幾個狀態列讓呼叫者可以自行決定大概何時要再來拿、或是過程要不要做一些事情
3. 避免建立多餘的producer，原本會同時建立兩個producer，一個負責transaction、一個負責一般的資料。然而實際上我們同時只會用一個...
4. 增加更多的測試