### PR TITLE
Add topic/partitions to broker for restful APIs

### DIFF
--- a/app/src/main/java/org/astraea/admin/Admin.java
+++ b/app/src/main/java/org/astraea/admin/Admin.java
@@ -96,11 +96,21 @@ public interface Admin extends Closeable {
   Set<Integer> brokerIds();
 
   /**
+   * list all partitions belongs to input brokers
+   *
+   * @param brokerId to search
+   * @return all partition belongs to brokers
+   */
+  default Set<TopicPartition> partitions(int brokerId) {
+    return partitions(topicNames(), Set.of(brokerId)).getOrDefault(brokerId, Set.of());
+  }
+
+  /**
    * @param topics topic names
-   * @param brokersID brokers ID
+   * @param brokerIds brokers ID
    * @return the partitions of brokers
    */
-  Set<TopicPartition> partitionsOfBrokers(Set<String> topics, Set<Integer> brokersID);
+  Map<Integer, Set<TopicPartition>> partitions(Set<String> topics, Set<Integer> brokerIds);
 
   /** @return data folders of all broker nodes */
   default Map<Integer, Set<String>> brokerFolders() {

--- a/app/src/main/java/org/astraea/web/BrokerHandler.java
+++ b/app/src/main/java/org/astraea/web/BrokerHandler.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.astraea.admin.Admin;
 import org.astraea.admin.Config;
+import org.astraea.admin.TopicPartition;
 
 class BrokerHandler implements Handler {
 
@@ -28,20 +29,39 @@ class BrokerHandler implements Handler {
 
   @Override
   public JsonObject get(Optional<String> target, Map<String, String> queries) {
+
     var brokers =
         admin.brokers(brokers(target)).entrySet().stream()
-            .map(e -> new Broker(e.getKey(), e.getValue()))
+            .map(e -> new Broker(e.getKey(), admin.partitions(e.getKey()), e.getValue()))
             .collect(Collectors.toUnmodifiableList());
     if (target.isPresent() && brokers.size() == 1) return brokers.get(0);
     return new Brokers(brokers);
   }
 
+  static class Topic implements JsonObject {
+    final String topic;
+    final int partitionCount;
+
+    Topic(String topic, int partitionCount) {
+      this.topic = topic;
+      this.partitionCount = partitionCount;
+    }
+  }
+
   static class Broker implements JsonObject {
     final int id;
+    final List<Topic> topics;
     final Map<String, String> configs;
 
-    Broker(int id, Config configs) {
+    Broker(int id, Set<TopicPartition> topicPartitions, Config configs) {
       this.id = id;
+      this.topics =
+          topicPartitions.stream()
+              .collect(Collectors.groupingBy(TopicPartition::topic))
+              .entrySet()
+              .stream()
+              .map(e -> new Topic(e.getKey(), e.getValue().size()))
+              .collect(Collectors.toUnmodifiableList());
       this.configs =
           StreamSupport.stream(configs.spliterator(), false)
               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));


### PR DESCRIPTION
產生下方的統計畫面
```json
    "brokers": [
        {
            "id": 1001,
            "topics": [
                {
                    "topic": "log",
                    "partitionCount": 8
                },
                {
                    "topic": "table",
                    "partitionCount": 10
                }
            ],
```