### PR TITLE
Fix NodeLatencyCostTest#testCost

### DIFF
--- a/app/src/test/java/org/astraea/app/cost/NodeLatencyCostTest.java
+++ b/app/src/test/java/org/astraea/app/cost/NodeLatencyCostTest.java
@@ -71,18 +71,22 @@ public class NodeLatencyCostTest extends RequireBrokerCluster {
       producer.sender().topic(Utils.randomString(10)).value(new byte[100]).run();
       producer.flush();
 
-      var beans = ProducerMetrics.nodes(MBeanClient.local());
-      var clusterBean =
-          ClusterBean.of(
-              Map.of(
-                  -1,
-                  beans.stream()
-                      .map(b -> (HasBeanObject) b)
-                      .collect(Collectors.toUnmodifiableList())));
-      var clusterInfo = Mockito.mock(ClusterInfo.class);
       var function = new NodeLatencyCost();
-      var cost = function.brokerCost(clusterInfo, clusterBean);
-      Assertions.assertEquals(1, cost.value().size());
+
+      Utils.waitFor(
+          () ->
+              function
+                      .brokerCost(
+                          Mockito.mock(ClusterInfo.class),
+                          ClusterBean.of(
+                              Map.of(
+                                  -1,
+                                  ProducerMetrics.nodes(MBeanClient.local()).stream()
+                                      .map(b -> (HasBeanObject) b)
+                                      .collect(Collectors.toUnmodifiableList()))))
+                      .value()
+                      .size()
+                  >= 1);
     }
   }
 


### PR DESCRIPTION
bean 的更新並不及時，因此給一點時間去等待資訊出現