### PR TITLE
Reset the number of brokers

### DIFF
--- a/app/src/test/java/org/astraea/app/service/RequireBrokerCluster.java
+++ b/app/src/test/java/org/astraea/app/service/RequireBrokerCluster.java
@@ -26,13 +26,30 @@ import org.junit.jupiter.api.AfterAll;
  * which is depended on true cluster.
  */
 public abstract class RequireBrokerCluster extends RequireJmxServer {
-  private static final int NUMBER_OF_BROKERS = 3;
-  private static final ZookeeperCluster ZOOKEEPER_CLUSTER = Services.zookeeperCluster();
-  private static final BrokerCluster BROKER_CLUSTER =
+  private static int NUMBER_OF_BROKERS = 3;
+  private static ZookeeperCluster ZOOKEEPER_CLUSTER = Services.zookeeperCluster();
+  private static BrokerCluster BROKER_CLUSTER =
       Services.brokerCluster(ZOOKEEPER_CLUSTER, NUMBER_OF_BROKERS);
 
   protected static String bootstrapServers() {
     return BROKER_CLUSTER.bootstrapServers();
+  }
+
+  /**
+   * Reset the number of Brokers
+   *
+   * @param numberOfBrokers the number of brokers
+   */
+  protected static void resetBrokerCluster(int numberOfBrokers) {
+    try {
+      BROKER_CLUSTER.close();
+      ZOOKEEPER_CLUSTER.close();
+      ZOOKEEPER_CLUSTER = Services.zookeeperCluster();
+      NUMBER_OF_BROKERS = numberOfBrokers;
+      BROKER_CLUSTER = Services.brokerCluster(ZOOKEEPER_CLUSTER, numberOfBrokers);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 
   protected static Map<Integer, Set<String>> logFolders() {

--- a/app/src/test/java/org/astraea/app/service/RequireJmxServerTest.java
+++ b/app/src/test/java/org/astraea/app/service/RequireJmxServerTest.java
@@ -61,4 +61,12 @@ public class RequireJmxServerTest extends RequireBrokerCluster {
       Assertions.assertTrue(legalChars.contains(address.charAt(i)));
     }
   }
+
+  @Test
+  void testResetBrokerCluster() {
+    resetBrokerCluster(1);
+    Assertions.assertEquals(bootstrapServers().split(",").length, 1);
+    resetBrokerCluster(3);
+    Assertions.assertEquals(bootstrapServers().split(",").length, 3);
+  }
 }


### PR DESCRIPTION
修改測試中的RequireBrokerCluster讓其能重新設置NUMBER_OF_BROKERS。原因在於測試中叢集中的三個節點都會共用一臺機器，導致獲取到的Broker metrics無法鑑別是在哪一個節點上。考慮到正常情況應該是一個節點一臺機器，故爲了保證測試正常進行，讓其能夠修改NUMBER_OF_BROKERS。