### PR TITLE
Swallow the exception thrown by fetchers

### DIFF
--- a/app/src/main/java/org/astraea/app/cost/NeutralIntegratedCost.java
+++ b/app/src/main/java/org/astraea/app/cost/NeutralIntegratedCost.java
@@ -165,7 +165,13 @@ public class NeutralIntegratedCost implements HasBrokerCost {
 
   @Override
   public Optional<Fetcher> fetcher() {
-    return Fetcher.of(metricsCost);
+    return Fetcher.of(
+        metricsCost.stream()
+            .map(CostFunction::fetcher)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(Collectors.toUnmodifiableList()),
+        e -> {});
   }
 
   static class BrokerMetrics {

--- a/app/src/main/java/org/astraea/app/metrics/collector/Fetcher.java
+++ b/app/src/main/java/org/astraea/app/metrics/collector/Fetcher.java
@@ -18,32 +18,36 @@ package org.astraea.app.metrics.collector;
 
 import java.util.Collection;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import org.astraea.app.cost.CostFunction;
+import java.util.stream.Stream;
 import org.astraea.app.metrics.HasBeanObject;
 import org.astraea.app.metrics.jmx.MBeanClient;
 
 @FunctionalInterface
 public interface Fetcher {
-
   /**
-   * merge all fetchers into single one
+   * merge all fetchers into single one.
    *
-   * @param functions cost function
+   * @param fetchers cost function
+   * @param errorHandler used to handle the runtime exception thrown by fetcher
    * @return fetcher if there is available fetcher. Otherwise, empty is returned
    */
-  static Optional<Fetcher> of(Collection<? extends CostFunction> functions) {
-    var fs =
-        functions.stream()
-            .map(CostFunction::fetcher)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .collect(Collectors.toUnmodifiableList());
-    if (fs.isEmpty()) return Optional.empty();
+  static Optional<Fetcher> of(
+      Collection<Fetcher> fetchers, Consumer<RuntimeException> errorHandler) {
+    if (fetchers.isEmpty()) return Optional.empty();
     return Optional.of(
         client ->
-            fs.stream()
-                .flatMap(f -> f.fetch(client).stream())
+            fetchers.stream()
+                .flatMap(
+                    f -> {
+                      try {
+                        return f.fetch(client).stream();
+                      } catch (RuntimeException e) {
+                        errorHandler.accept(e);
+                        return Stream.of();
+                      }
+                    })
                 .collect(Collectors.toUnmodifiableList()));
   }
 

--- a/app/src/main/java/org/astraea/app/metrics/jmx/MBeanClientImpl.java
+++ b/app/src/main/java/org/astraea/app/metrics/jmx/MBeanClientImpl.java
@@ -96,6 +96,8 @@ abstract class MBeanClientImpl implements MBeanClient {
               .map(MBeanFeatureInfo::getName)
               .collect(Collectors.toList());
 
+      System.out.println("attributeName: " + attributeName);
+
       // query the result
       return queryBean(beanQuery, attributeName);
     } catch (ReflectionException | IntrospectionException e) {

--- a/app/src/main/java/org/astraea/app/partitioner/StrictCostDispatcher.java
+++ b/app/src/main/java/org/astraea/app/partitioner/StrictCostDispatcher.java
@@ -209,6 +209,7 @@ public class StrictCostDispatcher implements Dispatcher {
     this.functions = functions;
     // the temporary exception won't affect the smooth-weighted too much.
     // TODO: should we propagate the exception by better way? For example: Slf4j ?
+    // see https://github.com/skiptests/astraea/issues/486
     this.fetcher =
         Fetcher.of(
             this.functions.keySet().stream()

--- a/app/src/main/java/org/astraea/app/partitioner/StrictCostDispatcher.java
+++ b/app/src/main/java/org/astraea/app/partitioner/StrictCostDispatcher.java
@@ -207,7 +207,16 @@ public class StrictCostDispatcher implements Dispatcher {
       Map<Integer, Integer> customJmxPort,
       Duration roundRobinLease) {
     this.functions = functions;
-    this.fetcher = Fetcher.of(this.functions.keySet());
+    // the temporary exception won't affect the smooth-weighted too much.
+    // TODO: should we propagate the exception by better way? For example: Slf4j ?
+    this.fetcher =
+        Fetcher.of(
+            this.functions.keySet().stream()
+                .map(CostFunction::fetcher)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toUnmodifiableList()),
+            Throwable::printStackTrace);
     this.jmxPortGetter = id -> Optional.ofNullable(customJmxPort.get(id)).or(() -> jmxPortDefault);
 
     // put local mbean client first

--- a/app/src/test/java/org/astraea/app/metrics/collector/FetcherTest.java
+++ b/app/src/test/java/org/astraea/app/metrics/collector/FetcherTest.java
@@ -18,7 +18,6 @@ package org.astraea.app.metrics.collector;
 
 import java.util.List;
 import java.util.Optional;
-import org.astraea.app.cost.CostFunction;
 import org.astraea.app.metrics.HasBeanObject;
 import org.astraea.app.metrics.jmx.MBeanClient;
 import org.junit.jupiter.api.Assertions;
@@ -34,22 +33,7 @@ public class FetcherTest {
     var mbean1 = Mockito.mock(HasBeanObject.class);
     Fetcher fetcher1 = client -> List.of(mbean1);
 
-    var fetcher =
-        Fetcher.of(
-                List.of(
-                    new CostFunction() {
-                      @Override
-                      public Optional<Fetcher> fetcher() {
-                        return Optional.of(fetcher0);
-                      }
-                    },
-                    new CostFunction() {
-                      @Override
-                      public Optional<Fetcher> fetcher() {
-                        return Optional.of(fetcher1);
-                      }
-                    }))
-            .get();
+    var fetcher = Fetcher.of(List.of(fetcher0, fetcher1), e -> {}).get();
 
     var result = fetcher.fetch(Mockito.mock(MBeanClient.class));
 
@@ -59,17 +43,19 @@ public class FetcherTest {
   }
 
   @Test
-  void testEmptyCostFunction() {
-    Assertions.assertEquals(Optional.empty(), Fetcher.of(List.of()));
-    Assertions.assertEquals(
-        Optional.empty(),
-        Fetcher.of(
-            List.of(
-                new CostFunction() {
-                  @Override
-                  public Optional<Fetcher> fetcher() {
-                    return Optional.empty();
-                  }
-                })));
+  void testEmpty() {
+    Assertions.assertEquals(Optional.empty(), Fetcher.of(List.of(), e -> {}));
+  }
+
+  @Test
+  void testSwallowException() {
+    var result = List.of(Mockito.mock(HasBeanObject.class));
+    Fetcher goodFetcher = client -> result;
+    Fetcher badFetcher =
+        client -> {
+          throw new RuntimeException("xxx");
+        };
+    var fetcher = Fetcher.of(List.of(badFetcher, goodFetcher), e -> {}).get();
+    Assertions.assertEquals(result, fetcher.fetch(Mockito.mock(MBeanClient.class)));
   }
 }


### PR DESCRIPTION
`StrictCostDispatcher`可結合許多不同的cost functions，然後再索取metrics的過程中可能有些fetchers會出現錯誤，在正常使用中這些錯誤應該都屬於臨時性的錯誤，例如連線被中斷或是目標的JVM尚未更新相關的metrics，因此`StrictCostDispatcher`可以先將該些錯誤吃掉，以免在長期測試中被中斷

不過另外一個角度則是如果遇到”一定會失敗的狀況“，或許我們就應該中斷程序，這需要更多討論，因此我在PR有留下TODO (referenced to #486)