### PR TITLE
Avoid creating too many partition lists

### DIFF
--- a/app/src/main/java/org/astraea/app/admin/ClusterInfo.java
+++ b/app/src/main/java/org/astraea/app/admin/ClusterInfo.java
@@ -82,7 +82,7 @@ public interface ClusterInfo {
             .filter(ReplicaInfo::isOnlineReplica)
             .filter(ReplicaInfo::isLeader)
             .collect(Collectors.groupingBy(ReplicaInfo::topic));
-    // This group is used commonly, so we cached it.
+    // This group is used commonly, so we cache it.
     var availableLeaderReplicasForBrokersTopics =
         allReplicas.stream()
             .filter(ReplicaInfo::isOnlineReplica)

--- a/app/src/main/java/org/astraea/app/admin/ClusterInfo.java
+++ b/app/src/main/java/org/astraea/app/admin/ClusterInfo.java
@@ -155,8 +155,7 @@ public interface ClusterInfo {
    * Get the list of replica leader information of each available partition for the given topic
    *
    * @param topic The Topic name
-   * @return A list of {@link ReplicaInfo}. It throws NoSuchElementException if the replica info of
-   *     the given topic is unknown to this ClusterInfo
+   * @return A list of {@link ReplicaInfo}.
    */
   List<ReplicaInfo> availableReplicaLeaders(String topic);
 
@@ -166,8 +165,7 @@ public interface ClusterInfo {
    *
    * @param broker the broker id
    * @param topic The Topic name
-   * @return A list of {@link ReplicaInfo}. It throws NoSuchElementException if the replica info of
-   *     the given topic is unknown to this ClusterInfo
+   * @return A list of {@link ReplicaInfo}.
    */
   default List<ReplicaInfo> availableReplicaLeaders(int broker, String topic) {
     return availableReplicaLeaders(topic).stream()
@@ -180,8 +178,7 @@ public interface ClusterInfo {
    * topic
    *
    * @param topic The topic name
-   * @return A list of {@link ReplicaInfo}. It throws NoSuchElementException if the replica info of
-   *     the given topic is unknown to this ClusterInfo
+   * @return A list of {@link ReplicaInfo}.
    */
   List<ReplicaInfo> availableReplicas(String topic);
 
@@ -196,8 +193,7 @@ public interface ClusterInfo {
    * Get the list of replica information of each partition/replica pair for the given topic
    *
    * @param topic The topic name
-   * @return A list of {@link ReplicaInfo}. It throws NoSuchElementException if the replica info of
-   *     the given topic is unknown to this ClusterInfo
+   * @return A list of {@link ReplicaInfo}.
    */
   List<ReplicaInfo> replicas(String topic);
 }

--- a/app/src/main/java/org/astraea/app/admin/ClusterInfo.java
+++ b/app/src/main/java/org/astraea/app/admin/ClusterInfo.java
@@ -16,7 +16,6 @@
  */
 package org.astraea.app.admin;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -68,21 +67,28 @@ public interface ClusterInfo {
   static ClusterInfo of(org.apache.kafka.common.Cluster cluster) {
     var nodes = cluster.nodes().stream().map(NodeInfo::of).collect(Collectors.toUnmodifiableList());
     var topics = cluster.topics();
-    var replicas =
+    var allReplicas =
         topics.stream()
-            .flatMap(t -> cluster.availablePartitionsForTopic(t).stream())
+            .flatMap(t -> cluster.partitionsForTopic(t).stream())
             .flatMap(p -> ReplicaInfo.of(p).stream())
             .collect(Collectors.toUnmodifiableList());
-    var availableReplicas = replicas.stream().collect(Collectors.groupingBy(ReplicaInfo::topic));
-    var availableReplicaLeaders =
-        availableReplicas.entrySet().stream()
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey,
-                    e ->
-                        e.getValue().stream()
-                            .filter(ReplicaInfo::isLeader)
-                            .collect(Collectors.toCollection(ArrayList::new))));
+    var replicasForTopic = allReplicas.stream().collect(Collectors.groupingBy(ReplicaInfo::topic));
+    var availableReplicasForTopic =
+        allReplicas.stream()
+            .filter(ReplicaInfo::isOnlineReplica)
+            .collect(Collectors.groupingBy(ReplicaInfo::topic));
+    var availableReplicaLeadersForTopics =
+        allReplicas.stream()
+            .filter(ReplicaInfo::isOnlineReplica)
+            .filter(ReplicaInfo::isLeader)
+            .collect(Collectors.groupingBy(ReplicaInfo::topic));
+    // This group is used commonly, so we cached it.
+    var availableLeaderReplicasForBrokersTopics =
+        allReplicas.stream()
+            .filter(ReplicaInfo::isOnlineReplica)
+            .filter(ReplicaInfo::isLeader)
+            .collect(Collectors.groupingBy(r -> Map.entry(r.nodeInfo().id(), r.topic())));
+
     return new ClusterInfo() {
       @Override
       public List<NodeInfo> nodes() {
@@ -101,35 +107,25 @@ public interface ClusterInfo {
 
       @Override
       public List<ReplicaInfo> availableReplicaLeaders(String topic) {
-        return availableReplicaLeaders.getOrDefault(topic, new ArrayList<>(0));
+        return availableReplicaLeadersForTopics.getOrDefault(topic, List.of());
+      }
+
+      @Override
+      public List<ReplicaInfo> availableReplicaLeaders(int broker, String topic) {
+        return availableLeaderReplicasForBrokersTopics.getOrDefault(
+            Map.entry(broker, topic), List.of());
       }
 
       @Override
       public List<ReplicaInfo> availableReplicas(String topic) {
-        return availableReplicas.getOrDefault(topic, List.of());
+        return availableReplicasForTopic.getOrDefault(topic, List.of());
       }
 
       @Override
       public List<ReplicaInfo> replicas(String topic) {
-        return replicas;
+        return replicasForTopic.getOrDefault(topic, List.of());
       }
     };
-  }
-
-  /**
-   * find the node associated to specify node and port. Normally, the node + port should be unique
-   * in cluster.
-   *
-   * @param host hostname
-   * @param port client port
-   * @return the node information. It throws NoSuchElementException if specify node and port is not
-   *     associated to any node
-   */
-  default NodeInfo node(String host, int port) {
-    return nodes().stream()
-        .filter(n -> n.host().equals(host) && n.port() == port)
-        .findAny()
-        .orElseThrow(() -> new NoSuchElementException(host + ":" + port + " is nonexistent"));
   }
 
   /**
@@ -163,6 +159,21 @@ public interface ClusterInfo {
    *     the given topic is unknown to this ClusterInfo
    */
   List<ReplicaInfo> availableReplicaLeaders(String topic);
+
+  /**
+   * Get the list of replica leader information of each available partition for the given
+   * broker/topic
+   *
+   * @param broker the broker id
+   * @param topic The Topic name
+   * @return A list of {@link ReplicaInfo}. It throws NoSuchElementException if the replica info of
+   *     the given topic is unknown to this ClusterInfo
+   */
+  default List<ReplicaInfo> availableReplicaLeaders(int broker, String topic) {
+    return availableReplicaLeaders(topic).stream()
+        .filter(r -> r.nodeInfo().id() == broker)
+        .collect(Collectors.toUnmodifiableList());
+  }
 
   /**
    * Get the list of replica information of each available partition/replica pair for the given

--- a/app/src/main/java/org/astraea/app/partitioner/smooth/SmoothWeightRoundRobinDispatcher.java
+++ b/app/src/main/java/org/astraea/app/partitioner/smooth/SmoothWeightRoundRobinDispatcher.java
@@ -66,7 +66,7 @@ public class SmoothWeightRoundRobinDispatcher extends Periodic<Map<Integer, Doub
   private final NeutralIntegratedCost neutralIntegratedCost = new NeutralIntegratedCost();
 
   private Map<Integer, Collection<HasBeanObject>> beans;
-  private Collection<ReplicaInfo> partitions;
+  private List<ReplicaInfo> partitions;
 
   public static final String JMX_PORT = "jmx.port";
 

--- a/app/src/main/java/org/astraea/app/partitioner/smooth/SmoothWeightRoundRobinDispatcher.java
+++ b/app/src/main/java/org/astraea/app/partitioner/smooth/SmoothWeightRoundRobinDispatcher.java
@@ -66,7 +66,7 @@ public class SmoothWeightRoundRobinDispatcher extends Periodic<Map<Integer, Doub
   private final NeutralIntegratedCost neutralIntegratedCost = new NeutralIntegratedCost();
 
   private Map<Integer, Collection<HasBeanObject>> beans;
-  private List<ReplicaInfo> partitions;
+  private Collection<ReplicaInfo> partitions;
 
   public static final String JMX_PORT = "jmx.port";
 

--- a/app/src/test/java/org/astraea/app/admin/AdminTest.java
+++ b/app/src/test/java/org/astraea/app/admin/AdminTest.java
@@ -737,8 +737,6 @@ public class AdminTest extends RequireBrokerCluster {
           NoSuchElementException.class, () -> clusterInfo.availableReplicaLeaders("Unknown Topic"));
       Assertions.assertThrows(NoSuchElementException.class, () -> clusterInfo.dataDirectories(-1));
       Assertions.assertThrows(NoSuchElementException.class, () -> clusterInfo.node(-1));
-      Assertions.assertThrows(
-          NoSuchElementException.class, () -> clusterInfo.node("unknown", 1024));
     }
   }
 

--- a/app/src/test/java/org/astraea/app/cost/ClusterInfoTest.java
+++ b/app/src/test/java/org/astraea/app/cost/ClusterInfoTest.java
@@ -43,7 +43,6 @@ public class ClusterInfoTest {
 
     Assertions.assertEquals(1, clusterInfo.nodes().size());
     Assertions.assertEquals(NodeInfo.of(node), clusterInfo.nodes().get(0));
-    Assertions.assertEquals(clusterInfo.nodes().get(0), clusterInfo.node(node.host(), node.port()));
     Assertions.assertEquals(1, clusterInfo.availableReplicas(partition.topic()).size());
     Assertions.assertEquals(1, clusterInfo.replicas(partition.topic()).size());
     Assertions.assertEquals(
@@ -60,7 +59,6 @@ public class ClusterInfoTest {
     var clusterInfo = ClusterInfo.of(Cluster.empty());
     Assertions.assertEquals(0, clusterInfo.replicas("unknown").size());
     Assertions.assertThrows(NoSuchElementException.class, () -> clusterInfo.node(0));
-    Assertions.assertThrows(NoSuchElementException.class, () -> clusterInfo.node("", -1));
     Assertions.assertEquals(0, clusterInfo.availableReplicas("unknown").size());
     Assertions.assertEquals(0, clusterInfo.availableReplicaLeaders("unknown").size());
     Assertions.assertThrows(


### PR DESCRIPTION
<img width="1311" alt="截圖 2022-08-21 上午1 45 47" src="https://user-images.githubusercontent.com/6234750/185763400-097e9752-a4cb-450a-b466-0346e8af85f5.png">

主要原因是最後產生 <broker, topic> partitions 的時候會產生新的陣列，當 partitions 數量很多時會有明顯的成本，因此在建立ClusterInfo的時候我們就先分類好以避免後續的成本