### PR TITLE
Enable to commit offsets manually

### DIFF
--- a/app/src/main/java/org/astraea/app/consumer/AssignedConsumer.java
+++ b/app/src/main/java/org/astraea/app/consumer/AssignedConsumer.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.app.consumer;
+
+/**
+ * This inherited consumer offers function related to partition assigment.
+ *
+ * @param <Key> key
+ * @param <Value> value
+ */
+public interface AssignedConsumer<Key, Value> extends Consumer<Key, Value> {}

--- a/app/src/main/java/org/astraea/app/consumer/PartitionsBuilder.java
+++ b/app/src/main/java/org/astraea/app/consumer/PartitionsBuilder.java
@@ -22,6 +22,7 @@ import static java.util.stream.Collectors.toList;
 import java.util.Map;
 import java.util.Set;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.astraea.app.admin.TopicPartition;
 
 public class PartitionsBuilder<Key, Value> extends Builder<Key, Value> {
@@ -102,8 +103,34 @@ public class PartitionsBuilder<Key, Value> extends Builder<Key, Value> {
     return this;
   }
 
+  @SuppressWarnings("unchecked")
   @Override
-  protected void assignOrSubscribe(Consumer<Key, Value> kafkaConsumer) {
+  public AssignedConsumer<Key, Value> build() {
+    var kafkaConsumer =
+        new KafkaConsumer<>(
+            configs,
+            Deserializer.of((Deserializer<Key>) keyDeserializer),
+            Deserializer.of((Deserializer<Value>) valueDeserializer));
     kafkaConsumer.assign(partitions.stream().map(TopicPartition::to).collect(toList()));
+
+    // this mode is not supported by kafka, so we have to calculate the offset first
+    if (distanceFromLatest > 0) {
+      var partitions = kafkaConsumer.assignment();
+      // 1) get the end offsets from all subscribed partitions
+      var endOffsets = kafkaConsumer.endOffsets(partitions);
+      // 2) calculate and then seek to the correct offset (end offset - recent offset)
+      endOffsets.forEach(
+          (tp, latest) -> kafkaConsumer.seek(tp, Math.max(0, latest - distanceFromLatest)));
+    }
+
+    return new AssignedConsumerImpl<>(kafkaConsumer);
+  }
+
+  private static class AssignedConsumerImpl<Key, Value> extends Builder.BaseConsumer<Key, Value>
+      implements AssignedConsumer<Key, Value> {
+
+    public AssignedConsumerImpl(Consumer<Key, Value> kafkaConsumer) {
+      super(kafkaConsumer);
+    }
   }
 }

--- a/app/src/main/java/org/astraea/app/consumer/SubscribedConsumer.java
+++ b/app/src/main/java/org/astraea/app/consumer/SubscribedConsumer.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.app.consumer;
+
+import java.time.Duration;
+
+/**
+ * This inherited consumer offers function related to consumer group.
+ *
+ * @param <Key> key
+ * @param <Value> value
+ */
+public interface SubscribedConsumer<Key, Value> extends Consumer<Key, Value> {
+
+  /**
+   * commit the consumed offsets right now.
+   *
+   * @param timeout to wait commit.
+   */
+  void commitOffsets(Duration timeout);
+}


### PR DESCRIPTION
這隻PR包含以下工作：
1. 新增`SubscribedConsumer` and `AssignedConsumer`用來表示不同的訂閱行為
2. `SubscribedConsumer`有額外的offset commit方法