### PR TITLE
rename functions

### DIFF
--- a/app/src/main/java/org/astraea/balancer/log/LayeredClusterLogAllocation.java
+++ b/app/src/main/java/org/astraea/balancer/log/LayeredClusterLogAllocation.java
@@ -54,7 +54,7 @@ public class LayeredClusterLogAllocation implements ClusterLogAllocation {
   public static LayeredClusterLogAllocation of(ClusterInfo clusterInfo) {
     final Map<TopicPartition, List<LogPlacement>> allocation =
         clusterInfo.topics().stream()
-            .map(clusterInfo::partitions)
+            .map(clusterInfo::replicas)
             .flatMap(Collection::stream)
             .collect(
                 Collectors.groupingBy(

--- a/app/src/main/java/org/astraea/cost/ClusterInfo.java
+++ b/app/src/main/java/org/astraea/cost/ClusterInfo.java
@@ -31,7 +31,7 @@ public interface ClusterInfo {
       }
 
       @Override
-      public List<ReplicaInfo> availablePartitionLeaders(String topic) {
+      public List<ReplicaInfo> availableReplicaLeaders(String topic) {
         return cluster.availablePartitionsForTopic(topic).stream()
             .map(ReplicaInfo::of)
             .map(
@@ -41,7 +41,7 @@ public interface ClusterInfo {
       }
 
       @Override
-      public List<ReplicaInfo> availablePartitions(String topic) {
+      public List<ReplicaInfo> availableReplicas(String topic) {
         return cluster.availablePartitionsForTopic(topic).stream()
             .map(ReplicaInfo::of)
             .flatMap(Collection::stream)
@@ -49,7 +49,7 @@ public interface ClusterInfo {
       }
 
       @Override
-      public List<ReplicaInfo> partitions(String topic) {
+      public List<ReplicaInfo> replicas(String topic) {
         return cluster.partitionsForTopic(topic).stream()
             .map(ReplicaInfo::of)
             .flatMap(Collection::stream)
@@ -94,13 +94,13 @@ public interface ClusterInfo {
       }
 
       @Override
-      public List<ReplicaInfo> availablePartitionLeaders(String topic) {
-        return cluster.availablePartitionLeaders(topic);
+      public List<ReplicaInfo> availableReplicaLeaders(String topic) {
+        return cluster.availableReplicaLeaders(topic);
       }
 
       @Override
-      public List<ReplicaInfo> availablePartitions(String topic) {
-        return cluster.availablePartitions(topic);
+      public List<ReplicaInfo> availableReplicas(String topic) {
+        return cluster.availableReplicas(topic);
       }
 
       @Override
@@ -109,8 +109,8 @@ public interface ClusterInfo {
       }
 
       @Override
-      public List<ReplicaInfo> partitions(String topic) {
-        return cluster.partitions(topic);
+      public List<ReplicaInfo> replicas(String topic) {
+        return cluster.replicas(topic);
       }
 
       @Override
@@ -168,7 +168,7 @@ public interface ClusterInfo {
    * @param topic The Topic name
    * @return A list of {@link ReplicaInfo}
    */
-  List<ReplicaInfo> availablePartitionLeaders(String topic);
+  List<ReplicaInfo> availableReplicaLeaders(String topic);
 
   /**
    * Get the list of replica information of each available partition/replica pair for the given
@@ -177,7 +177,7 @@ public interface ClusterInfo {
    * @param topic The topic name
    * @return A list of {@link ReplicaInfo}
    */
-  List<ReplicaInfo> availablePartitions(String topic);
+  List<ReplicaInfo> availableReplicas(String topic);
 
   /**
    * All topic names
@@ -192,7 +192,7 @@ public interface ClusterInfo {
    * @param topic The topic name
    * @return A list of {@link ReplicaInfo}
    */
-  List<ReplicaInfo> partitions(String topic);
+  List<ReplicaInfo> replicas(String topic);
 
   /**
    * @param brokerId broker id

--- a/app/src/main/java/org/astraea/partitioner/StrictCostDispatcher.java
+++ b/app/src/main/java/org/astraea/partitioner/StrictCostDispatcher.java
@@ -58,7 +58,7 @@ public class StrictCostDispatcher implements Dispatcher {
 
   @Override
   public int partition(String topic, byte[] key, byte[] value, ClusterInfo clusterInfo) {
-    var partitionLeaders = clusterInfo.availablePartitionLeaders(topic);
+    var partitionLeaders = clusterInfo.availableReplicaLeaders(topic);
     // just return first partition if there is no available partitions
     if (partitionLeaders.isEmpty()) return 0;
 

--- a/app/src/main/java/org/astraea/partitioner/smooth/SmoothWeightRoundRobinDispatcher.java
+++ b/app/src/main/java/org/astraea/partitioner/smooth/SmoothWeightRoundRobinDispatcher.java
@@ -148,7 +148,7 @@ public class SmoothWeightRoundRobinDispatcher extends Periodic<Map<Integer, Doub
   }
 
   private void refreshPartitionMetaData(ClusterInfo clusterInfo, String topic) {
-    partitions = clusterInfo.availablePartitions(topic);
+    partitions = clusterInfo.availableReplicas(topic);
     partitions.forEach(
         p ->
             hasPartitions

--- a/app/src/test/java/org/astraea/balancer/log/LayeredClusterLogAllocationTest.java
+++ b/app/src/test/java/org/astraea/balancer/log/LayeredClusterLogAllocationTest.java
@@ -108,7 +108,7 @@ class LayeredClusterLogAllocationTest {
     final var allocation0 = LayeredClusterLogAllocation.of(fakeClusterInfo);
     final var allocation1 = LayeredClusterLogAllocation.of(allocation0);
     fakeClusterInfo.topics().stream()
-        .flatMap(x -> fakeClusterInfo.partitions(x).stream())
+        .flatMap(x -> fakeClusterInfo.replicas(x).stream())
         .forEach(
             replica ->
                 allocation1.changeDataDirectory(
@@ -126,7 +126,7 @@ class LayeredClusterLogAllocationTest {
     Assertions.assertEquals(10 * 10, allTopicPartitions.size());
     final var expectedTopicPartitions =
         fakeClusterInfo.topics().stream()
-            .flatMap(x -> fakeClusterInfo.partitions(x).stream())
+            .flatMap(x -> fakeClusterInfo.replicas(x).stream())
             .map(x -> TopicPartition.of(x.topic(), Integer.toString(x.partition())))
             .distinct()
             .sorted(

--- a/app/src/test/java/org/astraea/cost/ClusterInfoProvider.java
+++ b/app/src/test/java/org/astraea/cost/ClusterInfoProvider.java
@@ -89,15 +89,15 @@ public class ClusterInfoProvider {
       }
 
       @Override
-      public List<ReplicaInfo> availablePartitionLeaders(String topic) {
-        return partitions(topic).stream()
+      public List<ReplicaInfo> availableReplicaLeaders(String topic) {
+        return replicas(topic).stream()
             .filter(ReplicaInfo::isLeader)
             .collect(Collectors.toUnmodifiableList());
       }
 
       @Override
-      public List<ReplicaInfo> availablePartitions(String topic) {
-        return partitions(topic);
+      public List<ReplicaInfo> availableReplicas(String topic) {
+        return replicas(topic);
       }
 
       @Override
@@ -106,7 +106,7 @@ public class ClusterInfoProvider {
       }
 
       @Override
-      public List<ReplicaInfo> partitions(String topic) {
+      public List<ReplicaInfo> replicas(String topic) {
         return replicas.get(topic);
       }
 

--- a/app/src/test/java/org/astraea/cost/ClusterInfoTest.java
+++ b/app/src/test/java/org/astraea/cost/ClusterInfoTest.java
@@ -26,15 +26,15 @@ public class ClusterInfoTest {
     Assertions.assertEquals(1, clusterInfo.nodes().size());
     Assertions.assertEquals(NodeInfo.of(node), clusterInfo.nodes().get(0));
     Assertions.assertEquals(clusterInfo.nodes().get(0), clusterInfo.node(node.host(), node.port()));
-    Assertions.assertEquals(1, clusterInfo.availablePartitions(partition.topic()).size());
-    Assertions.assertEquals(1, clusterInfo.partitions(partition.topic()).size());
+    Assertions.assertEquals(1, clusterInfo.availableReplicas(partition.topic()).size());
+    Assertions.assertEquals(1, clusterInfo.replicas(partition.topic()).size());
     Assertions.assertEquals(
-        NodeInfo.of(node), clusterInfo.availablePartitions(partition.topic()).get(0).nodeInfo());
+        NodeInfo.of(node), clusterInfo.availableReplicas(partition.topic()).get(0).nodeInfo());
     Assertions.assertEquals(
         NodeInfo.of(node),
-        clusterInfo.availablePartitionLeaders(partition.topic()).get(0).nodeInfo());
+        clusterInfo.availableReplicaLeaders(partition.topic()).get(0).nodeInfo());
     Assertions.assertEquals(
-        NodeInfo.of(node), clusterInfo.partitions(partition.topic()).get(0).nodeInfo());
+        NodeInfo.of(node), clusterInfo.replicas(partition.topic()).get(0).nodeInfo());
   }
 
   @Test

--- a/app/src/test/java/org/astraea/cost/FakeClusterInfo.java
+++ b/app/src/test/java/org/astraea/cost/FakeClusterInfo.java
@@ -18,12 +18,12 @@ public class FakeClusterInfo implements ClusterInfo {
   }
 
   @Override
-  public List<ReplicaInfo> availablePartitionLeaders(String topic) {
+  public List<ReplicaInfo> availableReplicaLeaders(String topic) {
     return List.of();
   }
 
   @Override
-  public List<ReplicaInfo> availablePartitions(String topic) {
+  public List<ReplicaInfo> availableReplicas(String topic) {
     return List.of();
   }
 
@@ -33,7 +33,7 @@ public class FakeClusterInfo implements ClusterInfo {
   }
 
   @Override
-  public List<ReplicaInfo> partitions(String topic) {
+  public List<ReplicaInfo> replicas(String topic) {
     return List.of();
   }
 

--- a/app/src/test/java/org/astraea/cost/ThroughputCostTest.java
+++ b/app/src/test/java/org/astraea/cost/ThroughputCostTest.java
@@ -35,7 +35,7 @@ public class ThroughputCostTest {
     Mockito.when(cluster.nodes()).thenReturn(List.of(node));
     Mockito.when(cluster.allBeans()).thenReturn(Map.of());
     Mockito.when(cluster.topics()).thenReturn(Set.of("t"));
-    Mockito.when(cluster.availablePartitions("t"))
+    Mockito.when(cluster.availableReplicas("t"))
         .thenReturn(List.of(ReplicaInfo.of("t", 0, node, true, true, false)));
 
     var cost =

--- a/app/src/test/java/org/astraea/cost/broker/CpuCostTest.java
+++ b/app/src/test/java/org/astraea/cost/broker/CpuCostTest.java
@@ -37,7 +37,7 @@ public class CpuCostTest {
           }
 
           @Override
-          public List<ReplicaInfo> availablePartitions(String topic) {
+          public List<ReplicaInfo> availableReplicas(String topic) {
             return List.of(
                 ReplicaInfo.of("t", 0, NodeInfo.of(1, "host1", 9092), true, true, false),
                 ReplicaInfo.of("t", 0, NodeInfo.of(2, "host2", 9092), false, true, false),
@@ -72,7 +72,7 @@ public class CpuCostTest {
           }
 
           @Override
-          public List<ReplicaInfo> availablePartitions(String topic) {
+          public List<ReplicaInfo> availableReplicas(String topic) {
             return List.of(
                 ReplicaInfo.of("t", 0, NodeInfo.of(1, "host1", 9092), true, true, false),
                 ReplicaInfo.of("t", 0, NodeInfo.of(2, "host2", 9092), false, true, false),

--- a/app/src/test/java/org/astraea/cost/broker/MemoryCostTest.java
+++ b/app/src/test/java/org/astraea/cost/broker/MemoryCostTest.java
@@ -38,7 +38,7 @@ public class MemoryCostTest {
           }
 
           @Override
-          public List<ReplicaInfo> availablePartitions(String topic) {
+          public List<ReplicaInfo> availableReplicas(String topic) {
             return List.of(
                 ReplicaInfo.of("t", 0, NodeInfo.of(1, "host1", 9092), true, false, false),
                 ReplicaInfo.of("t", 0, NodeInfo.of(2, "host2", 9092), false, true, false),
@@ -73,7 +73,7 @@ public class MemoryCostTest {
           }
 
           @Override
-          public List<ReplicaInfo> availablePartitions(String topic) {
+          public List<ReplicaInfo> availableReplicas(String topic) {
             return List.of(
                 ReplicaInfo.of("t", 0, NodeInfo.of(1, "host1", 9092), true, true, false),
                 ReplicaInfo.of("t", 0, NodeInfo.of(2, "host2", 9092), false, true, false),

--- a/app/src/test/java/org/astraea/partitioner/StrictCostDispatcherTest.java
+++ b/app/src/test/java/org/astraea/partitioner/StrictCostDispatcherTest.java
@@ -137,16 +137,16 @@ public class StrictCostDispatcherTest {
       var clusterInfo = Mockito.mock(ClusterInfo.class);
 
       // there is no available partition
-      Mockito.when(clusterInfo.availablePartitionLeaders("aa")).thenReturn(List.of());
+      Mockito.when(clusterInfo.availableReplicaLeaders("aa")).thenReturn(List.of());
       Mockito.when(clusterInfo.topics()).thenReturn(Set.of("aa"));
       Assertions.assertEquals(0, dispatcher.partition("aa", new byte[0], new byte[0], clusterInfo));
 
       // there is only one available partition
-      Mockito.when(clusterInfo.availablePartitionLeaders("aa")).thenReturn(List.of(p0));
+      Mockito.when(clusterInfo.availableReplicaLeaders("aa")).thenReturn(List.of(p0));
       Assertions.assertEquals(1, dispatcher.partition("aa", new byte[0], new byte[0], clusterInfo));
 
       // there is no beans, so it just returns the partition.
-      Mockito.when(clusterInfo.availablePartitionLeaders("aa")).thenReturn(List.of(p0, p1));
+      Mockito.when(clusterInfo.availableReplicaLeaders("aa")).thenReturn(List.of(p0, p1));
       Assertions.assertEquals(2, dispatcher.partition("aa", new byte[0], new byte[0], clusterInfo));
 
       // cost functions with weight


### PR DESCRIPTION
因為`ClusterInfo`的partitions()之回傳型態由List\<PartitionInfo>改成List\<ReplicaInfo>，因此將相關方法改名為replicas()較能表達其功能