### PR TITLE
Rename transaction API path from "transaction" to "transactions"

### DIFF
--- a/app/src/main/java/org/astraea/app/web/WebService.java
+++ b/app/src/main/java/org/astraea/app/web/WebService.java
@@ -37,7 +37,7 @@ public class WebService {
     server.createContext("/producers", new ProducerHandler(Admin.of(arg.configs())));
     server.createContext("/quotas", new QuotaHandler(Admin.of(arg.configs())));
     server.createContext("/pipelines", new PipelineHandler(Admin.of(arg.configs())));
-    server.createContext("/transaction", new TransactionHandler(Admin.of(arg.configs())));
+    server.createContext("/transactions", new TransactionHandler(Admin.of(arg.configs())));
     server.start();
   }
 

--- a/app/src/test/java/org/astraea/app/admin/AdminTest.java
+++ b/app/src/test/java/org/astraea/app/admin/AdminTest.java
@@ -834,8 +834,8 @@ public class AdminTest extends RequireBrokerCluster {
       var transaction = admin.transactions().get(producer.transactionId().get());
       Assertions.assertNotNull(transaction);
       Assertions.assertEquals(
-              transaction.state() == TransactionState.COMPLETE_COMMIT ? 0 : 1,
-              transaction.topicPartitions().size());
+          transaction.state() == TransactionState.COMPLETE_COMMIT ? 0 : 1,
+          transaction.topicPartitions().size());
     }
   }
 }

--- a/app/src/test/java/org/astraea/app/admin/AdminTest.java
+++ b/app/src/test/java/org/astraea/app/admin/AdminTest.java
@@ -806,8 +806,9 @@ public class AdminTest extends RequireBrokerCluster {
 
       var transaction = admin.transactions().get(producer.transactionId().get());
       Assertions.assertNotNull(transaction);
-      Assertions.assertEquals(TransactionState.COMPLETE_COMMIT, transaction.state());
-      Assertions.assertEquals(0, transaction.topicPartitions().size());
+      Assertions.assertEquals(
+          transaction.state() == TransactionState.COMPLETE_COMMIT ? 0 : 1,
+          transaction.topicPartitions().size());
     }
   }
 
@@ -832,8 +833,9 @@ public class AdminTest extends RequireBrokerCluster {
 
       var transaction = admin.transactions().get(producer.transactionId().get());
       Assertions.assertNotNull(transaction);
-      Assertions.assertEquals(TransactionState.COMPLETE_COMMIT, transaction.state());
-      Assertions.assertEquals(0, transaction.topicPartitions().size());
+      Assertions.assertEquals(
+              transaction.state() == TransactionState.COMPLETE_COMMIT ? 0 : 1,
+              transaction.topicPartitions().size());
     }
   }
 }


### PR DESCRIPTION
剛剛在審查#405的時候發現我不小心打錯路徑名稱....

另外也修正了一隻不穩定的測試