### PR TITLE
Enable to unsubscribe/resubscribe topics/partitions

### DIFF
--- a/app/src/main/java/org/astraea/app/consumer/Consumer.java
+++ b/app/src/main/java/org/astraea/app/consumer/Consumer.java
@@ -49,6 +49,12 @@ public interface Consumer<Key, Value> extends AutoCloseable {
   @Override
   void close();
 
+  /** resubscribe partitions or rejoin the consumer group. */
+  void resubscribe();
+
+  /** unsubscribe all partitions. */
+  void unsubscribe();
+
   /**
    * Create a consumer builder by setting specific topics
    *

--- a/app/src/main/java/org/astraea/app/consumer/PartitionsBuilder.java
+++ b/app/src/main/java/org/astraea/app/consumer/PartitionsBuilder.java
@@ -100,14 +100,23 @@ public class PartitionsBuilder<Key, Value> extends Builder<Key, Value> {
 
     seekStrategy.apply(kafkaConsumer, seekValue);
 
-    return new AssignedConsumerImpl<>(kafkaConsumer);
+    return new AssignedConsumerImpl<>(kafkaConsumer, partitions);
   }
 
   private static class AssignedConsumerImpl<Key, Value> extends Builder.BaseConsumer<Key, Value>
       implements AssignedConsumer<Key, Value> {
 
-    public AssignedConsumerImpl(Consumer<Key, Value> kafkaConsumer) {
+    private final Set<TopicPartition> partitions;
+
+    public AssignedConsumerImpl(
+        Consumer<Key, Value> kafkaConsumer, Set<TopicPartition> partitions) {
       super(kafkaConsumer);
+      this.partitions = partitions;
+    }
+
+    @Override
+    protected void doResubscribe() {
+      kafkaConsumer.assign(partitions.stream().map(TopicPartition::to).collect(toList()));
     }
   }
 }

--- a/app/src/test/java/org/astraea/app/consumer/ConsumerTest.java
+++ b/app/src/test/java/org/astraea/app/consumer/ConsumerTest.java
@@ -347,4 +347,32 @@ public class ConsumerTest extends RequireBrokerCluster {
                 .build(),
         "seek value should >= 0");
   }
+
+  @Test
+  void testResubscribe() {
+    var topic = Utils.randomString(10);
+    produceData(topic, 100);
+    try (var consumer =
+        Consumer.forTopics(Set.of(topic))
+            .bootstrapServers(bootstrapServers())
+            .fromBeginning()
+            .build()) {
+      Assertions.assertNotEquals(0, consumer.poll(Duration.ofSeconds(5)).size());
+      consumer.unsubscribe();
+      Assertions.assertThrows(
+          IllegalStateException.class, () -> consumer.poll(Duration.ofSeconds(2)));
+      // unsubscribe is idempotent op
+      consumer.unsubscribe();
+      consumer.unsubscribe();
+      consumer.unsubscribe();
+
+      consumer.resubscribe();
+      Assertions.assertNotEquals(0, consumer.poll(Duration.ofSeconds(5)).size());
+
+      // resubscribe is idempotent op
+      consumer.resubscribe();
+      consumer.resubscribe();
+      consumer.resubscribe();
+    }
+  }
 }


### PR DESCRIPTION
Astraea consumer 建立後便固定了訂閱的資訊，這樣在測試consumer re-balance時會有些不方便，因此這隻PR讓consumer可以暫時解除訂閱，如此就能自由的觸發re-balance