### PR TITLE
Wait for file writer complete

### DIFF
--- a/app/src/main/java/org/astraea/app/performance/Performance.java
+++ b/app/src/main/java/org/astraea/app/performance/Performance.java
@@ -168,9 +168,7 @@ public class Performance {
                     tracker));
 
     var fileWriterFuture =
-        fileWriter.isPresent()
-            ? CompletableFuture.runAsync(fileWriter.get())
-            : CompletableFuture.completedFuture(true);
+        fileWriter.map(CompletableFuture::runAsync).orElse(CompletableFuture.completedFuture(null));
 
     CompletableFuture.runAsync(
         () -> {

--- a/app/src/main/java/org/astraea/app/performance/Performance.java
+++ b/app/src/main/java/org/astraea/app/performance/Performance.java
@@ -167,7 +167,10 @@ public class Performance {
                             .sum(),
                     tracker));
 
-    fileWriter.ifPresent(CompletableFuture::runAsync);
+    var fileWriterFuture =
+        fileWriter.isPresent()
+            ? CompletableFuture.runAsync(fileWriter.get())
+            : CompletableFuture.completedFuture(true);
 
     CompletableFuture.runAsync(
         () -> {
@@ -191,6 +194,7 @@ public class Performance {
 
     consumerThreads.forEach(AbstractThread::waitForDone);
     tracker.waitForDone();
+    fileWriterFuture.join();
     return param.topic;
   }
 


### PR DESCRIPTION
執行 Performance tool 時，也等待 FileWriter 完成。

在#512 中，重構了許多thread 管理，其中 `fileWriter` thread 沒有等待完成。
`BufferedWriter` 還未 flush 資料，該 thread 已經被關閉。原來的 `BufferedWriter::close` 來不及執行就結束了。

這裡增加了等待 `fileWriter` thread 完成，讓 `BufferedWriter` 執行完 `close` 才把程式結束。