### PR TITLE
The web container should run in background

### DIFF
--- a/docker/start_kafka_tool.sh
+++ b/docker/start_kafka_tool.sh
@@ -71,8 +71,10 @@ function runContainer() {
   echo "JMX address: $ADDRESS:$JMX_PORT"
 
   # web service needs to bind a port to expose Restful APIs, so we have to open a port of container
-  need_to_bind_web=""
+  local need_to_bind_web=""
+  local background=""
   if [[ "$args" == web* ]]; then
+    background="-d"
     sentence=($args)
     defined_port="false"
     # use random port by default
@@ -96,6 +98,7 @@ function runContainer() {
   fi
 
   docker run --rm --init \
+    $background \
     -p $JMX_PORT:$JMX_PORT \
     $need_to_bind_web \
     "$IMAGE_NAME" \


### PR DESCRIPTION
We use the restful APIs to touch web service rather than console, so it does not need to run in foreground.