### PR TITLE
Remove ClusterInfo#dataDirectories

### DIFF
--- a/app/src/main/java/org/astraea/app/balancer/BalanceProcessDemo.java
+++ b/app/src/main/java/org/astraea/app/balancer/BalanceProcessDemo.java
@@ -48,7 +48,11 @@ public class BalanceProcessDemo {
       var clusterInfo = admin.clusterInfo(topics);
 
       // TODO: implement one interface to select the best plan from many plan ,see #544
-      var rebalancePlan = rebalancePlanGenerator.generate(clusterInfo).findFirst().orElseThrow();
+      var rebalancePlan =
+          rebalancePlanGenerator
+              .generate(admin.brokerFolders(), ClusterLogAllocation.of(clusterInfo))
+              .findFirst()
+              .orElseThrow();
       System.out.println(rebalancePlan);
       var targetAllocation = rebalancePlan.rebalancePlan();
 

--- a/app/src/main/java/org/astraea/app/balancer/generator/RebalancePlanGenerator.java
+++ b/app/src/main/java/org/astraea/app/balancer/generator/RebalancePlanGenerator.java
@@ -16,34 +16,15 @@
  */
 package org.astraea.app.balancer.generator;
 
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.astraea.app.admin.ClusterInfo;
 import org.astraea.app.balancer.RebalancePlanProposal;
 import org.astraea.app.balancer.log.ClusterLogAllocation;
 
-/** */
+@FunctionalInterface
 public interface RebalancePlanGenerator {
-
-  /**
-   * Generate a rebalance proposal, noted that this function doesn't require proposing exactly the
-   * same plan for the same input argument. There can be some randomization that takes part in this
-   * process.
-   *
-   * <p>If the generator implementation thinks it can't find any rebalance proposal(which the plan
-   * might improve the cluster). Then the implementation should return a Stream with exactly one
-   * rebalance plan proposal in it, where the proposed allocation will be exactly the same as the
-   * {@code baseAllocation} parameter. This means there is no movement or alteration will occur. And
-   * the implementation should place some detailed information in the info/warning/error string, to
-   * indicate the reason for no meaningful plan.
-   *
-   * @param clusterInfo the cluster state, implementation can take advantage of the data inside to
-   *     proposal the plan it feels confident to improve the cluster.
-   * @return a {@link Stream} generating rebalance plan regarding the given {@link ClusterInfo}
-   */
-  default Stream<RebalancePlanProposal> generate(ClusterInfo clusterInfo) {
-    return generate(clusterInfo, ClusterLogAllocation.of(clusterInfo));
-  }
-
   /**
    * Generate a rebalance proposal, noted that this function doesn't require proposing exactly the
    * same plan for the same input argument. There can be some randomization that takes part in this
@@ -56,11 +37,10 @@ public interface RebalancePlanGenerator {
    * occur. And The implementation should place some detailed information in the info/warning/error
    * string, to indicate the reason for no meaningful plan.
    *
-   * @param clusterInfo the cluster state, implementation can take advantage of the data inside to
-   *     proposal the plan it feels confident to improve the cluster.
+   * @param brokerFolders key is the broker id, and the value is the folder used to keep data
    * @param baseAllocation the cluster log allocation as the based of proposal generation.
    * @return a {@link Stream} generating rebalance plan regarding the given {@link ClusterInfo}
    */
   Stream<RebalancePlanProposal> generate(
-      ClusterInfo clusterInfo, ClusterLogAllocation baseAllocation);
+      Map<Integer, Set<String>> brokerFolders, ClusterLogAllocation baseAllocation);
 }

--- a/app/src/main/java/org/astraea/app/balancer/generator/ShufflePlanGenerator.java
+++ b/app/src/main/java/org/astraea/app/balancer/generator/ShufflePlanGenerator.java
@@ -19,14 +19,14 @@ package org.astraea.app.balancer.generator;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.astraea.app.admin.ClusterInfo;
-import org.astraea.app.admin.NodeInfo;
 import org.astraea.app.admin.TopicPartition;
 import org.astraea.app.balancer.RebalancePlanProposal;
 import org.astraea.app.balancer.log.ClusterLogAllocation;
@@ -62,11 +62,8 @@ public class ShufflePlanGenerator implements RebalancePlanGenerator {
 
   @Override
   public Stream<RebalancePlanProposal> generate(
-      ClusterInfo clusterInfo, ClusterLogAllocation baseAllocation) {
-    final var brokerIds =
-        clusterInfo.nodes().stream().map(NodeInfo::id).collect(Collectors.toUnmodifiableSet());
-
-    if (brokerIds.size() == 0) {
+      Map<Integer, Set<String>> brokerFolders, ClusterLogAllocation baseAllocation) {
+    if (brokerFolders.isEmpty()) {
       return Stream.of(
           RebalancePlanProposal.builder()
               .withRebalancePlan(baseAllocation)
@@ -74,7 +71,7 @@ public class ShufflePlanGenerator implements RebalancePlanGenerator {
               .build());
     }
 
-    if (brokerIds.size() == 1) {
+    if (brokerFolders.size() == 1) {
       return Stream.of(
           RebalancePlanProposal.builder()
               .withRebalancePlan(baseAllocation)
@@ -82,7 +79,7 @@ public class ShufflePlanGenerator implements RebalancePlanGenerator {
               .build());
     }
 
-    if (clusterInfo.topics().size() == 0) {
+    if (baseAllocation.topicPartitions().isEmpty()) {
       return Stream.of(
           RebalancePlanProposal.builder()
               .withRebalancePlan(baseAllocation)
@@ -100,7 +97,7 @@ public class ShufflePlanGenerator implements RebalancePlanGenerator {
 
           var candidates =
               IntStream.range(0, shuffleCount)
-                  .mapToObj(i -> allocationGenerator(clusterInfo, rebalancePlanBuilder))
+                  .mapToObj(i -> allocationGenerator(brokerFolders, rebalancePlanBuilder))
                   .collect(Collectors.toUnmodifiableList());
 
           var currentAllocation = baseAllocation;
@@ -111,10 +108,8 @@ public class ShufflePlanGenerator implements RebalancePlanGenerator {
   }
 
   private static Function<ClusterLogAllocation, ClusterLogAllocation> allocationGenerator(
-      ClusterInfo clusterInfo, RebalancePlanProposal.Build rebalancePlanBuilder) {
+      Map<Integer, Set<String>> brokerFolders, RebalancePlanProposal.Build rebalancePlanBuilder) {
     return currentAllocation -> {
-      var brokerIds =
-          clusterInfo.nodes().stream().map(NodeInfo::id).collect(Collectors.toUnmodifiableSet());
       var pickingList = new ArrayList<>(currentAllocation.topicPartitions());
       final var sourceTopicPartitionIndex = sourceTopicPartitionSelector(pickingList);
       final var sourceTopicPartition = pickingList.get(sourceTopicPartitionIndex);
@@ -135,7 +130,7 @@ public class ShufflePlanGenerator implements RebalancePlanGenerator {
 
                   // [Valid movement 1] add all brokers and remove all
                   // broker in current replica set
-                  brokerIds.stream()
+                  brokerFolders.keySet().stream()
                       .filter(
                           broker ->
                               sourceLogPlacements.stream().noneMatch(log -> log.broker() == broker))
@@ -143,8 +138,7 @@ public class ShufflePlanGenerator implements RebalancePlanGenerator {
                           targetBroker ->
                               (Supplier<ClusterLogAllocation>)
                                   () -> {
-                                    var destDir =
-                                        randomElement(clusterInfo.dataDirectories(targetBroker));
+                                    var destDir = randomElement(brokerFolders.get(targetBroker));
                                     rebalancePlanBuilder.addInfo(
                                         String.format(
                                             "Change replica set of topic %s partition %d, from %d to %d at %s.",

--- a/app/src/test/java/org/astraea/app/admin/AdminTest.java
+++ b/app/src/test/java/org/astraea/app/admin/AdminTest.java
@@ -713,10 +713,6 @@ public class AdminTest extends RequireBrokerCluster {
       Assertions.assertEquals(partitionCount * replicaCount, clusterInfo.replicas(topic0).size());
       Assertions.assertEquals(partitionCount * replicaCount, clusterInfo.replicas(topic1).size());
       Assertions.assertEquals(partitionCount * replicaCount, clusterInfo.replicas(topic2).size());
-      // ClusterInfo#dataDirectories
-      brokerIds()
-          .forEach(
-              id -> Assertions.assertEquals(logFolders().get(id), clusterInfo.dataDirectories(id)));
       // ClusterInfo#availableReplicas
       Assertions.assertEquals(
           partitionCount * replicaCount, clusterInfo.availableReplicas(topic0).size());
@@ -729,13 +725,9 @@ public class AdminTest extends RequireBrokerCluster {
       Assertions.assertEquals(partitionCount, clusterInfo.availableReplicaLeaders(topic1).size());
       Assertions.assertEquals(partitionCount, clusterInfo.availableReplicaLeaders(topic2).size());
       // No resource match found will raise exception
-      Assertions.assertThrows(
-          NoSuchElementException.class, () -> clusterInfo.replicas("Unknown Topic"));
-      Assertions.assertThrows(
-          NoSuchElementException.class, () -> clusterInfo.availableReplicas("Unknown Topic"));
-      Assertions.assertThrows(
-          NoSuchElementException.class, () -> clusterInfo.availableReplicaLeaders("Unknown Topic"));
-      Assertions.assertThrows(NoSuchElementException.class, () -> clusterInfo.dataDirectories(-1));
+      Assertions.assertEquals(List.of(), clusterInfo.replicas("Unknown Topic"));
+      Assertions.assertEquals(List.of(), clusterInfo.availableReplicas("Unknown Topic"));
+      Assertions.assertEquals(List.of(), clusterInfo.availableReplicaLeaders("Unknown Topic"));
       Assertions.assertThrows(NoSuchElementException.class, () -> clusterInfo.node(-1));
     }
   }

--- a/app/src/test/java/org/astraea/app/balancer/RebalancePlanProposalTest.java
+++ b/app/src/test/java/org/astraea/app/balancer/RebalancePlanProposalTest.java
@@ -17,7 +17,6 @@
 package org.astraea.app.balancer;
 
 import org.astraea.app.balancer.log.ClusterLogAllocation;
-import org.astraea.app.cost.ClusterInfoProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -25,8 +24,8 @@ class RebalancePlanProposalTest {
 
   @Test
   void testBuild() {
-    final var fakeClusterInfo = ClusterInfoProvider.fakeClusterInfo(10, 10, 10, 10);
-    final var thisAllocation = ClusterLogAllocation.of(fakeClusterInfo);
+    final var fakeCluster = FakeClusterInfo.of(10, 10, 10, 10);
+    final var thisAllocation = ClusterLogAllocation.of(fakeCluster);
     final var build =
         RebalancePlanProposal.builder()
             .withRebalancePlan(thisAllocation)

--- a/app/src/test/java/org/astraea/app/balancer/generator/ShufflePlanGeneratorTest.java
+++ b/app/src/test/java/org/astraea/app/balancer/generator/ShufflePlanGeneratorTest.java
@@ -20,9 +20,9 @@ import java.time.Duration;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
+import org.astraea.app.balancer.FakeClusterInfo;
 import org.astraea.app.balancer.log.ClusterLogAllocation;
 import org.astraea.app.common.Utils;
-import org.astraea.app.cost.ClusterInfoProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -35,8 +35,10 @@ class ShufflePlanGeneratorTest {
   @Test
   void testRun() {
     final var shufflePlanGenerator = new ShufflePlanGenerator(5, 10);
-    final var fakeCluster = ClusterInfoProvider.fakeClusterInfo(100, 10, 10, 3);
-    final var stream = shufflePlanGenerator.generate(fakeCluster);
+    final var fakeCluster = FakeClusterInfo.of(100, 10, 10, 3);
+    final var stream =
+        shufflePlanGenerator.generate(
+            fakeCluster.dataDirectories(), ClusterLogAllocation.of(fakeCluster));
     final var iterator = stream.iterator();
 
     Assertions.assertDoesNotThrow(() -> System.out.println(iterator.next()));
@@ -47,12 +49,12 @@ class ShufflePlanGeneratorTest {
   @ParameterizedTest
   @ValueSource(ints = {3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 301})
   void testMovement(int shuffle) {
-    final var fakeClusterInfo = ClusterInfoProvider.fakeClusterInfo(30, 30, 20, 5);
-    final var allocation = ClusterLogAllocation.of(fakeClusterInfo);
+    final var fakeCluster = FakeClusterInfo.of(30, 30, 20, 5);
+    final var allocation = ClusterLogAllocation.of(fakeCluster);
     final var shufflePlanGenerator = new ShufflePlanGenerator(() -> shuffle);
 
     shufflePlanGenerator
-        .generate(fakeClusterInfo)
+        .generate(fakeCluster.dataDirectories(), ClusterLogAllocation.of(fakeCluster))
         .limit(100)
         .forEach(
             proposal -> {
@@ -72,46 +74,73 @@ class ShufflePlanGeneratorTest {
 
   @Test
   void testNoNodes() {
-    final var fakeClusterInfo = ClusterInfoProvider.fakeClusterInfo(0, 0, 0, 0);
+    final var fakeCluster = FakeClusterInfo.of(0, 0, 0, 0);
     final var shufflePlanGenerator = new ShufflePlanGenerator(() -> 3);
 
-    final var proposal = shufflePlanGenerator.generate(fakeClusterInfo).iterator().next();
+    final var proposal =
+        shufflePlanGenerator
+            .generate(fakeCluster.dataDirectories(), ClusterLogAllocation.of(fakeCluster))
+            .iterator()
+            .next();
 
     System.out.println(proposal);
     Assertions.assertTrue(
         ClusterLogAllocation.findNonFulfilledAllocation(
-                ClusterLogAllocation.of(fakeClusterInfo), proposal.rebalancePlan())
+                ClusterLogAllocation.of(fakeCluster), proposal.rebalancePlan())
             .isEmpty());
     Assertions.assertTrue(proposal.warnings().size() >= 1);
-    Assertions.assertEquals(1, shufflePlanGenerator.generate(fakeClusterInfo).limit(10).count());
+    Assertions.assertEquals(
+        1,
+        shufflePlanGenerator
+            .generate(fakeCluster.dataDirectories(), ClusterLogAllocation.of(fakeCluster))
+            .limit(10)
+            .count());
   }
 
   @Test
   void testOneNode() {
-    final var fakeClusterInfo = ClusterInfoProvider.fakeClusterInfo(1, 1, 1, 1);
+    final var fakeCluster = FakeClusterInfo.of(1, 1, 1, 1);
     final var shufflePlanGenerator = new ShufflePlanGenerator(() -> 3);
 
-    final var proposal = shufflePlanGenerator.generate(fakeClusterInfo).iterator().next();
+    final var proposal =
+        shufflePlanGenerator
+            .generate(fakeCluster.dataDirectories(), ClusterLogAllocation.of(fakeCluster))
+            .iterator()
+            .next();
 
     System.out.println(proposal);
     Assertions.assertTrue(proposal.warnings().size() >= 1);
-    Assertions.assertEquals(1, shufflePlanGenerator.generate(fakeClusterInfo).limit(10).count());
+    Assertions.assertEquals(
+        1,
+        shufflePlanGenerator
+            .generate(fakeCluster.dataDirectories(), ClusterLogAllocation.of(fakeCluster))
+            .limit(10)
+            .count());
   }
 
   @Test
   void testNoTopic() {
-    final var fakeClusterInfo = ClusterInfoProvider.fakeClusterInfo(3, 0, 0, 0);
+    final var fakeCluster = FakeClusterInfo.of(3, 0, 0, 0);
     final var shufflePlanGenerator = new ShufflePlanGenerator(() -> 3);
 
-    final var proposal = shufflePlanGenerator.generate(fakeClusterInfo).iterator().next();
+    final var proposal =
+        shufflePlanGenerator
+            .generate(fakeCluster.dataDirectories(), ClusterLogAllocation.of(fakeCluster))
+            .iterator()
+            .next();
 
     System.out.println(proposal);
     Assertions.assertTrue(
         ClusterLogAllocation.findNonFulfilledAllocation(
-                ClusterLogAllocation.of(fakeClusterInfo), proposal.rebalancePlan())
+                ClusterLogAllocation.of(fakeCluster), proposal.rebalancePlan())
             .isEmpty());
     Assertions.assertTrue(proposal.warnings().size() >= 1);
-    Assertions.assertEquals(1, shufflePlanGenerator.generate(fakeClusterInfo).limit(10).count());
+    Assertions.assertEquals(
+        1,
+        shufflePlanGenerator
+            .generate(fakeCluster.dataDirectories(), ClusterLogAllocation.of(fakeCluster))
+            .limit(10)
+            .count());
   }
 
   @ParameterizedTest(name = "[{0}] {1} nodes, {2} topics, {3} partitions, {4} replicas")
@@ -131,12 +160,15 @@ class ShufflePlanGeneratorTest {
     // Notice: Stream#limit() will hurt performance. the number here might not reflect the actual
     // performance.
     final var shufflePlanGenerator = new ShufflePlanGenerator(0, 10);
-    final var fakeClusterInfo =
-        ClusterInfoProvider.fakeClusterInfo(nodeCount, topicCount, partitionCount, replicaCount);
+    final var fakeCluster = FakeClusterInfo.of(nodeCount, topicCount, partitionCount, replicaCount);
     final var size = 1000;
 
     final long s = System.nanoTime();
-    final var count = shufflePlanGenerator.generate(fakeClusterInfo).limit(size).count();
+    final var count =
+        shufflePlanGenerator
+            .generate(fakeCluster.dataDirectories(), ClusterLogAllocation.of(fakeCluster))
+            .limit(size)
+            .count();
     final long t = System.nanoTime();
     Assertions.assertEquals(size, count);
     System.out.printf("[%s]%n", scenario);
@@ -150,18 +182,23 @@ class ShufflePlanGeneratorTest {
   @Test
   void parallelStreamWorks() {
     final var shufflePlanGenerator = new ShufflePlanGenerator(0, 10);
-    final var fakeClusterInfo = ClusterInfoProvider.fakeClusterInfo(10, 20, 10, 3);
+    final var fakeCluster = FakeClusterInfo.of(10, 20, 10, 3);
 
     // generator can do parallel without error.
     Assertions.assertDoesNotThrow(
-        () -> shufflePlanGenerator.generate(fakeClusterInfo).parallel().limit(100).count());
+        () ->
+            shufflePlanGenerator
+                .generate(fakeCluster.dataDirectories(), ClusterLogAllocation.of(fakeCluster))
+                .parallel()
+                .limit(100)
+                .count());
   }
 
   @Test
   @Disabled
   void parallelPerformanceTests() throws InterruptedException {
     final var shufflePlanGenerator = new ShufflePlanGenerator(0, 10);
-    final var fakeClusterInfo = ClusterInfoProvider.fakeClusterInfo(50, 500, 30, 2);
+    final var fakeCluster = FakeClusterInfo.of(50, 500, 30, 2);
     final var counter = new LongAdder();
     final var forkJoinPool = new ForkJoinPool(ForkJoinPool.getCommonPoolParallelism());
     final var startTime = System.nanoTime();
@@ -169,7 +206,7 @@ class ShufflePlanGeneratorTest {
     forkJoinPool.submit(
         () ->
             shufflePlanGenerator
-                .generate(fakeClusterInfo)
+                .generate(fakeCluster.dataDirectories(), ClusterLogAllocation.of(fakeCluster))
                 .parallel()
                 .forEach((ignore) -> counter.increment()));
 

--- a/app/src/test/java/org/astraea/app/cost/ClusterInfoTest.java
+++ b/app/src/test/java/org/astraea/app/cost/ClusterInfoTest.java
@@ -61,7 +61,5 @@ public class ClusterInfoTest {
     Assertions.assertThrows(NoSuchElementException.class, () -> clusterInfo.node(0));
     Assertions.assertEquals(0, clusterInfo.availableReplicas("unknown").size());
     Assertions.assertEquals(0, clusterInfo.availableReplicaLeaders("unknown").size());
-    Assertions.assertThrows(
-        UnsupportedOperationException.class, () -> clusterInfo.dataDirectories(0));
   }
 }


### PR DESCRIPTION
1. 移除`ClusterInfo#dataDirectories`，該方法完全只為了`RebalancePlanGenerator`存在，而且在其他情境會產生矛盾（不存在）
2. 重構`RebalancePlanGenerator`讓其可以解構`ClusterInfo#dataDirectories`
3. 新增大量預設方法到`ClusterInfo`，降低其實作的複雜度