### PR TITLE
Fix incorrect check in `Migrator#moveTo`

### DIFF
--- a/app/src/main/java/org/astraea/app/admin/Builder.java
+++ b/app/src/main/java/org/astraea/app/admin/Builder.java
@@ -826,11 +826,13 @@ public class Builder {
               .get(topicPartition.topic())
               .partitions()
               .get(topicPartition.partition())
-              .replicas();
-      var notHere =
-          currentReplicas.stream()
+              .replicas()
+              .stream()
               .map(Node::id)
-              .filter(id -> !brokerFolders.containsKey(id))
+              .collect(Collectors.toUnmodifiableSet());
+      var notHere =
+          brokerFolders.keySet().stream()
+              .filter(id -> !currentReplicas.contains(id))
               .collect(Collectors.toUnmodifiableSet());
 
       if (!notHere.isEmpty())

--- a/app/src/test/java/org/astraea/app/admin/AdminTest.java
+++ b/app/src/test/java/org/astraea/app/admin/AdminTest.java
@@ -322,6 +322,22 @@ public class AdminTest extends RequireBrokerCluster {
   }
 
   @Test
+  void testPartialMoveToArgument() throws InterruptedException {
+    // arrange
+    try (Admin admin = Admin.of(bootstrapServers())) {
+      var topic = Utils.randomString();
+      admin.creator().topic(topic).numberOfPartitions(1).numberOfReplicas((short) 3).create();
+      TimeUnit.SECONDS.sleep(1);
+
+      // act, assert
+      var replica0 = 0;
+      var folder0 = logFolders().get(replica0).iterator().next();
+      Assertions.assertDoesNotThrow(
+          () -> admin.migrator().partition(topic, 0).moveTo(Map.of(replica0, folder0)));
+    }
+  }
+
+  @Test
   @DisabledOnOs(WINDOWS)
   void testMigrateAllPartitions() throws InterruptedException {
     var topicName = "testMigrateAllPartitions";

--- a/app/src/test/java/org/astraea/app/admin/AdminTest.java
+++ b/app/src/test/java/org/astraea/app/admin/AdminTest.java
@@ -328,12 +328,28 @@ public class AdminTest extends RequireBrokerCluster {
       var topic = Utils.randomString();
       admin.creator().topic(topic).numberOfPartitions(1).numberOfReplicas((short) 3).create();
       TimeUnit.SECONDS.sleep(1);
+      var replica0 = 0;
+      var replica1 = 1;
+      var replica2 = 2;
+      var folder0 = logFolders().get(replica0).iterator().next();
+      var folder1 = logFolders().get(replica1).iterator().next();
+      var folder2 = logFolders().get(replica2).iterator().next();
 
       // act, assert
-      var replica0 = 0;
-      var folder0 = logFolders().get(replica0).iterator().next();
       Assertions.assertDoesNotThrow(
           () -> admin.migrator().partition(topic, 0).moveTo(Map.of(replica0, folder0)));
+      Assertions.assertDoesNotThrow(
+          () ->
+              admin
+                  .migrator()
+                  .partition(topic, 0)
+                  .moveTo(Map.of(replica0, folder0, replica1, folder1)));
+      Assertions.assertDoesNotThrow(
+          () ->
+              admin
+                  .migrator()
+                  .partition(topic, 0)
+                  .moveTo(Map.of(replica0, folder0, replica1, folder1, replica2, folder2)));
     }
   }
 


### PR DESCRIPTION
#440 中對 `Migrator#moveTo` 實作一些檢查，確保要進行 data directory 搬移的對象是當前 replica list 的一份子。

不過這個檢查寫錯了

* 我們要確保的是**進行 data directory 搬移的對象是當前 replica list 的一份子**
* 但是被我寫成**所有 replica list 的成員都要被搬移**。

假設現在有個 partition 有 `[0,1,2]` 這個 replica list，假設我只想對 0 進行 data directory 搬移，則當前的檢查會拋出 `[1,2]` 並非 replica list 的一部分這個錯誤，只有傳入的 map 指定對 0,1,2 這三個 broker 同時做 data directory 的搬移才不會發生錯誤。

這個 PR 修正這些檢查