### PR TITLE
Allow to ignore jmx port and NodeLatencyCost can't parse beans

### DIFF
--- a/app/src/main/java/org/astraea/app/cost/NodeLatencyCost.java
+++ b/app/src/main/java/org/astraea/app/cost/NodeLatencyCost.java
@@ -16,6 +16,7 @@
  */
 package org.astraea.app.cost;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -48,6 +49,7 @@ public class NodeLatencyCost implements HasBrokerCost {
     return Optional.of(
         client ->
             KafkaMetrics.Producer.nodes(client).values().stream()
+                .flatMap(Collection::stream)
                 .map(b -> (HasBeanObject) b)
                 .collect(Collectors.toUnmodifiableList()));
   }

--- a/app/src/test/java/org/astraea/app/cost/NodeLatencyCostTest.java
+++ b/app/src/test/java/org/astraea/app/cost/NodeLatencyCostTest.java
@@ -17,6 +17,7 @@
 package org.astraea.app.cost;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.astraea.app.admin.Admin;
@@ -25,6 +26,7 @@ import org.astraea.app.admin.ClusterInfo;
 import org.astraea.app.common.Utils;
 import org.astraea.app.metrics.HasBeanObject;
 import org.astraea.app.metrics.KafkaMetrics;
+import org.astraea.app.metrics.jmx.BeanObject;
 import org.astraea.app.metrics.jmx.MBeanClient;
 import org.astraea.app.producer.Producer;
 import org.astraea.app.service.RequireBrokerCluster;
@@ -61,5 +63,19 @@ public class NodeLatencyCostTest extends RequireBrokerCluster {
       Assertions.assertEquals(1, cost.value().size());
       Assertions.assertNotNull(cost.value().get(brokerId));
     }
+  }
+
+  @Test
+  void testFetcher() {
+    var function = new NodeLatencyCost();
+    var client = Mockito.mock(MBeanClient.class);
+    Mockito.when(client.queryBeans(Mockito.any()))
+        .thenReturn(
+            List.of(
+                new BeanObject("a", Map.of("node-id", "node-10"), Map.of()),
+                new BeanObject("a", Map.of("node-id", "node-10"), Map.of()),
+                new BeanObject("a", Map.of("node-id", "node-11"), Map.of())));
+    var result = function.fetcher().get().fetch(client);
+    Assertions.assertEquals(3, result.size());
   }
 }

--- a/app/src/test/java/org/astraea/app/partitioner/StrictCostDispatcherTest.java
+++ b/app/src/test/java/org/astraea/app/partitioner/StrictCostDispatcherTest.java
@@ -18,7 +18,6 @@ package org.astraea.app.partitioner;
 
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.astraea.app.admin.ClusterBean;
@@ -53,10 +52,9 @@ public class StrictCostDispatcherTest {
   void testJmxPort() {
     try (var dispatcher = new StrictCostDispatcher()) {
       dispatcher.configure(Configuration.of(Map.of()));
-      Assertions.assertThrows(
-          NoSuchElementException.class, () -> dispatcher.jmxPortGetter.apply(0));
+      Assertions.assertEquals(Optional.empty(), dispatcher.jmxPortGetter.apply(0));
       dispatcher.configure(Configuration.of(Map.of(StrictCostDispatcher.JMX_PORT, "12345")));
-      Assertions.assertEquals(12345, dispatcher.jmxPortGetter.apply(0));
+      Assertions.assertEquals(Optional.of(12345), dispatcher.jmxPortGetter.apply(0));
     }
   }
 


### PR DESCRIPTION
修復兩個bugs:

1. JMX port沒定義時會噴出錯誤
2. NodeLatencyCost 無法處理多個beans