### PR TITLE
Revise the return type of `LogPlacement#logDirectory` to `String`

### DIFF
--- a/app/src/main/java/org/astraea/app/balancer/log/ClusterLogAllocation.java
+++ b/app/src/main/java/org/astraea/app/balancer/log/ClusterLogAllocation.java
@@ -28,7 +28,7 @@ import org.astraea.app.admin.TopicPartition;
 public interface ClusterLogAllocation {
 
   /** let specific broker leave the replica set and let another broker join the replica set. */
-  void migrateReplica(TopicPartition topicPartition, int atBroker, int toBroker);
+  void migrateReplica(TopicPartition topicPartition, int atBroker, int toBroker, String toDataDir);
 
   /** let specific follower log become the leader log of this topic/partition. */
   void letReplicaBecomeLeader(TopicPartition topicPartition, int followerReplica);

--- a/app/src/main/java/org/astraea/app/balancer/log/LayeredClusterLogAllocation.java
+++ b/app/src/main/java/org/astraea/app/balancer/log/LayeredClusterLogAllocation.java
@@ -163,7 +163,7 @@ public class LayeredClusterLogAllocation implements ClusterLogAllocation {
 
   @Override
   public synchronized void migrateReplica(
-      TopicPartition topicPartition, int broker, int destinationBroker) {
+      TopicPartition topicPartition, int broker, int destinationBroker, String destinationDataDir) {
     ensureNotLocked();
 
     final List<LogPlacement> sourceLogPlacements = this.logPlacements(topicPartition);
@@ -187,7 +187,7 @@ public class LayeredClusterLogAllocation implements ClusterLogAllocation {
             .mapToObj(
                 index ->
                     index == sourceLogIndex
-                        ? LogPlacement.of(destinationBroker)
+                        ? LogPlacement.of(destinationBroker, destinationDataDir)
                         : sourceLogPlacements.get(index))
             .collect(Collectors.toUnmodifiableList()));
   }

--- a/app/src/main/java/org/astraea/app/balancer/log/LogPlacement.java
+++ b/app/src/main/java/org/astraea/app/balancer/log/LogPlacement.java
@@ -16,20 +16,17 @@
  */
 package org.astraea.app.balancer.log;
 
-import java.util.Optional;
+import java.util.Objects;
 
 /** This class describe the placement state of one kafka log. */
 public interface LogPlacement {
 
   int broker();
 
-  Optional<String> logDirectory();
-
-  static LogPlacement of(int broker) {
-    return of(broker, null);
-  }
+  String logDirectory();
 
   static LogPlacement of(int broker, String logDirectory) {
+    Objects.requireNonNull(logDirectory);
     return new LogPlacement() {
       @Override
       public int broker() {
@@ -37,8 +34,8 @@ public interface LogPlacement {
       }
 
       @Override
-      public Optional<String> logDirectory() {
-        return Optional.ofNullable(logDirectory);
+      public String logDirectory() {
+        return logDirectory;
       }
 
       @Override

--- a/app/src/main/java/org/astraea/app/common/Utils.java
+++ b/app/src/main/java/org/astraea/app/common/Utils.java
@@ -21,9 +21,11 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.nio.file.Files;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -211,6 +213,14 @@ public final class Utils {
           throw new IllegalStateException("Duplicate key");
         },
         TreeMap::new);
+  }
+
+  /** @return a random element from the given collection. */
+  public static <T> T randomElement(Collection<T> collection) {
+    return collection.stream()
+        .skip(ThreadLocalRandom.current().nextInt(0, collection.size()))
+        .findFirst()
+        .orElseThrow();
   }
 
   private Utils() {}

--- a/app/src/test/java/org/astraea/app/common/UtilsTest.java
+++ b/app/src/test/java/org/astraea/app/common/UtilsTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
@@ -65,5 +66,16 @@ public class UtilsTest {
         () ->
             Stream.of(Map.entry(1, "hello"), Map.entry(1, "world"))
                 .collect(Utils.toSortedMap(Map.Entry::getKey, Map.Entry::getValue)));
+  }
+
+  @Test
+  void testRandomElement() {
+    final var numbers = IntStream.range(0, 50).boxed().collect(Collectors.toUnmodifiableList());
+
+    int[] counter = new int[50];
+
+    for (int i = 0; i < 10000; i++) counter[Utils.randomElement(numbers)]++;
+
+    for (int count : counter) Assertions.assertTrue(count > 0);
   }
 }


### PR DESCRIPTION
https://github.com/skiptests/astraea/blob/9083ee0b4f5029b93b07a85cd27014ce3e3062cb/app/src/main/java/org/astraea/app/balancer/log/LogPlacement.java#L22-L26

目前 `LogPlacement#logDirectory` 回傳的形態是 `Optional<String>`，這個 PR 把它修改爲 `String`，即 `RebalancePlanGenerator` 必須明確指出要搬移至哪個 log dir，這樣做的好處是 `CostFunction` 和 `BalancePlanExecutor` 在實作上可以不需要考量這個不知道會搬到哪裏的例外。