### PR TITLE
simplify sizeTimeSeries

### DIFF
--- a/app/src/main/java/org/astraea/app/cost/ReplicaDiskInCost.java
+++ b/app/src/main/java/org/astraea/app/cost/ReplicaDiskInCost.java
@@ -29,7 +29,6 @@ import org.astraea.app.admin.NodeInfo;
 import org.astraea.app.admin.TopicPartition;
 import org.astraea.app.admin.TopicPartitionReplica;
 import org.astraea.app.metrics.HasBeanObject;
-import org.astraea.app.metrics.broker.HasValue;
 import org.astraea.app.metrics.broker.LogMetrics;
 import org.astraea.app.metrics.collector.Fetcher;
 
@@ -202,11 +201,7 @@ public class ReplicaDiskInCost implements HasBrokerCost, HasPartitionCost {
             metrics -> {
               // calculate the increase rate over a specific window of time
               var sizeTimeSeries =
-                  metrics.getValue().stream()
-                      .filter(bean -> bean instanceof HasValue)
-                      .filter(bean -> bean.beanObject().properties().get("type").equals("Log"))
-                      .filter(bean -> bean.beanObject().properties().get("name").equals("Size"))
-                      .map(bean -> (HasValue) bean)
+                  LogMetrics.Log.meters(metrics.getValue(), LogMetrics.Log.SIZE).stream()
                       .sorted(Comparator.comparingLong(HasBeanObject::createdTimestamp).reversed())
                       .collect(Collectors.toUnmodifiableList());
               var latestSize = sizeTimeSeries.stream().findFirst().orElseThrow();

--- a/app/src/test/java/org/astraea/app/cost/ReplicaDiskInCostTest.java
+++ b/app/src/test/java/org/astraea/app/cost/ReplicaDiskInCostTest.java
@@ -128,14 +128,13 @@ class ReplicaDiskInCostTest extends RequireBrokerCluster {
     return ClusterBean.of(Map.of(1, broker1, 2, broker2, 3, broker3));
   }
 
-  private static HasValue fakeBeanObject(
+  private static LogMetrics.Log.Meter fakeBeanObject(
       String type, String name, String topic, String partition, long size, long time) {
-    BeanObject beanObject =
+    return new LogMetrics.Log.Meter(
         new BeanObject(
-            "",
+            "kafka.log",
             Map.of("name", name, "type", type, "topic", topic, "partition", partition),
             Map.of("Value", size),
-            time);
-    return HasValue.of(beanObject);
+            time));
   }
 }


### PR DESCRIPTION
簡化ReplicaDiskInCost中 sizeTimeSeries的計算方法，改用LogMetrics.Log.Meter