### PR TITLE
Enable consumer to trace all subscriptions

### DIFF
--- a/app/src/main/java/org/astraea/app/consumer/SubscribedConsumer.java
+++ b/app/src/main/java/org/astraea/app/consumer/SubscribedConsumer.java
@@ -17,7 +17,10 @@
 package org.astraea.app.consumer;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import org.astraea.app.admin.TopicPartition;
 
 /**
  * This inherited consumer offers function related to consumer group.
@@ -42,4 +45,10 @@ public interface SubscribedConsumer<Key, Value> extends Consumer<Key, Value> {
 
   /** @return group instance id (static member) */
   Optional<String> groupInstanceId();
+
+  /**
+   * @return the historical subscription. key is the time of getting assignments. value is the
+   *     assignments.
+   */
+  Map<Long, Set<TopicPartition>> historicalSubscription();
 }

--- a/app/src/test/java/org/astraea/app/consumer/ConsumerTest.java
+++ b/app/src/test/java/org/astraea/app/consumer/ConsumerTest.java
@@ -447,4 +447,72 @@ public class ConsumerTest extends RequireBrokerCluster {
     closed.set(true);
     fs.get();
   }
+
+  @Test
+  void testHistoricalSubscription() {
+    var partitions = 3;
+    var topic = Utils.randomString(10);
+    try (var admin = Admin.of(bootstrapServers())) {
+      admin.creator().topic(topic).numberOfPartitions(partitions).create();
+      Utils.sleep(Duration.ofSeconds(3));
+    }
+
+    var groupId = Utils.randomString(10);
+    var closed = new AtomicBoolean(false);
+
+    var consumers =
+        IntStream.range(0, 2)
+            .mapToObj(
+                ignored ->
+                    Consumer.forTopics(Set.of(topic))
+                        .bootstrapServers(bootstrapServers())
+                        .groupId(groupId)
+                        .enableTrace()
+                        .build())
+            .collect(Collectors.toUnmodifiableList());
+
+    var fs =
+        Utils.sequence(
+            consumers.stream()
+                .map(
+                    c ->
+                        CompletableFuture.runAsync(
+                            () -> {
+                              try (c) {
+                                while (!closed.get()) c.poll(Duration.ofSeconds(1));
+                              }
+                            }))
+                .collect(Collectors.toUnmodifiableList()));
+
+    Utils.waitFor(() -> consumers.stream().allMatch(c -> c.historicalSubscription().size() >= 1));
+
+    // create another consumer to trigger balance
+    try (var consumer =
+        Consumer.forTopics(Set.of(topic))
+            .bootstrapServers(bootstrapServers())
+            .groupId(groupId)
+            .enableTrace()
+            .build()) {
+
+      Utils.waitFor(
+          () -> {
+            consumer.poll(Duration.ofSeconds(1));
+            return consumers.stream().allMatch(c -> c.historicalSubscription().size() > 1);
+          });
+    }
+
+    // produce data to make sure the balance get done.
+    produceData(topic, 100);
+
+    try (var consumer =
+        Consumer.forTopics(Set.of(topic))
+            .bootstrapServers(bootstrapServers())
+            .groupId(groupId)
+            .fromBeginning()
+            .build()) {
+      Utils.waitFor(() -> !consumer.poll(Duration.ofSeconds(1)).isEmpty());
+      Assertions.assertTrue(
+          consumers.stream().anyMatch(c -> c.historicalSubscription().size() > 1));
+    }
+  }
 }


### PR DESCRIPTION
當啟用追蹤時，`consumer`會紀錄每次 balance後的結果和時間，這會方便我們在performance印出相關資訊