### PR TITLE
Rename kafka-tool to app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ build
 # generated dockerfiles
 zookeeper.dockerfile
 broker.dockerfile
-kafka_tool.dockerfile
+app.dockerfile
 spark.dockerfile
 deps.dockerfile
 # we don't put binary file to git repo

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Run the tool from source code
 
 Run the tool from release
 ```shell
-./docker/start_kafka_tool.sh offset --bootstrap.servers 192.168.50.178:19993
+./docker/start_app.sh offset --bootstrap.servers 192.168.50.178:19993
 ```
 
 ### Offset Explorer Configurations
@@ -253,17 +253,17 @@ Run the tool from source code
 Run the tool from release
 ```shell
 # fetch every Mbeans from specific JMX server.
-./docker/start_kafka_tool.sh metrics --jmx.server 192.168.50.178:1099
+./docker/start_app.sh metrics --jmx.server 192.168.50.178:1099
 
 # fetch any Mbean that its object name contains property "type=Memory".
-./docker/start_kafka_tool.sh metrics --jmx.server 192.168.50.178:1099 --property type=Memory
+./docker/start_app.sh metrics --jmx.server 192.168.50.178:1099 --property type=Memory
 
 # fetch any Mbean that belongs to "kafka.network" domain name,
 # and it's object name contains two properties "request=Metadata" and "name=LocalTimeMs".
-./docker/start_kafka_tool.sh metrics --jmx.server 192.168.50.178:1099 --domain kafka.network --property request=Metadata --property name=LocalTimeMs
+./docker/start_app.sh metrics --jmx.server 192.168.50.178:1099 --domain kafka.network --property request=Metadata --property name=LocalTimeMs
 
 # list all Mbeans' object name on specific JMX server.
-./docker/start_kafka_tool.sh metrics --jmx.server 192.168.50.178:1099 --view-object-name-list
+./docker/start_app.sh metrics --jmx.server 192.168.50.178:1099 --view-object-name-list
 ```
 
 ### Metric Explorer Configurations
@@ -390,7 +390,7 @@ $ ./gradlew run --args="monitor --bootstrap.servers 192.168.103.39:9092"
 2. --port: the port used by web server
 
 ```shell
-./docker/start_kafka_tool.sh web --bootstrap.servers 192.168.50.178:19993 --port 12345"
+./docker/start_app.sh web --bootstrap.servers 192.168.50.178:19993 --port 12345"
 ```
 
 ## Query all topics 

--- a/docker/start_app.sh
+++ b/docker/start_app.sh
@@ -19,9 +19,9 @@ source $DOCKER_FOLDER/docker_build_common.sh
 
 # ===============================[global variables]===============================
 declare -r VERSION=${REVISION:-${VERSION:-main}}
-declare -r REPO=${REPO:-ghcr.io/skiptests/astraea/kafka-tool}
+declare -r REPO=${REPO:-ghcr.io/skiptests/astraea/app}
 declare -r IMAGE_NAME="$REPO:$VERSION"
-declare -r DOCKERFILE=$DOCKER_FOLDER/kafka_tool.dockerfile
+declare -r DOCKERFILE=$DOCKER_FOLDER/app.dockerfile
 declare -r JMX_PORT=${JMX_PORT:-"$(getRandomPort)"}
 # for web service
 declare -r WEB_PORT=${WEB_PORT:-"$(getRandomPort)"}
@@ -31,9 +31,9 @@ declare -r HEAP_OPTS="${HEAP_OPTS:-"-Xmx2G -Xms2G"}"
 # ===================================[functions]===================================
 
 function showHelp() {
-  echo "Usage: [ENV] start_kafka_tool.sh"
+  echo "Usage: [ENV] start_app.sh"
   echo "ENV: "
-  echo "    REPO=astraea/kafka-tool    set the docker repo"
+  echo "    REPO=astraea/app    set the docker repo"
   echo "    BUILD=false                set true if you want to build image locally"
   echo "    RUN=false                  set false if you want to build/pull image only"
 }


### PR DESCRIPTION
隨著逐漸整合越來越多功能，只用"kafka-tool"來稱呼顯得侷限，因此改用我們的入口名稱`app`來取代