### PR TITLE
QuotaCreator should use DataRate rather than long

### DIFF
--- a/app/src/main/java/org/astraea/app/admin/Builder.java
+++ b/app/src/main/java/org/astraea/app/admin/Builder.java
@@ -52,6 +52,7 @@ import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
 import org.apache.kafka.common.quota.ClientQuotaFilter;
 import org.apache.kafka.common.quota.ClientQuotaFilterComponent;
+import org.astraea.app.common.DataRate;
 import org.astraea.app.common.Utils;
 
 public class Builder {
@@ -936,17 +937,17 @@ public class Builder {
     @Override
     public Client clientId(String id) {
       return new Client() {
-        private int produceRate = Integer.MAX_VALUE;
-        private int consumeRate = Integer.MAX_VALUE;
+        private DataRate produceRate = null;
+        private DataRate consumeRate = null;
 
         @Override
-        public Client produceRate(int value) {
+        public Client produceRate(DataRate value) {
           this.produceRate = value;
           return this;
         }
 
         @Override
-        public Client consumeRate(int value) {
+        public Client consumeRate(DataRate value) {
           this.consumeRate = value;
           return this;
         }
@@ -954,14 +955,14 @@ public class Builder {
         @Override
         public void create() {
           var q = new ArrayList<ClientQuotaAlteration.Op>();
-          if (produceRate != Integer.MAX_VALUE)
+          if (produceRate != null)
             q.add(
                 new ClientQuotaAlteration.Op(
-                    Quota.Limit.PRODUCER_BYTE_RATE.nameOfKafka(), (double) produceRate));
-          if (consumeRate != Integer.MAX_VALUE)
+                    Quota.Limit.PRODUCER_BYTE_RATE.nameOfKafka(), produceRate.byteRate()));
+          if (consumeRate != null)
             q.add(
                 new ClientQuotaAlteration.Op(
-                    Quota.Limit.CONSUMER_BYTE_RATE.nameOfKafka(), (double) consumeRate));
+                    Quota.Limit.CONSUMER_BYTE_RATE.nameOfKafka(), consumeRate.byteRate()));
           if (!q.isEmpty())
             Utils.packException(
                 () ->

--- a/app/src/main/java/org/astraea/app/admin/QuotaCreator.java
+++ b/app/src/main/java/org/astraea/app/admin/QuotaCreator.java
@@ -16,6 +16,8 @@
  */
 package org.astraea.app.admin;
 
+import org.astraea.app.common.DataRate;
+
 /**
  * Kafka quota APIs are too incomprehensible to use, so we re-design quota APIs to builder pattern.
  */
@@ -38,16 +40,16 @@ public interface QuotaCreator {
    */
   interface Client {
     /**
-     * @param value A rate representing the upper bound (bytes/sec) for producer traffic
+     * @param value A rate representing the upper bound for producer traffic
      * @return this object
      */
-    Client produceRate(int value);
+    Client produceRate(DataRate value);
 
     /**
-     * @param value A rate representing the upper bound (bytes/sec) for consumer traffic
+     * @param value A rate representing the upper bound for consumer traffic
      * @return this object
      */
-    Client consumeRate(int value);
+    Client consumeRate(DataRate value);
 
     void create();
   }

--- a/app/src/main/java/org/astraea/app/web/QuotaHandler.java
+++ b/app/src/main/java/org/astraea/app/web/QuotaHandler.java
@@ -65,8 +65,8 @@ public class QuotaHandler implements Handler {
       admin
           .quotaCreator()
           .clientId(request.value(CLIENT_ID_KEY))
-          // TODO: use DataRate#Field to parse string
-          //  (it will be introduced by https://github.com/skiptests/astraea/issues/488)
+          // TODO: use DataRate#Field (traced https://github.com/skiptests/astraea/issues/488)
+          // see https://github.com/skiptests/astraea/issues/490
           .produceRate(
               request
                   .get(PRODUCE_RATE_KEY)

--- a/app/src/main/java/org/astraea/app/web/QuotaHandler.java
+++ b/app/src/main/java/org/astraea/app/web/QuotaHandler.java
@@ -65,6 +65,8 @@ public class QuotaHandler implements Handler {
       admin
           .quotaCreator()
           .clientId(request.value(CLIENT_ID_KEY))
+          // TODO: use DataRate#Field to parse string
+          //  (it will be introduced by https://github.com/skiptests/astraea/issues/488)
           .produceRate(
               request
                   .get(PRODUCE_RATE_KEY)

--- a/app/src/main/java/org/astraea/app/web/QuotaHandler.java
+++ b/app/src/main/java/org/astraea/app/web/QuotaHandler.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.astraea.app.admin.Admin;
+import org.astraea.app.common.DataRate;
 
 public class QuotaHandler implements Handler {
 
@@ -64,8 +65,18 @@ public class QuotaHandler implements Handler {
       admin
           .quotaCreator()
           .clientId(request.value(CLIENT_ID_KEY))
-          .produceRate(request.intValue(PRODUCE_RATE_KEY, Integer.MAX_VALUE))
-          .consumeRate(request.intValue(CONSUME_RATE_KEY, Integer.MAX_VALUE))
+          .produceRate(
+              request
+                  .get(PRODUCE_RATE_KEY)
+                  .map(Long::parseLong)
+                  .map(v -> DataRate.Byte.of(v).perSecond())
+                  .orElse(null))
+          .consumeRate(
+              request
+                  .get(CONSUME_RATE_KEY)
+                  .map(Long::parseLong)
+                  .map(v -> DataRate.Byte.of(v).perSecond())
+                  .orElse(null))
           .create();
       return new Quotas(
           admin.quotas(org.astraea.app.admin.Quota.Target.CLIENT_ID, request.value(CLIENT_ID_KEY)));

--- a/app/src/test/java/org/astraea/app/admin/AdminTest.java
+++ b/app/src/test/java/org/astraea/app/admin/AdminTest.java
@@ -35,6 +35,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.errors.GroupNotEmptyException;
+import org.astraea.app.common.DataRate;
 import org.astraea.app.common.Utils;
 import org.astraea.app.concurrent.State;
 import org.astraea.app.concurrent.ThreadPool;
@@ -585,7 +586,12 @@ public class AdminTest extends RequireBrokerCluster {
   @Test
   void testClientQuota() {
     try (var admin = Admin.of(bootstrapServers())) {
-      admin.quotaCreator().clientId("my-id").produceRate(10).consumeRate(100).create();
+      admin
+          .quotaCreator()
+          .clientId("my-id")
+          .produceRate(DataRate.Byte.of(100L).perSecond())
+          .consumeRate(DataRate.Byte.of(100L).perSecond())
+          .create();
       Utils.sleep(Duration.ofSeconds(2));
 
       java.util.function.Consumer<List<Quota>> checker =
@@ -641,8 +647,16 @@ public class AdminTest extends RequireBrokerCluster {
   @Test
   void testMultipleClientQuota() {
     try (var admin = Admin.of(bootstrapServers())) {
-      admin.quotaCreator().clientId("my-id").consumeRate(100).create();
-      admin.quotaCreator().clientId("my-id").produceRate(999).create();
+      admin
+          .quotaCreator()
+          .clientId("my-id")
+          .consumeRate(DataRate.Byte.of(100L).perSecond())
+          .create();
+      admin
+          .quotaCreator()
+          .clientId("my-id")
+          .produceRate(DataRate.Byte.of(1000L).perSecond())
+          .create();
       Utils.sleep(Duration.ofSeconds(2));
       Assertions.assertEquals(2, admin.quotas(Quota.Target.CLIENT_ID, "my-id").size());
     }

--- a/app/src/test/java/org/astraea/app/admin/AdminTest.java
+++ b/app/src/test/java/org/astraea/app/admin/AdminTest.java
@@ -589,7 +589,7 @@ public class AdminTest extends RequireBrokerCluster {
       admin
           .quotaCreator()
           .clientId("my-id")
-          .produceRate(DataRate.Byte.of(100L).perSecond())
+          .produceRate(DataRate.Byte.of(10L).perSecond())
           .consumeRate(DataRate.Byte.of(100L).perSecond())
           .create();
       Utils.sleep(Duration.ofSeconds(2));


### PR DESCRIPTION
感謝 @garyparrot  在 #481 中重構了 `DataRate`，因此可以讓其作為public APIs的一部分了