### PR TITLE
Fix flaky AdminTest#testOffsets

### DIFF
--- a/app/src/test/java/org/astraea/admin/AdminTest.java
+++ b/app/src/test/java/org/astraea/admin/AdminTest.java
@@ -122,7 +122,7 @@ public class AdminTest extends RequireBrokerCluster {
     try (var admin = Admin.of(bootstrapServers())) {
       admin.creator().topic(topicName).numberOfPartitions(3).create();
       // wait for syncing topic creation
-      TimeUnit.SECONDS.sleep(5);
+      TimeUnit.SECONDS.sleep(3);
       var offsets = admin.offsets(Set.of(topicName));
       Assertions.assertEquals(3, offsets.size());
       offsets
@@ -134,6 +134,8 @@ public class AdminTest extends RequireBrokerCluster {
               });
 
       admin.creator().topic("a").numberOfPartitions(3).create();
+      // wait for syncing topic creation
+      TimeUnit.SECONDS.sleep(3);
       Assertions.assertEquals(6, admin.offsets().size());
     }
   }


### PR DESCRIPTION
```
AdminTest > testOffsets() FAILED
[30](https://github.com/skiptests/astraea/runs/6440503201?check_suite_focus=true#step:5:30)
    org.opentest4j.AssertionFailedError: expected: <6> but was: <3>
[31](https://github.com/skiptests/astraea/runs/6440503201?check_suite_focus=true#step:5:31)
        at app//org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
[32](https://github.com/skiptests/astraea/runs/6440503201?check_suite_focus=true#step:5:32)
        at app//org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
[33](https://github.com/skiptests/astraea/runs/6440503201?check_suite_focus=true#step:5:33)
        at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:150)
[34](https://github.com/skiptests/astraea/runs/6440503201?check_suite_focus=true#step:5:34)
        at app//org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:145)
[35](https://github.com/skiptests/astraea/runs/6440503201?check_suite_focus=true#step:5:35)
        at app//org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:527)
[36](https://github.com/skiptests/astraea/runs/6440503201?check_suite_focus=true#step:5:36)
        at app//org.astraea.admin.AdminTest.testOffsets(AdminTest.java:137)
```