### PR TITLE
Allow `ClusterLogAllocation#migrationReplica` specify data directory

### DIFF
--- a/app/src/main/java/org/astraea/app/balancer/log/ClusterLogAllocation.java
+++ b/app/src/main/java/org/astraea/app/balancer/log/ClusterLogAllocation.java
@@ -27,8 +27,29 @@ import org.astraea.app.admin.TopicPartition;
  */
 public interface ClusterLogAllocation {
 
-  /** let specific broker leave the replica set and let another broker join the replica set. */
-  void migrateReplica(TopicPartition topicPartition, int atBroker, int toBroker);
+  /**
+   * let specific broker leave the replica set and let another broker join the replica set. Which
+   * data directory the migrated replica will be is up to the Kafka broker implementation to decide.
+   *
+   * @param topicPartition the topic/partition to perform replica migration
+   * @param atBroker the id of the broker about to remove
+   * @param toBroker the id of the broker about to replace the removed broker
+   */
+  default void migrateReplica(TopicPartition topicPartition, int atBroker, int toBroker) {
+    migrateReplica(topicPartition, atBroker, toBroker, null);
+  }
+
+  /**
+   * let specific broker leave the replica set and let another broker join the replica set.
+   *
+   * @param topicPartition the topic/partition to perform replica migration
+   * @param atBroker the id of the broker about to remove
+   * @param toBroker the id of the broker about to replace the removed broker
+   * @param toDir the absolute path of the data directory this migrated replica is supposed to be on
+   *     the destination broker, if {@code null} is specified then the data directory choice is left
+   *     up to the Kafka broker implementation.
+   */
+  void migrateReplica(TopicPartition topicPartition, int atBroker, int toBroker, String toDir);
 
   /** let specific follower log become the leader log of this topic/partition. */
   void letReplicaBecomeLeader(TopicPartition topicPartition, int followerReplica);

--- a/app/src/main/java/org/astraea/app/balancer/log/ClusterLogAllocation.java
+++ b/app/src/main/java/org/astraea/app/balancer/log/ClusterLogAllocation.java
@@ -38,6 +38,7 @@ public interface ClusterLogAllocation {
   default void migrateReplica(TopicPartition topicPartition, int atBroker, int toBroker) {
     migrateReplica(topicPartition, atBroker, toBroker, null);
   }
+  // TODO: Revise the log argument by TopicPartitionReplica, once #411 is merged
 
   /**
    * let specific broker leave the replica set and let another broker join the replica set.
@@ -50,12 +51,14 @@ public interface ClusterLogAllocation {
    *     up to the Kafka broker implementation.
    */
   void migrateReplica(TopicPartition topicPartition, int atBroker, int toBroker, String toDir);
+  // TODO: Revise the log argument by TopicPartitionReplica, once #411 is merged
 
   /** let specific follower log become the leader log of this topic/partition. */
   void letReplicaBecomeLeader(TopicPartition topicPartition, int followerReplica);
 
   /** change the data directory of specific log */
   void changeDataDirectory(TopicPartition topicPartition, int atBroker, String newPath);
+  // TODO: Revise the log argument by TopicPartitionReplica, once #411 is merged
 
   /** Retrieve the log placements of specific {@link TopicPartition}. */
   List<LogPlacement> logPlacements(TopicPartition topicPartition);

--- a/app/src/main/java/org/astraea/app/balancer/log/ClusterLogAllocation.java
+++ b/app/src/main/java/org/astraea/app/balancer/log/ClusterLogAllocation.java
@@ -56,10 +56,6 @@ public interface ClusterLogAllocation {
   /** let specific follower log become the leader log of this topic/partition. */
   void letReplicaBecomeLeader(TopicPartition topicPartition, int followerReplica);
 
-  /** change the data directory of specific log */
-  void changeDataDirectory(TopicPartition topicPartition, int atBroker, String newPath);
-  // TODO: Revise the log argument by TopicPartitionReplica, once #411 is merged
-
   /** Retrieve the log placements of specific {@link TopicPartition}. */
   List<LogPlacement> logPlacements(TopicPartition topicPartition);
 

--- a/app/src/main/java/org/astraea/app/balancer/log/LayeredClusterLogAllocation.java
+++ b/app/src/main/java/org/astraea/app/balancer/log/LayeredClusterLogAllocation.java
@@ -163,7 +163,7 @@ public class LayeredClusterLogAllocation implements ClusterLogAllocation {
 
   @Override
   public synchronized void migrateReplica(
-      TopicPartition topicPartition, int broker, int destinationBroker) {
+      TopicPartition topicPartition, int broker, int destinationBroker, String toDir) {
     ensureNotLocked();
 
     final List<LogPlacement> sourceLogPlacements = this.logPlacements(topicPartition);
@@ -187,7 +187,7 @@ public class LayeredClusterLogAllocation implements ClusterLogAllocation {
             .mapToObj(
                 index ->
                     index == sourceLogIndex
-                        ? LogPlacement.of(destinationBroker)
+                        ? LogPlacement.of(destinationBroker, toDir)
                         : sourceLogPlacements.get(index))
             .collect(Collectors.toUnmodifiableList()));
   }

--- a/app/src/main/java/org/astraea/app/balancer/log/LayeredClusterLogAllocation.java
+++ b/app/src/main/java/org/astraea/app/balancer/log/LayeredClusterLogAllocation.java
@@ -228,30 +228,6 @@ public class LayeredClusterLogAllocation implements ClusterLogAllocation {
   }
 
   @Override
-  public synchronized void changeDataDirectory(
-      TopicPartition topicPartition, int broker, String path) {
-    ensureNotLocked();
-
-    final List<LogPlacement> sourceLogPlacements = this.logPlacements(topicPartition);
-    if (sourceLogPlacements == null)
-      throw new IllegalMigrationException(
-          topicPartition.topic() + "-" + topicPartition.partition() + " no such topic/partition");
-
-    int sourceLogIndex = indexOfBroker(sourceLogPlacements, broker).orElse(-1);
-    if (sourceLogIndex == -1)
-      throw new IllegalMigrationException(
-          broker + " is not part of the replica set for " + topicPartition);
-
-    final var oldLog = this.logPlacements(topicPartition).get(sourceLogIndex);
-    final var newLog = LogPlacement.of(oldLog.broker(), path);
-    this.allocation.put(
-        topicPartition,
-        IntStream.range(0, sourceLogPlacements.size())
-            .mapToObj(index -> index == sourceLogIndex ? newLog : sourceLogPlacements.get(index))
-            .collect(Collectors.toUnmodifiableList()));
-  }
-
-  @Override
   public List<LogPlacement> logPlacements(TopicPartition topicPartition) {
     if (allocation.containsKey(topicPartition)) return allocation.get(topicPartition);
     else if (upperLayer != null) return upperLayer.logPlacements(topicPartition);

--- a/app/src/main/java/org/astraea/app/balancer/log/LayeredClusterLogAllocation.java
+++ b/app/src/main/java/org/astraea/app/balancer/log/LayeredClusterLogAllocation.java
@@ -176,11 +176,6 @@ public class LayeredClusterLogAllocation implements ClusterLogAllocation {
       throw new IllegalMigrationException(
           broker + " is not part of the replica set for " + topicPartition);
 
-    int destinationLogIndex = indexOfBroker(sourceLogPlacements, destinationBroker).orElse(-1);
-    if (destinationLogIndex != -1)
-      throw new IllegalArgumentException(
-          destinationBroker + " is already part of the replica set, no need to move");
-
     this.allocation.put(
         topicPartition,
         IntStream.range(0, sourceLogPlacements.size())

--- a/app/src/test/java/org/astraea/app/balancer/log/LayeredClusterLogAllocationTest.java
+++ b/app/src/test/java/org/astraea/app/balancer/log/LayeredClusterLogAllocationTest.java
@@ -169,10 +169,9 @@ class LayeredClusterLogAllocationTest {
     final var allocation = LayeredClusterLogAllocation.of(fakeClusterInfo);
     final var toModify = allocation.topicPartitionStream().findFirst().orElseThrow();
 
-    // TODO test CLA#migrateReplica(a,b,c,d)
-
     // can modify before lock
     Assertions.assertDoesNotThrow(() -> allocation.migrateReplica(toModify, 0, 9));
+    Assertions.assertDoesNotThrow(() -> allocation.migrateReplica(toModify, 0, 9, "somewhere"));
     Assertions.assertDoesNotThrow(() -> allocation.letReplicaBecomeLeader(toModify, 1));
 
     final var extended = LayeredClusterLogAllocation.of(allocation);
@@ -181,10 +180,13 @@ class LayeredClusterLogAllocationTest {
     Assertions.assertThrows(
         IllegalStateException.class, () -> allocation.migrateReplica(toModify, 9, 0));
     Assertions.assertThrows(
+        IllegalStateException.class, () -> allocation.migrateReplica(toModify, 0, 9, "somewhere"));
+    Assertions.assertThrows(
         IllegalStateException.class, () -> allocation.letReplicaBecomeLeader(toModify, 0));
 
     // the extended one can modify
     Assertions.assertDoesNotThrow(() -> extended.migrateReplica(toModify, 9, 0));
+    Assertions.assertDoesNotThrow(() -> extended.migrateReplica(toModify, 0, 9, "somewhere"));
     Assertions.assertDoesNotThrow(() -> extended.letReplicaBecomeLeader(toModify, 0));
   }
 }

--- a/app/src/test/java/org/astraea/app/balancer/log/LayeredClusterLogAllocationTest.java
+++ b/app/src/test/java/org/astraea/app/balancer/log/LayeredClusterLogAllocationTest.java
@@ -79,19 +79,32 @@ class LayeredClusterLogAllocationTest {
     final var fakeClusterInfo =
         ClusterInfoProvider.fakeClusterInfo(3, 1, 1, 1, (i) -> Set.of("topic"));
     final var clusterLogAllocation = LayeredClusterLogAllocation.of(fakeClusterInfo);
-    final var sourceTopicPartition = TopicPartition.of("topic", "0");
+    final var sourceTopicPartition0 = TopicPartition.of("topic", "0");
 
-    clusterLogAllocation.migrateReplica(sourceTopicPartition, 0, 1, dataDirectory);
+    clusterLogAllocation.migrateReplica(sourceTopicPartition0, 0, 1, dataDirectory);
 
     Assertions.assertEquals(
-        1, clusterLogAllocation.logPlacements(sourceTopicPartition).get(0).broker());
+        1, clusterLogAllocation.logPlacements(sourceTopicPartition0).get(0).broker());
     Assertions.assertEquals(
         dataDirectory,
         clusterLogAllocation
-            .logPlacements(sourceTopicPartition)
+            .logPlacements(sourceTopicPartition0)
             .get(0)
             .logDirectory()
             .orElse(null));
+
+    final var sourceTopicPartition1 = TopicPartition.of("topic", "0");
+    clusterLogAllocation.migrateReplica(sourceTopicPartition1, 1, 1, dataDirectory);
+    Assertions.assertEquals(
+        1, clusterLogAllocation.logPlacements(sourceTopicPartition1).get(0).broker());
+    Assertions.assertEquals(
+        dataDirectory,
+        clusterLogAllocation
+            .logPlacements(sourceTopicPartition1)
+            .get(0)
+            .logDirectory()
+            .orElse(null));
+
     Assertions.assertDoesNotThrow(() -> LayeredClusterLogAllocation.of(clusterLogAllocation));
   }
 

--- a/app/src/test/java/org/astraea/app/balancer/log/LayeredClusterLogAllocationTest.java
+++ b/app/src/test/java/org/astraea/app/balancer/log/LayeredClusterLogAllocationTest.java
@@ -171,8 +171,8 @@ class LayeredClusterLogAllocationTest {
 
     // can modify before lock
     Assertions.assertDoesNotThrow(() -> allocation.migrateReplica(toModify, 0, 9));
-    Assertions.assertDoesNotThrow(() -> allocation.migrateReplica(toModify, 0, 9, "somewhere"));
-    Assertions.assertDoesNotThrow(() -> allocation.letReplicaBecomeLeader(toModify, 1));
+    Assertions.assertDoesNotThrow(() -> allocation.migrateReplica(toModify, 1, 8, "somewhere"));
+    Assertions.assertDoesNotThrow(() -> allocation.letReplicaBecomeLeader(toModify, 2));
 
     final var extended = LayeredClusterLogAllocation.of(allocation);
 
@@ -186,7 +186,7 @@ class LayeredClusterLogAllocationTest {
 
     // the extended one can modify
     Assertions.assertDoesNotThrow(() -> extended.migrateReplica(toModify, 9, 0));
-    Assertions.assertDoesNotThrow(() -> extended.migrateReplica(toModify, 0, 9, "somewhere"));
+    Assertions.assertDoesNotThrow(() -> extended.migrateReplica(toModify, 8, 1, "somewhere"));
     Assertions.assertDoesNotThrow(() -> extended.letReplicaBecomeLeader(toModify, 0));
   }
 }


### PR DESCRIPTION
延續 https://github.com/skiptests/astraea/pull/412#issuecomment-1159626602

令 `ClusterLogAllocation#migrationReplica` 能夠指定要搬移到哪個 data directory，同時修改 `ShufflePlanGenerator` 的實作，使他能夠使用這個新的 API 來做產生計劃，這樣產生的計劃比較明確，能使後續 `CostFunction` 比較好做預測。