### PR TITLE
Simplify input/ouput cost

### DIFF
--- a/app/src/main/java/org/astraea/app/cost/BrokerInputCost.java
+++ b/app/src/main/java/org/astraea/app/cost/BrokerInputCost.java
@@ -16,108 +16,33 @@
  */
 package org.astraea.app.cost;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.astraea.app.admin.ClusterBean;
 import org.astraea.app.admin.ClusterInfo;
 import org.astraea.app.metrics.KafkaMetrics;
 import org.astraea.app.metrics.broker.BrokerTopicMetricsResult;
 import org.astraea.app.metrics.collector.Fetcher;
 
-/**
- * The result is computed by "BytesInPerSec.count". "BytesInPerSec.count" responds to the input
- * throughput of brokers.
- *
- * <ol>
- *   <li>We normalize the metric as score(by T-score).
- *   <li>We record these data of each second.
- *   <li>We only keep the last ten seconds of data.
- *   <li>The final result is the average of the ten-second data.
- * </ol>
- */
 public class BrokerInputCost implements HasBrokerCost {
-  private final Map<Integer, BrokerMetric> brokersMetric = new HashMap<>();
-
   @Override
   public BrokerCost brokerCost(ClusterInfo clusterInfo, ClusterBean clusterBean) {
-    var costMetrics =
+    var brokerCost =
         clusterBean.all().entrySet().stream()
             .collect(
                 Collectors.toMap(
                     Map.Entry::getKey,
                     entry ->
-                        entry.getValue().stream()
-                            .filter(
-                                hasBeanObject ->
-                                    KafkaMetrics.BrokerTopic.BytesInPerSec.metricName()
-                                        .equals(
-                                            hasBeanObject.beanObject().properties().get("name")))
-                            .findAny()
-                            .orElseThrow()))
-            .entrySet()
-            .stream()
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey,
-                    entry -> {
-                      if (!brokersMetric.containsKey(entry.getKey())) {
-                        brokersMetric.put(entry.getKey(), new BrokerMetric());
-                      }
-                      var broker = brokersMetric.get(entry.getKey());
-                      var inBean = (BrokerTopicMetricsResult) entry.getValue();
-                      var count = (double) (inBean.count() - broker.accumulateCount);
-                      broker.accumulateCount = inBean.count();
-                      return count;
-                    }));
-    costMetrics.forEach((broker, v) -> brokersMetric.get(broker).updateLoad(v));
-
-    return this::computeLoad;
-  }
-
-  Map<Integer, Double> computeLoad() {
-    return brokersMetric.entrySet().stream()
-        .collect(
-            Collectors.toMap(
-                Map.Entry::getKey,
-                e ->
-                    Math.round(
-                            e.getValue().load.stream()
-                                    .filter(aDouble -> !aDouble.equals(-1.0))
-                                    .mapToDouble(i -> i)
-                                    .average()
-                                    .orElse(0.5)
-                                * 100)
-                        / 100.0));
+                        KafkaMetrics.BrokerTopic.BytesInPerSec.of(entry.getValue()).stream()
+                            .mapToDouble(BrokerTopicMetricsResult::oneMinuteRate)
+                            .sum()));
+    return () -> brokerCost;
   }
 
   @Override
   public Optional<Fetcher> fetcher() {
     return Optional.of(client -> List.of(KafkaMetrics.BrokerTopic.BytesInPerSec.fetch(client)));
-  }
-
-  private static class BrokerMetric {
-    // mbean data.  BytesInPerSec.count
-    private long accumulateCount = 0L;
-
-    // Record the latest 10 numbers only.
-    private final List<Double> load =
-        IntStream.range(0, 10).mapToObj(i -> -1.0).collect(Collectors.toList());
-    private int loadIndex = 0;
-
-    private BrokerMetric() {}
-
-    /**
-     * This method record input data into a list. This list contains the latest 10 record. Each time
-     * it is called, the current index, "loadIndex", is increased by 1.
-     */
-    void updateLoad(Double load) {
-      var cLoad = load.isNaN() ? 0.5 : load;
-      this.load.set(loadIndex, cLoad);
-      loadIndex = (loadIndex + 1) % 10;
-    }
   }
 }

--- a/app/src/main/java/org/astraea/app/cost/BrokerOutputCost.java
+++ b/app/src/main/java/org/astraea/app/cost/BrokerOutputCost.java
@@ -16,108 +16,34 @@
  */
 package org.astraea.app.cost;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.astraea.app.admin.ClusterBean;
 import org.astraea.app.admin.ClusterInfo;
 import org.astraea.app.metrics.KafkaMetrics;
 import org.astraea.app.metrics.broker.BrokerTopicMetricsResult;
 import org.astraea.app.metrics.collector.Fetcher;
 
-/**
- * The result is computed by "BytesOutPerSec.count". "BytesOutPerSec.count" responds to the output
- * throughput of brokers.
- *
- * <ol>
- *   <li>We normalize the metric as score(by T-score).
- *   <li>We record these data of each second.
- *   <li>We only keep the last ten seconds of data.
- *   <li>The final result is the average of the ten-second data.
- * </ol>
- */
 public class BrokerOutputCost implements HasBrokerCost {
-  private final Map<Integer, BrokerMetric> brokersMetric = new HashMap<>();
 
   @Override
   public BrokerCost brokerCost(ClusterInfo clusterInfo, ClusterBean clusterBean) {
-    var costMetrics =
+    var brokerCost =
         clusterBean.all().entrySet().stream()
             .collect(
                 Collectors.toMap(
                     Map.Entry::getKey,
                     entry ->
-                        entry.getValue().stream()
-                            .filter(
-                                hasBeanObject ->
-                                    KafkaMetrics.BrokerTopic.BytesOutPerSec.metricName()
-                                        .equals(
-                                            hasBeanObject.beanObject().properties().get("name")))
-                            .findAny()
-                            .orElseThrow()))
-            .entrySet()
-            .stream()
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey,
-                    entry -> {
-                      if (!brokersMetric.containsKey(entry.getKey())) {
-                        brokersMetric.put(entry.getKey(), new BrokerMetric());
-                      }
-                      var broker = brokersMetric.get(entry.getKey());
-                      var inBean = (BrokerTopicMetricsResult) entry.getValue();
-                      var count = (double) (inBean.count() - broker.accumulateCount);
-                      broker.accumulateCount = inBean.count();
-                      return count;
-                    }));
-    costMetrics.forEach((broker, v) -> brokersMetric.get(broker).updateLoad(v));
-
-    return this::computeLoad;
-  }
-
-  Map<Integer, Double> computeLoad() {
-    return brokersMetric.entrySet().stream()
-        .collect(
-            Collectors.toMap(
-                Map.Entry::getKey,
-                e ->
-                    Math.round(
-                            e.getValue().load.stream()
-                                    .filter(aDouble -> !aDouble.equals(-1.0))
-                                    .mapToDouble(i -> i)
-                                    .average()
-                                    .orElse(0.5)
-                                * 100)
-                        / 100.0));
+                        KafkaMetrics.BrokerTopic.BytesOutPerSec.of(entry.getValue()).stream()
+                            .mapToDouble(BrokerTopicMetricsResult::oneMinuteRate)
+                            .sum()));
+    return () -> brokerCost;
   }
 
   @Override
   public Optional<Fetcher> fetcher() {
     return Optional.of(client -> List.of(KafkaMetrics.BrokerTopic.BytesOutPerSec.fetch(client)));
-  }
-
-  private static class BrokerMetric {
-    // mbean data. BytesOutPerSec.count
-    private long accumulateCount = 0L;
-
-    // Record the latest 10 numbers only.
-    private final List<Double> load =
-        IntStream.range(0, 10).mapToObj(i -> -1.0).collect(Collectors.toList());
-    private int loadIndex = 0;
-
-    private BrokerMetric() {}
-
-    /**
-     * This method record input data into a list. This list contains the latest 10 record. Each time
-     * it is called, the current index, "loadIndex", is increased by 1.
-     */
-    void updateLoad(Double load) {
-      var cLoad = load.isNaN() ? 0.5 : load;
-      this.load.set(loadIndex, cLoad);
-      loadIndex = (loadIndex + 1) % 10;
-    }
   }
 }

--- a/app/src/main/java/org/astraea/app/metrics/KafkaMetrics.java
+++ b/app/src/main/java/org/astraea/app/metrics/KafkaMetrics.java
@@ -94,6 +94,21 @@ public final class KafkaMetrics {
       return metricName;
     }
 
+    /**
+     * find out the objects related to this metrics.
+     *
+     * @param objects to search
+     * @return collection of BrokerTopicMetricsResult, or empty if all objects are not related to
+     *     this metrics
+     */
+    public Collection<BrokerTopicMetricsResult> of(Collection<HasBeanObject> objects) {
+      return objects.stream()
+          .filter(o -> o instanceof BrokerTopicMetricsResult)
+          .filter(o -> metricName().equals(o.beanObject().properties().get("name")))
+          .map(o -> (BrokerTopicMetricsResult) o)
+          .collect(Collectors.toUnmodifiableList());
+    }
+
     public BrokerTopicMetricsResult fetch(MBeanClient mBeanClient) {
       return new BrokerTopicMetricsResult(
           mBeanClient.queryBean(

--- a/app/src/main/java/org/astraea/app/metrics/jmx/BeanObject.java
+++ b/app/src/main/java/org/astraea/app/metrics/jmx/BeanObject.java
@@ -18,7 +18,6 @@ package org.astraea.app.metrics.jmx;
 
 import static java.util.Map.Entry;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -51,22 +50,17 @@ public class BeanObject {
       Map<String, Object> attributes,
       long createdTimestamp) {
     this.domainName = Objects.requireNonNull(domainName);
-
     // copy properties, and remove null key or null value
-    Objects.requireNonNull(properties);
-    Map<String, String> propertyMap =
-        properties.entrySet().stream()
-            .filter(entry -> entry.getKey() != null && entry.getValue() != null)
-            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-    this.properties = Collections.unmodifiableMap(propertyMap);
+    this.properties =
+        Objects.requireNonNull(properties).entrySet().stream()
+            .filter(entry1 -> entry1.getKey() != null && entry1.getValue() != null)
+            .collect(Collectors.toUnmodifiableMap(Entry::getKey, Entry::getValue));
 
     // copy attribute, and remove null key or null value
-    Objects.requireNonNull(attributes);
-    Map<String, Object> attributeMap =
-        attributes.entrySet().stream()
+    this.attributes =
+        Objects.requireNonNull(attributes).entrySet().stream()
             .filter(entry -> entry.getKey() != null && entry.getValue() != null)
-            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-    this.attributes = Collections.unmodifiableMap(attributeMap);
+            .collect(Collectors.toUnmodifiableMap(Entry::getKey, Entry::getValue));
     this.createdTimestamp = createdTimestamp;
   }
 

--- a/app/src/main/java/org/astraea/app/metrics/jmx/MBeanClientImpl.java
+++ b/app/src/main/java/org/astraea/app/metrics/jmx/MBeanClientImpl.java
@@ -96,8 +96,6 @@ abstract class MBeanClientImpl implements MBeanClient {
               .map(MBeanFeatureInfo::getName)
               .collect(Collectors.toList());
 
-      System.out.println("attributeName: " + attributeName);
-
       // query the result
       return queryBean(beanQuery, attributeName);
     } catch (ReflectionException | IntrospectionException e) {

--- a/app/src/test/java/org/astraea/app/cost/BrokerInputCostTest.java
+++ b/app/src/test/java/org/astraea/app/cost/BrokerInputCostTest.java
@@ -16,12 +16,10 @@
  */
 package org.astraea.app.cost;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import org.astraea.app.admin.ClusterBean;
 import org.astraea.app.admin.ClusterInfo;
-import org.astraea.app.metrics.HasBeanObject;
 import org.astraea.app.metrics.KafkaMetrics;
 import org.astraea.app.metrics.broker.BrokerTopicMetricsResult;
 import org.astraea.app.metrics.collector.BeanCollector;
@@ -30,39 +28,28 @@ import org.astraea.app.metrics.jmx.BeanObject;
 import org.astraea.app.service.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 public class BrokerInputCostTest extends RequireBrokerCluster {
+
   @Test
-  void testTScoreCost() {
+  void testCost() {
     var brokerInputCost = new BrokerInputCost();
     var scores =
         brokerInputCost
-            .brokerCost(ClusterInfo.EMPTY, clusterBean(50000L, 20000L, 5000L))
-            .normalize(Normalizer.TScore())
+            .brokerCost(
+                ClusterInfo.EMPTY,
+                ClusterBean.of(
+                    Map.of(
+                        1,
+                        List.of(brokerTopicMetricsResult(10000D)),
+                        2,
+                        List.of(brokerTopicMetricsResult(20000D)),
+                        3,
+                        List.of(brokerTopicMetricsResult(5000D)))))
             .value();
-    Assertions.assertEquals(0.63, scores.get(1));
-    Assertions.assertEquals(0.47, scores.get(2));
-    Assertions.assertEquals(0.39, scores.get(3));
-
-    scores =
-        brokerInputCost
-            .brokerCost(ClusterInfo.EMPTY, clusterBean(55555L, 25352L, 25000L))
-            .normalize(Normalizer.TScore())
-            .value();
-    Assertions.assertEquals(0.64, scores.get(1));
-    Assertions.assertEquals(0.43, scores.get(2));
-    Assertions.assertEquals(0.43, scores.get(3));
-  }
-
-  @Test
-  void testNoNormalize() {
-    var brokerInputCost = new BrokerInputCost();
-    var scores =
-        brokerInputCost.brokerCost(ClusterInfo.EMPTY, clusterBean(10000L, 20000L, 5000L)).value();
-    Assertions.assertEquals(10000.0, scores.get(1));
-    Assertions.assertEquals(20000.0, scores.get(2));
-    Assertions.assertEquals(5000.0, scores.get(3));
+    Assertions.assertEquals(10000D, scores.get(1));
+    Assertions.assertEquals(20000D, scores.get(2));
+    Assertions.assertEquals(5000D, scores.get(3));
   }
 
   @Test
@@ -94,23 +81,11 @@ public class BrokerInputCostTest extends RequireBrokerCluster {
     }
   }
 
-  private ClusterBean clusterBean(long in1, long in2, long in3) {
-    var BytesInPerSec1 = mockResult(KafkaMetrics.BrokerTopic.BytesInPerSec.metricName(), in1);
-    var BytesInPerSec2 = mockResult(KafkaMetrics.BrokerTopic.BytesInPerSec.metricName(), in2);
-    var BytesInPerSec3 = mockResult(KafkaMetrics.BrokerTopic.BytesInPerSec.metricName(), in3);
-
-    Collection<HasBeanObject> broker1 = List.of(BytesInPerSec1);
-    Collection<HasBeanObject> broker2 = List.of(BytesInPerSec2);
-    Collection<HasBeanObject> broker3 = List.of(BytesInPerSec3);
-    return ClusterBean.of(Map.of(1, broker1, 2, broker2, 3, broker3));
-  }
-
-  private BrokerTopicMetricsResult mockResult(String name, long count) {
-    var result = Mockito.mock(BrokerTopicMetricsResult.class);
-    var bean = Mockito.mock(BeanObject.class);
-    Mockito.when(result.beanObject()).thenReturn(bean);
-    Mockito.when(bean.properties()).thenReturn(Map.of("name", name));
-    Mockito.when(result.count()).thenReturn(count);
-    return result;
+  private static BrokerTopicMetricsResult brokerTopicMetricsResult(double value) {
+    return new BrokerTopicMetricsResult(
+        new BeanObject(
+            "object",
+            Map.of("name", KafkaMetrics.BrokerTopic.BytesInPerSec.metricName()),
+            Map.of("OneMinuteRate", value)));
   }
 }

--- a/app/src/test/java/org/astraea/app/cost/BrokerOutputCostTest.java
+++ b/app/src/test/java/org/astraea/app/cost/BrokerOutputCostTest.java
@@ -16,12 +16,10 @@
  */
 package org.astraea.app.cost;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import org.astraea.app.admin.ClusterBean;
 import org.astraea.app.admin.ClusterInfo;
-import org.astraea.app.metrics.HasBeanObject;
 import org.astraea.app.metrics.KafkaMetrics;
 import org.astraea.app.metrics.broker.BrokerTopicMetricsResult;
 import org.astraea.app.metrics.collector.BeanCollector;
@@ -30,29 +28,28 @@ import org.astraea.app.metrics.jmx.BeanObject;
 import org.astraea.app.service.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
-public class BrokerOutPutCostTest extends RequireBrokerCluster {
+public class BrokerOutputCostTest extends RequireBrokerCluster {
+
   @Test
   void testCost() {
     var brokerOutputCost = new BrokerOutputCost();
     var scores =
         brokerOutputCost
-            .brokerCost(ClusterInfo.EMPTY, clusterBean(10000L, 20000L, 5000L))
-            .normalize(Normalizer.TScore())
+            .brokerCost(
+                ClusterInfo.EMPTY,
+                ClusterBean.of(
+                    Map.of(
+                        1,
+                        List.of(brokerTopicMetricsResult(10000D)),
+                        2,
+                        List.of(brokerTopicMetricsResult(20000D)),
+                        3,
+                        List.of(brokerTopicMetricsResult(5000D)))))
             .value();
-    Assertions.assertEquals(0.47, scores.get(1));
-    Assertions.assertEquals(0.63, scores.get(2));
-    Assertions.assertEquals(0.39, scores.get(3));
-
-    scores =
-        brokerOutputCost
-            .brokerCost(ClusterInfo.EMPTY, clusterBean(55555L, 25352L, 25000L))
-            .normalize(Normalizer.TScore())
-            .value();
-    Assertions.assertEquals(0.64, scores.get(1));
-    Assertions.assertEquals(0.43, scores.get(2));
-    Assertions.assertEquals(0.43, scores.get(3));
+    Assertions.assertEquals(10000D, scores.get(1));
+    Assertions.assertEquals(20000D, scores.get(2));
+    Assertions.assertEquals(5000D, scores.get(3));
   }
 
   @Test
@@ -84,23 +81,11 @@ public class BrokerOutPutCostTest extends RequireBrokerCluster {
     }
   }
 
-  private ClusterBean clusterBean(long out1, long out2, long out3) {
-    var BytesInPerSec1 = mockResult(KafkaMetrics.BrokerTopic.BytesOutPerSec.metricName(), out1);
-    var BytesInPerSec2 = mockResult(KafkaMetrics.BrokerTopic.BytesOutPerSec.metricName(), out2);
-    var BytesInPerSec3 = mockResult(KafkaMetrics.BrokerTopic.BytesOutPerSec.metricName(), out3);
-
-    Collection<HasBeanObject> broker1 = List.of(BytesInPerSec1);
-    Collection<HasBeanObject> broker2 = List.of(BytesInPerSec2);
-    Collection<HasBeanObject> broker3 = List.of(BytesInPerSec3);
-    return ClusterBean.of(Map.of(1, broker1, 2, broker2, 3, broker3));
-  }
-
-  private BrokerTopicMetricsResult mockResult(String name, long count) {
-    var result = Mockito.mock(BrokerTopicMetricsResult.class);
-    var bean = Mockito.mock(BeanObject.class);
-    Mockito.when(result.beanObject()).thenReturn(bean);
-    Mockito.when(bean.properties()).thenReturn(Map.of("name", name));
-    Mockito.when(result.count()).thenReturn(count);
-    return result;
+  private static BrokerTopicMetricsResult brokerTopicMetricsResult(double value) {
+    return new BrokerTopicMetricsResult(
+        new BeanObject(
+            "object",
+            Map.of("name", KafkaMetrics.BrokerTopic.BytesOutPerSec.metricName()),
+            Map.of("OneMinuteRate", value)));
   }
 }


### PR DESCRIPTION
這隻PR除了一些重構以外，也簡化了`BrokerInputCost`和`BrokerOutputCost`的邏輯，包含：
1. 移除了`TScore`，使用這兩個cost的傢伙應該要自行去做正規劃
2. 改用`oneMinuteRate`取代`count`，前者提供更合理的觀察指標