### PR TITLE
Enable to list reassignment by Admin

### DIFF
--- a/app/src/main/java/org/astraea/app/admin/Admin.java
+++ b/app/src/main/java/org/astraea/app/admin/Admin.java
@@ -232,6 +232,23 @@ public interface Admin extends Closeable {
    */
   void removeStaticMembers(String groupId, Set<String> members);
 
+  /**
+   * Get the reassignments of all topics.
+   *
+   * @return reassignment
+   */
+  default Map<TopicPartition, Reassignment> reassignments() {
+    return reassignments(topicNames());
+  }
+
+  /**
+   * Get the reassignments of topics. It returns nothing if the partitions are not migrating.
+   *
+   * @param topics to search
+   * @return reassignment
+   */
+  Map<TopicPartition, Reassignment> reassignments(Set<String> topics);
+
   @Override
   void close();
 }

--- a/app/src/main/java/org/astraea/app/admin/Builder.java
+++ b/app/src/main/java/org/astraea/app/admin/Builder.java
@@ -612,17 +612,15 @@ public class Builder {
 
       var result =
           new HashMap<
-              TopicPartition,
-              Map.Entry<List<Reassignment.Location>, List<Reassignment.Location>>>();
+              TopicPartition, Map.Entry<Set<Reassignment.Location>, Set<Reassignment.Location>>>();
 
       dirs.forEach(
           (replica, logDir) -> {
             var brokerId = replica.brokerId();
             var tp = new TopicPartition(replica.topic(), replica.partition());
             var ls =
-                result.computeIfAbsent(
-                    tp, ignored -> Map.entry(new ArrayList<>(), new ArrayList<>()));
-            // case 0: the replica is moved from a folder to another folder (in the same node)
+                result.computeIfAbsent(tp, ignored -> Map.entry(new HashSet<>(), new HashSet<>()));
+            // the replica is moved from a folder to another folder (in the same node)
             if (logDir.getFutureReplicaLogDir() != null)
               ls.getValue()
                   .add(new Reassignment.Location(brokerId, logDir.getFutureReplicaLogDir()));
@@ -647,8 +645,8 @@ public class Builder {
                   Map.Entry::getKey,
                   e ->
                       new Reassignment(
-                          Collections.unmodifiableList(e.getValue().getKey()),
-                          Collections.unmodifiableList(e.getValue().getValue()))));
+                          Collections.unmodifiableSet(e.getValue().getKey()),
+                          Collections.unmodifiableSet(e.getValue().getValue()))));
     }
   }
 

--- a/app/src/main/java/org/astraea/app/admin/Builder.java
+++ b/app/src/main/java/org/astraea/app/admin/Builder.java
@@ -577,6 +577,79 @@ public class Builder {
                   .all()
                   .get());
     }
+
+    @Override
+    public Map<TopicPartition, Reassignment> reassignments(Set<String> topics) {
+      var assignments =
+          Utils.packException(
+              () ->
+                  admin
+                      .listPartitionReassignments(
+                          partitions(topics).stream()
+                              .map(TopicPartition::to)
+                              .collect(Collectors.toSet()))
+                      .reassignments()
+                      .get());
+
+      var dirs =
+          Utils.packException(
+              () ->
+                  admin
+                      .describeReplicaLogDirs(
+                          replicas(topics).entrySet().stream()
+                              .flatMap(
+                                  e ->
+                                      e.getValue().stream()
+                                          .map(
+                                              r ->
+                                                  new org.apache.kafka.common.TopicPartitionReplica(
+                                                      e.getKey().topic(),
+                                                      e.getKey().partition(),
+                                                      r.broker())))
+                              .collect(Collectors.toUnmodifiableList()))
+                      .all()
+                      .get());
+
+      var result =
+          new HashMap<
+              TopicPartition,
+              Map.Entry<List<Reassignment.Location>, List<Reassignment.Location>>>();
+
+      dirs.forEach(
+          (replica, logDir) -> {
+            var brokerId = replica.brokerId();
+            var tp = new TopicPartition(replica.topic(), replica.partition());
+            var ls =
+                result.computeIfAbsent(
+                    tp, ignored -> Map.entry(new ArrayList<>(), new ArrayList<>()));
+            // case 0: the replica is moved from a folder to another folder (in the same node)
+            if (logDir.getFutureReplicaLogDir() != null)
+              ls.getValue()
+                  .add(new Reassignment.Location(brokerId, logDir.getFutureReplicaLogDir()));
+            if (logDir.getCurrentReplicaLogDir() != null) {
+              var assignment = assignments.get(TopicPartition.to(tp));
+              // the replica is moved from a node to another node
+              if (assignment != null && assignment.addingReplicas().contains(brokerId)) {
+                ls.getValue()
+                    .add(new Reassignment.Location(brokerId, logDir.getCurrentReplicaLogDir()));
+              } else {
+                ls.getKey()
+                    .add(new Reassignment.Location(brokerId, logDir.getCurrentReplicaLogDir()));
+              }
+            }
+          });
+
+      return result.entrySet().stream()
+          // empty "to" means there is no reassignment
+          .filter(e -> !e.getValue().getValue().isEmpty())
+          .collect(
+              Collectors.toMap(
+                  Map.Entry::getKey,
+                  e ->
+                      new Reassignment(
+                          Collections.unmodifiableList(e.getValue().getKey()),
+                          Collections.unmodifiableList(e.getValue().getValue()))));
+    }
   }
 
   private static class ConfigImpl implements Config {

--- a/app/src/main/java/org/astraea/app/admin/Reassignment.java
+++ b/app/src/main/java/org/astraea/app/admin/Reassignment.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.app.admin;
+
+import java.util.Collection;
+import java.util.Objects;
+
+public class Reassignment {
+  private final Collection<Location> from;
+  private final Collection<Location> to;
+
+  Reassignment(Collection<Location> from, Collection<Location> to) {
+    this.from = from;
+    this.to = to;
+  }
+
+  /** @return the partition locations before migration */
+  public Collection<Location> from() {
+    return from;
+  }
+
+  /** @return the partition locations after migration */
+  public Collection<Location> to() {
+    return to;
+  }
+
+  @Override
+  public String toString() {
+    return "Reassignment{" + "from=" + from + ", to=" + to + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Reassignment that = (Reassignment) o;
+    return Objects.equals(from, that.from) && Objects.equals(to, that.to);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(from, to);
+  }
+
+  public static class Location {
+    private final int broker;
+    private final String path;
+
+    public Location(int broker, String path) {
+      this.broker = broker;
+      this.path = Objects.requireNonNull(path);
+    }
+
+    public int broker() {
+      return broker;
+    }
+
+    public String path() {
+      return path;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      Location location = (Location) o;
+      return broker == location.broker && path.equals(location.path);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(broker, path);
+    }
+
+    @Override
+    public String toString() {
+      return "Location{" + "broker=" + broker + ", path='" + path + '\'' + '}';
+    }
+  }
+}

--- a/app/src/main/java/org/astraea/app/common/Utils.java
+++ b/app/src/main/java/org/astraea/app/common/Utils.java
@@ -134,11 +134,24 @@ public final class Utils {
    * @param done a flag indicating the result.
    */
   public static void waitFor(Supplier<Boolean> done, Duration timeout) {
+    waitForNonNull(() -> done.get() ? "good" : null, timeout);
+  }
+
+  /**
+   * loop the supplier until it returns non-null value
+   *
+   * @param supplier to loop
+   * @param timeout to break the loop
+   * @param <T> returned type
+   * @return value from supplier
+   */
+  public static <T> T waitForNonNull(Supplier<T> supplier, Duration timeout) {
     var endTime = System.currentTimeMillis() + timeout.toMillis();
     Exception lastError = null;
     while (System.currentTimeMillis() <= endTime)
       try {
-        if (done.get()) return;
+        var r = supplier.get();
+        if (r != null) return r;
         TimeUnit.SECONDS.sleep(1);
       } catch (Exception e) {
         lastError = e;


### PR DESCRIPTION
新增`Admin#reassignments`用來列舉目前的搬移狀況，包含兩種例子：

1. 節點之間的搬移
2. 目錄之間的搬移