### PR TITLE
Cache the cluster info to reduce the cost of converting kafka cluster…

### DIFF
--- a/app/src/main/java/org/astraea/app/admin/ClusterInfo.java
+++ b/app/src/main/java/org/astraea/app/admin/ClusterInfo.java
@@ -27,11 +27,35 @@ import org.astraea.app.metrics.HasBeanObject;
 
 public interface ClusterInfo {
 
+  /**
+   * convert the kafka ClusterInfo to our ClusterInfo. All data structure are converted immediately,
+   * so you should cache the result if the performance is critical
+   *
+   * @param cluster kafka ClusterInfo
+   * @return astraea ClusterInfo
+   */
   static ClusterInfo of(org.apache.kafka.common.Cluster cluster) {
+    var nodes = cluster.nodes().stream().map(NodeInfo::of).collect(Collectors.toUnmodifiableList());
+    var topics = cluster.topics();
+    var replicas =
+        topics.stream()
+            .flatMap(t -> cluster.availablePartitionsForTopic(t).stream())
+            .flatMap(p -> ReplicaInfo.of(p).stream())
+            .collect(Collectors.toUnmodifiableList());
+    var availableReplicas = replicas.stream().collect(Collectors.groupingBy(ReplicaInfo::topic));
+    var availableReplicaLeaders =
+        availableReplicas.entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey,
+                    e ->
+                        e.getValue().stream()
+                            .filter(ReplicaInfo::isLeader)
+                            .collect(Collectors.toUnmodifiableList())));
     return new ClusterInfo() {
       @Override
       public List<NodeInfo> nodes() {
-        return cluster.nodes().stream().map(NodeInfo::of).collect(Collectors.toUnmodifiableList());
+        return nodes;
       }
 
       @Override
@@ -41,48 +65,22 @@ public interface ClusterInfo {
       }
 
       public Set<String> topics() {
-        return cluster.topics();
+        return topics;
       }
 
       @Override
       public List<ReplicaInfo> availableReplicaLeaders(String topic) {
-        var info =
-            cluster.availablePartitionsForTopic(topic).stream()
-                .map(ReplicaInfo::of)
-                .map(
-                    replicas ->
-                        replicas.stream().filter(ReplicaInfo::isLeader).findFirst().orElseThrow())
-                .collect(Collectors.toUnmodifiableList());
-        if (info.isEmpty())
-          throw new NoSuchElementException(
-              "This ClusterInfo have no information about topic \"" + topic + "\"");
-        return info;
+        return availableReplicaLeaders.getOrDefault(topic, List.of());
       }
 
       @Override
       public List<ReplicaInfo> availableReplicas(String topic) {
-        var info =
-            cluster.availablePartitionsForTopic(topic).stream()
-                .map(ReplicaInfo::of)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toUnmodifiableList());
-        if (info.isEmpty())
-          throw new NoSuchElementException(
-              "This ClusterInfo have no information about topic \"" + topic + "\"");
-        return info;
+        return availableReplicas.getOrDefault(topic, List.of());
       }
 
       @Override
       public List<ReplicaInfo> replicas(String topic) {
-        var info =
-            cluster.partitionsForTopic(topic).stream()
-                .map(ReplicaInfo::of)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toUnmodifiableList());
-        if (info.isEmpty())
-          throw new NoSuchElementException(
-              "This ClusterInfo have no information about topic \"" + topic + "\"");
-        return info;
+        return replicas;
       }
 
       @Override

--- a/app/src/main/java/org/astraea/app/admin/ClusterInfo.java
+++ b/app/src/main/java/org/astraea/app/admin/ClusterInfo.java
@@ -28,8 +28,8 @@ import org.astraea.app.metrics.HasBeanObject;
 public interface ClusterInfo {
 
   /**
-   * convert the kafka ClusterInfo to our ClusterInfo. All data structure are converted immediately,
-   * so you should cache the result if the performance is critical
+   * convert the kafka Cluster to our ClusterInfo. All data structure are converted immediately, so
+   * you should cache the result if the performance is critical
    *
    * @param cluster kafka ClusterInfo
    * @return astraea ClusterInfo

--- a/app/src/main/java/org/astraea/app/partitioner/Dispatcher.java
+++ b/app/src/main/java/org/astraea/app/partitioner/Dispatcher.java
@@ -17,12 +17,16 @@
 package org.astraea.app.partitioner;
 
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.producer.Partitioner;
 import org.apache.kafka.common.Cluster;
 import org.astraea.app.admin.ClusterInfo;
 
 public interface Dispatcher extends Partitioner {
+  /** cache the cluster info to reduce the cost of converting cluster. */
+  ConcurrentHashMap<Cluster, ClusterInfo> CLUSTER_CACHE = new ConcurrentHashMap<>();
+
   /**
    * Compute the partition for the given record.
    *
@@ -59,7 +63,7 @@ public interface Dispatcher extends Partitioner {
         topic,
         keyBytes == null ? new byte[0] : keyBytes,
         valueBytes == null ? new byte[0] : valueBytes,
-        ClusterInfo.of(cluster));
+        CLUSTER_CACHE.computeIfAbsent(cluster, ignored -> ClusterInfo.of(cluster)));
   }
 
   @Override

--- a/app/src/main/java/org/astraea/app/partitioner/Dispatcher.java
+++ b/app/src/main/java/org/astraea/app/partitioner/Dispatcher.java
@@ -24,7 +24,10 @@ import org.apache.kafka.common.Cluster;
 import org.astraea.app.admin.ClusterInfo;
 
 public interface Dispatcher extends Partitioner {
-  /** cache the cluster info to reduce the cost of converting cluster. */
+  /**
+   * cache the cluster info to reduce the cost of converting cluster. Producer does not update
+   * Cluster frequently, so it is ok to cache it.
+   */
   ConcurrentHashMap<Cluster, ClusterInfo> CLUSTER_CACHE = new ConcurrentHashMap<>();
 
   /**

--- a/app/src/test/java/org/astraea/app/cost/ClusterInfoTest.java
+++ b/app/src/test/java/org/astraea/app/cost/ClusterInfoTest.java
@@ -19,6 +19,7 @@ package org.astraea.app.cost;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import org.apache.kafka.common.Cluster;
 import org.astraea.app.admin.ClusterBean;
 import org.astraea.app.admin.ClusterInfo;
@@ -35,6 +36,7 @@ public class ClusterInfoTest {
     var node = NodeInfoTest.node();
     var partition = ReplicaInfoTest.partitionInfo();
     var kafkaCluster = Mockito.mock(Cluster.class);
+    Mockito.when(kafkaCluster.topics()).thenReturn(Set.of(partition.topic()));
     Mockito.when(kafkaCluster.availablePartitionsForTopic(partition.topic()))
         .thenReturn(List.of(partition));
     Mockito.when(kafkaCluster.partitionsForTopic(partition.topic())).thenReturn(List.of(partition));
@@ -59,14 +61,11 @@ public class ClusterInfoTest {
   @Test
   void testIllegalQuery() {
     var clusterInfo = ClusterInfo.of(Cluster.empty());
-
-    Assertions.assertThrows(NoSuchElementException.class, () -> clusterInfo.replicas("unknown"));
+    Assertions.assertEquals(0, clusterInfo.replicas("unknown").size());
     Assertions.assertThrows(NoSuchElementException.class, () -> clusterInfo.node(0));
     Assertions.assertThrows(NoSuchElementException.class, () -> clusterInfo.node("", -1));
-    Assertions.assertThrows(
-        NoSuchElementException.class, () -> clusterInfo.availableReplicas("unknown"));
-    Assertions.assertThrows(
-        NoSuchElementException.class, () -> clusterInfo.availableReplicaLeaders("unknown"));
+    Assertions.assertEquals(0, clusterInfo.availableReplicas("unknown").size());
+    Assertions.assertEquals(0, clusterInfo.availableReplicaLeaders("unknown").size());
     Assertions.assertThrows(
         UnsupportedOperationException.class, () -> clusterInfo.dataDirectories(0));
   }


### PR DESCRIPTION
兩個重點：
1. Producer並不會一直更新`Cluster`，因此我們可以透過暫存來避免過多的轉換吃掉頻寬
2. 讓RR的更新頻率可以被參數化
3. 將RR的更新頻率預設值調整成與更新beans的時間一致