### PR TITLE
Support to execute migration plans by Reassignment Web API

### DIFF
--- a/app/src/main/java/org/astraea/app/web/ReassignmentHandler.java
+++ b/app/src/main/java/org/astraea/app/web/ReassignmentHandler.java
@@ -24,6 +24,7 @@ import org.astraea.app.admin.Admin;
 import org.astraea.app.admin.TopicPartition;
 
 public class ReassignmentHandler implements Handler {
+  static final String PLANS_KEY = "plans";
   static final String TOPIC_KEY = "topic";
   static final String PARTITION_KEY = "partition";
   static final String FROM_KEY = "from";
@@ -36,23 +37,31 @@ public class ReassignmentHandler implements Handler {
   }
 
   @Override
-  public Response post(PostRequest request) {
-    // case 0: move replica to another folder
-    if (request.has(BROKER_KEY, TOPIC_KEY, PARTITION_KEY, TO_KEY)) {
-      admin
-          .migrator()
-          .partition(request.value(TOPIC_KEY), request.intValue(PARTITION_KEY))
-          .moveTo(Map.of(request.intValue(BROKER_KEY), request.value(TO_KEY)));
-      return Response.ACCEPT;
-    }
-    // case 1: move replica to another broker
-    if (request.has(TOPIC_KEY, PARTITION_KEY, TO_KEY)) {
-      admin
-          .migrator()
-          .partition(request.value(TOPIC_KEY), request.intValue(PARTITION_KEY))
-          .moveTo(request.intValues(TO_KEY));
-      return Response.ACCEPT;
-    }
+  public Response post(PostRequest requests) {
+    var rs =
+        requests.requests(PLANS_KEY).stream()
+            .map(
+                request -> {
+                  // case 0: move replica to another folder
+                  if (request.has(BROKER_KEY, TOPIC_KEY, PARTITION_KEY, TO_KEY)) {
+                    admin
+                        .migrator()
+                        .partition(request.value(TOPIC_KEY), request.intValue(PARTITION_KEY))
+                        .moveTo(Map.of(request.intValue(BROKER_KEY), request.value(TO_KEY)));
+                    return Response.ACCEPT;
+                  }
+                  // case 1: move replica to another broker
+                  if (request.has(TOPIC_KEY, PARTITION_KEY, TO_KEY)) {
+                    admin
+                        .migrator()
+                        .partition(request.value(TOPIC_KEY), request.intValue(PARTITION_KEY))
+                        .moveTo(request.intValues(TO_KEY));
+                    return Response.ACCEPT;
+                  }
+                  return Response.BAD_REQUEST;
+                })
+            .collect(Collectors.toUnmodifiableList());
+    if (!rs.isEmpty() && rs.stream().allMatch(r -> r == Response.ACCEPT)) return Response.ACCEPT;
     return Response.BAD_REQUEST;
   }
 

--- a/docs/web_server/web_api_reassignments_chinese.md
+++ b/docs/web_server/web_api_reassignments_chinese.md
@@ -63,11 +63,11 @@ cURL 範例
 ```shell
 curl -X POST http://localhost:8001/reassignments \
     -H "Content-Type: application/json" \
-    -d '{
+    -d '"plans":[{
     "topic": "chia", 
     "partition": 0,
     "to": [1003]
-    }' 
+    }]' 
 ```
 
 ## 變更 replica 的資料路徑
@@ -90,10 +90,10 @@ cURL 範例
 ```shell
 curl -X POST http://localhost:8001/reassignments \
     -H "Content-Type: application/json" \
-    -d '{
+    -d '"plans":[{
     "topic": "chia", 
     "partition": 0,
     "broker": 1003
     "to": "/tmp/data"
-    }' 
+    }]' 
 ```


### PR DESCRIPTION
支援一次執行多個migration plans，這會方便我們之後執行balancer