### PR TITLE
Smooth weight Round Robin algorithm

### DIFF
--- a/app/src/main/java/org/astraea/cost/Periodic.java
+++ b/app/src/main/java/org/astraea/cost/Periodic.java
@@ -25,4 +25,19 @@ public abstract class Periodic<Value> {
   protected long currentTime() {
     return System.currentTimeMillis();
   }
+
+  /**
+   * Updates the value interval second.
+   *
+   * @param updater Methods that need to be updated regularly.
+   * @param interval Required interval.
+   * @return an object of type Value created from the parameter value.
+   */
+  protected Value tryUpdate(Supplier<Value> updater, int interval) {
+    if (Utils.overSecond(lastUpdate, interval)) {
+      value = updater.get();
+      lastUpdate = currentTime();
+    }
+    return value;
+  }
 }

--- a/app/src/main/java/org/astraea/partitioner/smoothPartitioner/SmoothWeightRoundRobin.java
+++ b/app/src/main/java/org/astraea/partitioner/smoothPartitioner/SmoothWeightRoundRobin.java
@@ -1,0 +1,97 @@
+package org.astraea.partitioner.smoothPartitioner;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.astraea.cost.Periodic;
+import org.astraea.cost.brokersMetrics.CostUtils;
+
+/**
+ * Given initial key-score pair, it will output a preferred key with the highest current weight. The
+ * current weight of the chosen key will decrease the sum of effective weight. And all current
+ * weight will increment by its effective weight. It may result in "higher score with higher chosen
+ * rate". For example:
+ *
+ * <p>||========================================||============================================||
+ * ||------------ Broker in cluster ------------||------------- Effective weight -------------||
+ * ||------------------Broker1------------------||-------------------- 5 ---------------------||
+ * ||------------------Broker2------------------||-------------------- 1 ---------------------||
+ * ||------------------Broker3------------------||-------------------- 1 ---------------------||
+ * ||===========================================||============================================||
+ *
+ * <p>||===================||=======================||===============||======================||
+ * ||--- Request Number ---|| Before current weight || Target Broker || After current weight ||
+ * ||----------1-----------||------ {5, 1, 1} ------||----Broker1----||----- {-2, 1, 1} -----||
+ * ||----------2-----------||------ {3, 2, 2} ------||----Broker1----||----- {-4, 2, 2} -----||
+ * ||----------3-----------||------ {1, 3, 3} ------||----Broker2----||----- { 1,-4, 3} -----||
+ * ||----------4-----------||------ {6,-3, 4} ------||----Broker1----||----- {-1,-3, 4} -----||
+ * ||----------5-----------||------ {4,-2, 5} ------||----Broker3----||----- { 4,-2,-2} -----||
+ * ||----------6-----------||------ {9,-1,-1} ------||----Broker1----||----- { 2,-1,-1} -----||
+ * ||----------7-----------||------ {7, 0, 0} ------||----Broker1----||----- { 0, 0, 0} -----||
+ * ||======================||=======================||===============||======================||
+ */
+public final class SmoothWeightRoundRobin extends Periodic<Void> {
+  private Map<Integer, Double> effectiveWeight;
+  private double effectiveWeightSum;
+  public Map<Integer, Double> currentWeight;
+
+  public SmoothWeightRoundRobin() {}
+
+  public SmoothWeightRoundRobin(Map<Integer, Double> effectiveWeight) {
+    init(effectiveWeight);
+  }
+
+  public synchronized void init(Map<Integer, Double> brokerScore) {
+    tryUpdate(
+        () -> {
+          if (effectiveWeight == null) {
+            this.effectiveWeight = new ConcurrentHashMap<>(brokerScore);
+            this.effectiveWeight.replaceAll(
+                (k, v) -> (double) Math.round(100 * (1.0 / brokerScore.size())) / 100.0);
+            this.currentWeight = new ConcurrentHashMap<>(brokerScore);
+            this.currentWeight.replaceAll((k, v) -> 0.0);
+            this.effectiveWeightSum =
+                this.effectiveWeight.values().stream().mapToDouble(i -> i).sum();
+          } else {
+            var zCurrentLoad = CostUtils.ZScore(brokerScore);
+            this.effectiveWeight.replaceAll(
+                (k, v) -> {
+                  var zLoad = zCurrentLoad.get(k);
+                  var score =
+                      Math.round(
+                              10000
+                                  * (v
+                                      - (zLoad.isNaN() ? 0.0 : zLoad)
+                                          * 0.01
+                                          / this.effectiveWeight.size()))
+                          / 10000.0;
+                  if (score > 1.0) {
+                    return 1.0;
+                  } else if (score < 0.0) {
+                    return 0.0;
+                  }
+                  return score;
+                });
+            this.effectiveWeightSum =
+                this.effectiveWeight.values().stream().mapToDouble(i -> i).sum();
+          }
+          return null;
+        },
+        10);
+  }
+
+  /**
+   * Get the preferred ID, and update the state.
+   *
+   * @return the preferred ID
+   */
+  public int getAndChoose() {
+    var maxID =
+        this.currentWeight.entrySet().stream()
+            .max(Comparator.comparingDouble(Map.Entry::getValue))
+            .orElseGet(() -> Map.entry(0, 0.0))
+            .getKey();
+    this.currentWeight.computeIfPresent(maxID, (ID, value) -> value - effectiveWeightSum);
+    return maxID;
+  }
+}


### PR DESCRIPTION
#315 中SWRR演算法討論，我有想到解決炮口一致的問題。
簡而言之借鑑了VNSWRR的思路。
因爲SWRR算出來的節點排序是固定的所以可以先事先算好一定量的後續排序。而不是需要的時候再一筆筆算。
這樣能帶來兩個好處：
1.解決炮口問題，一開始我們根據初始權重生成排序，然後隨機起點，這樣炮口就不一致了。
2.SWRR算法的時間複雜度是O(n),n爲節點數量，因爲他需要從所有節點中找到狀態最好的。改稱先算排序那就變成了直接拿，複雜度就變爲了O(1),這在節點數量有很多的情況下效能會有所改善。
缺點：
空間換時間，外加需要考慮排序所花的時間，何時排序才能不影響某筆資料的latency

第二個好處目前似乎還不急，我讀其他文章這個算法的效能瓶頸似乎在有2000個節點纔會開始影響。
似乎可以先只選用第一個好處的做法，只在初始化的時候生成排序和隨機起點。

其他神祕數字我還在思考，暫時還沒有頭緒。