### PR TITLE
The build is broken after we rename availablePartitionLeaders to availableReplicaLeaders

### DIFF
--- a/app/src/main/java/org/astraea/partitioner/smooth/SmoothWeightRoundRobin.java
+++ b/app/src/main/java/org/astraea/partitioner/smooth/SmoothWeightRoundRobin.java
@@ -86,7 +86,7 @@ public final class SmoothWeightRoundRobin
         brokersIDofTopic.computeIfAbsent(
             topic,
             e ->
-                clusterInfo.availablePartitionLeaders(topic).stream()
+                clusterInfo.availableReplicaLeaders(topic).stream()
                     .map(replicaInfo -> replicaInfo.nodeInfo().id())
                     .collect(Collectors.toList()));
     this.currentWeight =

--- a/app/src/test/java/org/astraea/partitioner/smooth/SmoothWeightRoundRobinDispatchTest.java
+++ b/app/src/test/java/org/astraea/partitioner/smooth/SmoothWeightRoundRobinDispatchTest.java
@@ -296,7 +296,7 @@ public class SmoothWeightRoundRobinDispatchTest extends RequireBrokerCluster {
     var testCluster =
         new FakeClusterInfo() {
           @Override
-          public List<ReplicaInfo> availablePartitionLeaders(String topic) {
+          public List<ReplicaInfo> availableReplicaLeaders(String topic) {
             return List.of(re1, re2, re3);
           }
         };

--- a/app/src/test/java/org/astraea/partitioner/smooth/SmoothWeightRoundRobinTest.java
+++ b/app/src/test/java/org/astraea/partitioner/smooth/SmoothWeightRoundRobinTest.java
@@ -58,7 +58,7 @@ public class SmoothWeightRoundRobinTest {
     Mockito.when(node3.id()).thenReturn(3);
     return new FakeClusterInfo() {
       @Override
-      public List<ReplicaInfo> availablePartitionLeaders(String topic) {
+      public List<ReplicaInfo> availableReplicaLeaders(String topic) {
         return List.of(re1, re2, re3);
       }
     };


### PR DESCRIPTION
https://github.com/skiptests/astraea/commit/6a6135cd0ed5df788e87311c2b9ef2eb9257aa51 breaks the build, and it is caused by https://github.com/skiptests/astraea/commit/0840f87daed9c48825782c0f30a09d06c56d780e which renamed some APIs