### PR TITLE
Enable to remove all members/static members

### DIFF
--- a/app/src/main/java/org/astraea/app/admin/Admin.java
+++ b/app/src/main/java/org/astraea/app/admin/Admin.java
@@ -216,6 +216,15 @@ public interface Admin extends Closeable {
    */
   Map<String, Transaction> transactions(Set<String> transactionIds);
 
+  /** @param groupId to remove all (dynamic and static) members */
+  void removeAllMembers(String groupId);
+
+  /**
+   * @param groupId to remove static members
+   * @param members group instance id (static member)
+   */
+  void removeStaticMembers(String groupId, Set<String> members);
+
   @Override
   void close();
 }

--- a/app/src/main/java/org/astraea/app/admin/Builder.java
+++ b/app/src/main/java/org/astraea/app/admin/Builder.java
@@ -36,9 +36,11 @@ import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.ConsumerGroupListing;
 import org.apache.kafka.clients.admin.ListTopicsOptions;
 import org.apache.kafka.clients.admin.MemberDescription;
+import org.apache.kafka.clients.admin.MemberToRemove;
 import org.apache.kafka.clients.admin.NewPartitionReassignment;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.clients.admin.RemoveMembersFromConsumerGroupOptions;
 import org.apache.kafka.clients.admin.TransactionListing;
 import org.apache.kafka.common.ElectionType;
 import org.apache.kafka.common.TopicPartitionReplica;
@@ -550,6 +552,32 @@ public class Builder {
               admin.describeTransactions(transactionIds).all().get().entrySet().stream()
                   .collect(
                       Collectors.toMap(Map.Entry::getKey, e -> Transaction.from(e.getValue()))));
+    }
+
+    @Override
+    public void removeAllMembers(String groupId) {
+      Utils.packException(
+          () ->
+              admin
+                  .removeMembersFromConsumerGroup(
+                      groupId, new RemoveMembersFromConsumerGroupOptions())
+                  .all()
+                  .get());
+    }
+
+    @Override
+    public void removeStaticMembers(String groupId, Set<String> members) {
+      Utils.packException(
+          () ->
+              admin
+                  .removeMembersFromConsumerGroup(
+                      groupId,
+                      new RemoveMembersFromConsumerGroupOptions(
+                          members.stream()
+                              .map(MemberToRemove::new)
+                              .collect(Collectors.toUnmodifiableList())))
+                  .all()
+                  .get());
     }
   }
 

--- a/app/src/main/java/org/astraea/app/consumer/Builder.java
+++ b/app/src/main/java/org/astraea/app/consumer/Builder.java
@@ -39,7 +39,8 @@ abstract class Builder<Key, Value> {
    * @return this builder
    */
   public Builder<Key, Value> fromBeginning() {
-    return config(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    this.configs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    return this;
   }
 
   /**
@@ -48,7 +49,8 @@ abstract class Builder<Key, Value> {
    * @return this builder
    */
   public Builder<Key, Value> fromLatest() {
-    return config(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+    this.configs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+    return this;
   }
 
   /**
@@ -76,23 +78,15 @@ abstract class Builder<Key, Value> {
     return (Builder<Key, NewValue>) this;
   }
 
-  public Builder<Key, Value> config(String key, String value) {
-    this.configs.put(key, value);
-    return this;
-  }
-
-  public Builder<Key, Value> configs(Map<String, String> configs) {
-    this.configs.putAll(configs);
-    return this;
-  }
-
   public Builder<Key, Value> bootstrapServers(String bootstrapServers) {
-    return config(
+    this.configs.put(
         ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, Objects.requireNonNull(bootstrapServers));
+    return this;
   }
 
   public Builder<Key, Value> isolation(Isolation isolation) {
-    return config(ConsumerConfig.ISOLATION_LEVEL_CONFIG, isolation.nameOfKafka());
+    this.configs.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, isolation.nameOfKafka());
+    return this;
   }
 
   /** @return consumer instance. The different builders may return inherited consumer interface. */

--- a/app/src/main/java/org/astraea/app/consumer/PartitionsBuilder.java
+++ b/app/src/main/java/org/astraea/app/consumer/PartitionsBuilder.java
@@ -79,15 +79,13 @@ public class PartitionsBuilder<Key, Value> extends Builder<Key, Value> {
     return (PartitionsBuilder<Key, NewValue>) super.valueDeserializer(valueDeserializer);
   }
 
-  @Override
   public PartitionsBuilder<Key, Value> config(String key, String value) {
-    super.config(key, value);
+    this.configs.put(key, value);
     return this;
   }
 
-  @Override
   public PartitionsBuilder<Key, Value> configs(Map<String, String> configs) {
-    super.configs(configs);
+    this.configs.putAll(configs);
     return this;
   }
 

--- a/app/src/main/java/org/astraea/app/consumer/SubscribedConsumer.java
+++ b/app/src/main/java/org/astraea/app/consumer/SubscribedConsumer.java
@@ -17,6 +17,7 @@
 package org.astraea.app.consumer;
 
 import java.time.Duration;
+import java.util.Optional;
 
 /**
  * This inherited consumer offers function related to consumer group.
@@ -32,4 +33,13 @@ public interface SubscribedConsumer<Key, Value> extends Consumer<Key, Value> {
    * @param timeout to wait commit.
    */
   void commitOffsets(Duration timeout);
+
+  /** @return the group id including this consumer */
+  String groupId();
+
+  /** @return the member id used by this consumer */
+  String memberId();
+
+  /** @return group instance id (static member) */
+  Optional<String> groupInstanceId();
 }


### PR DESCRIPTION
這邊新增兩個方法給admin
1. 刪除所有members (static and dynamic)
2. 刪除static members

kafka目前不支援刪除dynamic members :(