### PR TITLE
Introduce NodeLatencyCost depending on local metrics to be default co…

### DIFF
--- a/app/src/main/java/org/astraea/app/cost/NodeLatencyCost.java
+++ b/app/src/main/java/org/astraea/app/cost/NodeLatencyCost.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.app.cost;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.astraea.app.admin.ClusterInfo;
+import org.astraea.app.metrics.HasBeanObject;
+import org.astraea.app.metrics.KafkaMetrics;
+import org.astraea.app.metrics.collector.Fetcher;
+import org.astraea.app.metrics.producer.HasProducerNodeMetrics;
+
+public class NodeLatencyCost implements HasBrokerCost {
+
+  @Override
+  public BrokerCost brokerCost(ClusterInfo clusterInfo) {
+    var result =
+        clusterInfo.clusterBean().all().entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey,
+                    e ->
+                        e.getValue().stream()
+                            .filter(b -> b instanceof HasProducerNodeMetrics)
+                            .map(b -> (HasProducerNodeMetrics) b)
+                            .mapToDouble(HasProducerNodeMetrics::requestLatencyAvg)
+                            .sum()));
+    return () -> result;
+  }
+
+  @Override
+  public Optional<Fetcher> fetcher() {
+    return Optional.of(
+        client ->
+            KafkaMetrics.Producer.nodes(client).values().stream()
+                .map(b -> (HasBeanObject) b)
+                .collect(Collectors.toUnmodifiableList()));
+  }
+}

--- a/app/src/test/java/org/astraea/app/cost/NodeLatencyCostTest.java
+++ b/app/src/test/java/org/astraea/app/cost/NodeLatencyCostTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.app.cost;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.astraea.app.admin.Admin;
+import org.astraea.app.admin.ClusterBean;
+import org.astraea.app.admin.ClusterInfo;
+import org.astraea.app.common.Utils;
+import org.astraea.app.metrics.HasBeanObject;
+import org.astraea.app.metrics.KafkaMetrics;
+import org.astraea.app.metrics.jmx.MBeanClient;
+import org.astraea.app.producer.Producer;
+import org.astraea.app.service.RequireBrokerCluster;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class NodeLatencyCostTest extends RequireBrokerCluster {
+
+  @Test
+  void testCost() {
+    var brokerId = brokerIds().iterator().next();
+    var topic = Utils.randomString(10);
+    try (var admin = Admin.of(bootstrapServers());
+        var producer = Producer.of(bootstrapServers())) {
+      admin.creator().topic(topic).numberOfPartitions(1).create();
+      Utils.sleep(Duration.ofSeconds(3));
+      producer.sender().topic(Utils.randomString(10)).value(new byte[100]).run();
+      producer.flush();
+
+      var beans = KafkaMetrics.Producer.node(MBeanClient.local(), brokerId);
+      var clusterBean =
+          ClusterBean.of(
+              Map.of(
+                  brokerId,
+                  beans.values().stream()
+                      .map(b -> (HasBeanObject) b)
+                      .collect(Collectors.toUnmodifiableList())));
+      var clusterInfo = Mockito.mock(ClusterInfo.class);
+      Mockito.when(clusterInfo.clusterBean()).thenReturn(clusterBean);
+
+      var function = new NodeLatencyCost();
+      var cost = function.brokerCost(clusterInfo);
+      Assertions.assertEquals(1, cost.value().size());
+      Assertions.assertNotNull(cost.value().get(brokerId));
+    }
+  }
+}

--- a/app/src/test/java/org/astraea/app/metrics/producer/HasProducerNodeMetricsTest.java
+++ b/app/src/test/java/org/astraea/app/metrics/producer/HasProducerNodeMetricsTest.java
@@ -16,37 +16,90 @@
  */
 package org.astraea.app.metrics.producer;
 
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import org.astraea.app.admin.Admin;
+import org.astraea.app.admin.TopicPartition;
 import org.astraea.app.common.Utils;
 import org.astraea.app.metrics.KafkaMetrics;
 import org.astraea.app.metrics.jmx.MBeanClient;
 import org.astraea.app.producer.Producer;
-import org.astraea.app.service.RequireSingleBrokerCluster;
+import org.astraea.app.service.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class HasProducerNodeMetricsTest extends RequireSingleBrokerCluster {
+public class HasProducerNodeMetricsTest extends RequireBrokerCluster {
 
   @Test
-  void testAttributes() throws ExecutionException, InterruptedException {
+  void testSingleBroker() throws ExecutionException, InterruptedException {
     var topic = Utils.randomString(10);
-    try (var producer = Producer.of(bootstrapServers())) {
+    try (var admin = Admin.of(bootstrapServers());
+        var producer = Producer.of(bootstrapServers())) {
+      admin.creator().topic(topic).numberOfPartitions(1).create();
+      Utils.sleep(Duration.ofSeconds(3));
+      var owner = admin.replicas(Set.of(topic)).get(new TopicPartition(topic, 0)).get(0).broker();
       producer.sender().topic(topic).run().toCompletableFuture().get();
-      var metrics = KafkaMetrics.Producer.node(MBeanClient.local(), brokerIds().iterator().next());
+      var metrics = KafkaMetrics.Producer.node(MBeanClient.local(), owner);
       Assertions.assertEquals(1, metrics.size());
-      var producerNodeMetrics = metrics.get("producer-1");
-      Assertions.assertNotEquals(0D, producerNodeMetrics.incomingByteRate());
-      Assertions.assertNotEquals(0D, producerNodeMetrics.incomingByteTotal());
-      Assertions.assertNotEquals(0D, producerNodeMetrics.outgoingByteRate());
-      Assertions.assertNotEquals(0D, producerNodeMetrics.outgoingByteTotal());
-      Assertions.assertNotEquals(0D, producerNodeMetrics.requestLatencyAvg());
-      Assertions.assertNotEquals(0D, producerNodeMetrics.requestLatencyMax());
-      Assertions.assertNotEquals(0D, producerNodeMetrics.requestRate());
-      Assertions.assertNotEquals(0D, producerNodeMetrics.requestSizeAvg());
-      Assertions.assertNotEquals(0D, producerNodeMetrics.requestSizeMax());
-      Assertions.assertNotEquals(0D, producerNodeMetrics.requestTotal());
-      Assertions.assertNotEquals(0D, producerNodeMetrics.responseRate());
-      Assertions.assertNotEquals(0D, producerNodeMetrics.responseTotal());
+      check(metrics.get("producer-1"));
     }
+  }
+
+  @Test
+  void testMultiBrokers() throws ExecutionException, InterruptedException {
+    var topic = Utils.randomString(10);
+    try (var admin = Admin.of(bootstrapServers());
+        var producer = Producer.of(bootstrapServers())) {
+      admin.creator().topic(topic).numberOfPartitions(3).create();
+      Utils.sleep(Duration.ofSeconds(3));
+      var owner = admin.replicas(Set.of(topic)).get(new TopicPartition(topic, 0)).get(0).broker();
+      producer
+          .sender()
+          .topic(topic)
+          .value(new byte[10])
+          .partition(0)
+          .run()
+          .toCompletableFuture()
+          .get();
+      producer
+          .sender()
+          .topic(topic)
+          .value(new byte[10])
+          .partition(1)
+          .run()
+          .toCompletableFuture()
+          .get();
+      producer
+          .sender()
+          .topic(topic)
+          .value(new byte[10])
+          .partition(2)
+          .run()
+          .toCompletableFuture()
+          .get();
+      var metrics = KafkaMetrics.Producer.nodes(MBeanClient.local());
+      Assertions.assertNotEquals(1, metrics.size());
+      Assertions.assertTrue(metrics.keySet().containsAll(brokerIds()));
+      metrics.values().stream()
+          .flatMap(Collection::stream)
+          .forEach(HasProducerNodeMetricsTest::check);
+    }
+  }
+
+  private static void check(HasProducerNodeMetrics metrics) {
+    Assertions.assertNotEquals(0D, metrics.incomingByteRate());
+    Assertions.assertNotEquals(0D, metrics.incomingByteTotal());
+    Assertions.assertNotEquals(0D, metrics.outgoingByteRate());
+    Assertions.assertNotEquals(0D, metrics.outgoingByteTotal());
+    Assertions.assertNotEquals(0D, metrics.requestLatencyAvg());
+    Assertions.assertNotEquals(0D, metrics.requestLatencyMax());
+    Assertions.assertNotEquals(0D, metrics.requestRate());
+    Assertions.assertNotEquals(0D, metrics.requestSizeAvg());
+    Assertions.assertNotEquals(0D, metrics.requestSizeMax());
+    Assertions.assertNotEquals(0D, metrics.requestTotal());
+    Assertions.assertNotEquals(0D, metrics.responseRate());
+    Assertions.assertNotEquals(0D, metrics.responseTotal());
   }
 }

--- a/app/src/test/java/org/astraea/app/partitioner/RoundRobinTest.java
+++ b/app/src/test/java/org/astraea/app/partitioner/RoundRobinTest.java
@@ -25,10 +25,10 @@ import org.junit.jupiter.api.Test;
 public class RoundRobinTest {
 
   @Test
-  void testSmoothWeighted() {
-    var weight = Map.of(0, 10D, 1, 5D);
+  void testSmoothRoundRobin() {
+    var scores = Map.of(0, 10D, 1, 5D);
 
-    var rr = RoundRobin.smoothWeighted(weight);
+    var rr = RoundRobin.smooth(scores);
 
     // nothing to pick
     Assertions.assertEquals(Optional.empty(), rr.next(Set.of()));
@@ -39,7 +39,7 @@ public class RoundRobinTest {
     Assertions.assertEquals(Optional.of(1), rr.next(Set.of(1)));
 
     // reset
-    rr = RoundRobin.smoothWeighted(weight);
+    rr = RoundRobin.smooth(scores);
     Assertions.assertEquals(Optional.of(0), rr.next(Set.of(0, 1)));
     Assertions.assertEquals(Optional.of(1), rr.next(Set.of(0, 1)));
     Assertions.assertEquals(Optional.of(0), rr.next(Set.of(0, 1)));

--- a/app/src/test/java/org/astraea/app/partitioner/StrictCostDispatcherTest.java
+++ b/app/src/test/java/org/astraea/app/partitioner/StrictCostDispatcherTest.java
@@ -273,4 +273,11 @@ public class StrictCostDispatcherTest {
     Assertions.assertEquals(1, dispatcher.functions.size());
     Assertions.assertEquals(1, dispatcher.receivers.size());
   }
+
+  @Test
+  void testCostToScore() {
+    var cost = Map.of(1, 100D, 2, 10D);
+    var score = StrictCostDispatcher.costToScore(cost);
+    Assertions.assertTrue(score.get(2) > score.get(1));
+  }
 }

--- a/app/src/test/java/org/astraea/app/partitioner/StrictCostDispatcherTest.java
+++ b/app/src/test/java/org/astraea/app/partitioner/StrictCostDispatcherTest.java
@@ -209,26 +209,27 @@ public class StrictCostDispatcherTest {
     Mockito.when(clusterInfo.availableReplicaLeaders(Mockito.anyString()))
         .thenReturn(List.of(replicaInfo0, replicaInfo1, replicaInfo2));
     Mockito.when(clusterInfo.clusterBean()).thenReturn(ClusterBean.of(Map.of()));
-    // there is no receivers by default
-    Assertions.assertEquals(0, dispatcher.receivers.size());
+    // there is one local receiver by default
+    Assertions.assertEquals(1, dispatcher.receivers.size());
+    Assertions.assertEquals(-1, dispatcher.receivers.keySet().iterator().next());
 
     // generate two receivers since there are two brokers (hosting three replicas)
     dispatcher.partition("topic", new byte[0], new byte[0], clusterInfo);
-    Assertions.assertEquals(2, dispatcher.receivers.size());
+    Assertions.assertEquals(3, dispatcher.receivers.size());
     Assertions.assertEquals(2, count.get());
 
     // all brokers have receivers already so no new receiver is born
     dispatcher.partition("topic", new byte[0], new byte[0], clusterInfo);
-    Assertions.assertEquals(2, dispatcher.receivers.size());
+    Assertions.assertEquals(3, dispatcher.receivers.size());
     Assertions.assertEquals(2, count.get());
   }
 
   @Test
   void testEmptyJmxPort() {
     var dispatcher = new StrictCostDispatcher();
-    Assertions.assertThrows(
-        IllegalArgumentException.class,
-        () -> dispatcher.configure(Map.of(new ThroughputCost(), 1D), Optional.empty(), Map.of()));
+
+    // pass due to local mbean
+    dispatcher.configure(Map.of(new ThroughputCost(), 1D), Optional.empty(), Map.of());
 
     // pass due to default port
     dispatcher.configure(Map.of(new ThroughputCost(), 1D), Optional.of(111), Map.of());
@@ -268,7 +269,8 @@ public class StrictCostDispatcherTest {
   @Test
   void testDefaultFunction() {
     var dispatcher = new StrictCostDispatcher();
-    dispatcher.configure(Map.of(), Optional.empty(), Map.of());
+    dispatcher.configure(Configuration.of(Map.of()));
     Assertions.assertEquals(1, dispatcher.functions.size());
+    Assertions.assertEquals(1, dispatcher.receivers.size());
   }
 }


### PR DESCRIPTION
1. `NodeLatencyCost`透過本地producer metrics來衡量節點延遲
2. `StrictCostDispatcher`的預設cost function改用`NodeLatencyCost`