### PR TITLE
Fix log shrinkage cause `ReplicaSyncingMonitor` to raise an exception.

### DIFF
--- a/app/src/main/java/org/astraea/app/admin/ReplicaSyncingMonitor.java
+++ b/app/src/main/java/org/astraea/app/admin/ReplicaSyncingMonitor.java
@@ -233,6 +233,10 @@ public class ReplicaSyncingMonitor {
       var currentBit = currentSize.measurement(DataUnit.Bit).doubleValue();
       var leaderBit = leaderSize.measurement(DataUnit.Bit).doubleValue();
       if (currentBit == leaderBit) return 100;
+      // The Admin API doesn't offer any concurrency guarantee for these log size numbers. It is
+      // hard ensure the relationship between these two numbers, So we just assume the follower log
+      // size might somehow be larger than the leader log.
+      // TODO: prove the below condition is impossible to occur so it is safe to remove it.
       if (currentBit > leaderBit) return Double.NaN;
       return currentBit / leaderBit * 100.0;
     }


### PR DESCRIPTION
resolve #311.

https://github.com/skiptests/astraea/blob/ee5f014ef684c15b6b5417e57c7c072ebd238be3/app/src/main/java/org/astraea/app/admin/ReplicaSyncingMonitor.java#L218-L231

`ReplicaSyncingMonitor` 原先假設 log size 不會縮減，對此在程式碼內穿插一段邏輯，如果觸發這樣的情境會直接丟出錯誤，但 log retention/log compaction 可能會造成 log 大小縮減，對此這個假設並不正確，這個 PR 移除這段 safe check，允許出現 log size 在追蹤過程中變小的情況。

```shell
[2022-06-10T16:54:59.630245]
  Topic "topic-1":
  | Partition 0:
  | | replica on broker   0 => [####################] 100.00% [leader, synced, log-shrunk]
  | | replica on broker   1 => [########            ]  43.75% ? Byte/seconds (unknown) [log-shrunk]
  Topic "topic-2":
  | Partition 0:
  | | replica on broker   0 => [####################] 100.00% [leader, synced, log-shrunk]
  | | replica on broker   1 => [########            ]  43.75% ? Byte/seconds (unknown) [log-shrunk]
  Topic "topic-3":
  | Partition 0:
  | | replica on broker   0 => [####################] 100.00% [leader, synced, log-shrunk]
  | | replica on broker   1 => [########            ]  43.75% ? Byte/seconds (unknown) [log-shrunk]

[2022-06-10T16:54:59.650637]
  Topic "topic-1":
  | Partition 0:
  | | replica on broker   0 => [####################] 100.00% [leader, synced, log-shrunk]
  | | replica on broker   1 => [                    ]    NaN% 3.00 KB/seconds (unknown) [log-shrunk]
  Topic "topic-2":
  | Partition 0:
  | | replica on broker   0 => [####################] 100.00% [leader, synced, log-shrunk]
  | | replica on broker   1 => [                    ]    NaN% 3.00 KB/seconds (unknown) [log-shrunk]
  Topic "topic-3":
  | Partition 0:
  | | replica on broker   0 => [####################] 100.00% [leader, synced, log-shrunk]
  | | replica on broker   1 => [                    ]    NaN% 3.00 KB/seconds (unknown) [log-shrunk]
```

現在如果觸發這些問題，會顯示提示 `log-shrunk`，然後部分資訊可能會不可見。