### PR TITLE
Refactor Response callback

### DIFF
--- a/app/src/main/java/org/astraea/app/web/BalancerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BalancerHandler.java
@@ -19,7 +19,6 @@ package org.astraea.app.web;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.astraea.app.admin.Admin;
 import org.astraea.app.admin.ClusterBean;
@@ -50,11 +49,12 @@ class BalancerHandler implements Handler {
   }
 
   @Override
-  public Response get(Optional<String> target, Map<String, String> queries) {
+  public Response get(Channel channel) {
     var clusterInfo = admin.clusterInfo();
     var clusterAllocation = ClusterLogAllocation.of(clusterInfo);
     var cost = costFunction.clusterCost(clusterInfo, ClusterBean.EMPTY).value();
-    var limit = Integer.parseInt(queries.getOrDefault(LIMIT_KEY, String.valueOf(LIMIT_DEFAULT)));
+    var limit =
+        Integer.parseInt(channel.queries().getOrDefault(LIMIT_KEY, String.valueOf(LIMIT_DEFAULT)));
     var planAndCost =
         generator
             .generate(admin.brokerFolders(), clusterAllocation)

--- a/app/src/main/java/org/astraea/app/web/BeanHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BeanHandler.java
@@ -17,8 +17,6 @@
 package org.astraea.app.web;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.astraea.app.admin.Admin;
@@ -37,9 +35,9 @@ public class BeanHandler implements Handler {
   }
 
   @Override
-  public Response get(Optional<String> domain, Map<String, String> properties) {
-    var builder = BeanQuery.builder().usePropertyListPattern().properties(properties);
-    domain.ifPresent(builder::domainName);
+  public Response get(Channel channel) {
+    var builder = BeanQuery.builder().usePropertyListPattern().properties(channel.queries());
+    channel.target().ifPresent(builder::domainName);
     return new NodeBeans(
         clients.stream()
             .map(

--- a/app/src/main/java/org/astraea/app/web/BrokerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BrokerHandler.java
@@ -44,13 +44,13 @@ class BrokerHandler implements Handler {
   }
 
   @Override
-  public Response get(Optional<String> target, Map<String, String> queries) {
+  public Response get(Channel channel) {
 
     var brokers =
-        admin.brokers(brokers(target)).entrySet().stream()
+        admin.brokers(brokers(channel.target())).entrySet().stream()
             .map(e -> new Broker(e.getKey(), admin.partitions(e.getKey()), e.getValue()))
             .collect(Collectors.toUnmodifiableList());
-    if (target.isPresent() && brokers.size() == 1) return brokers.get(0);
+    if (channel.target().isPresent() && brokers.size() == 1) return brokers.get(0);
     return new Brokers(brokers);
   }
 

--- a/app/src/main/java/org/astraea/app/web/Channel.java
+++ b/app/src/main/java/org/astraea/app/web/Channel.java
@@ -144,7 +144,7 @@ interface Channel {
           var allPaths =
               Arrays.stream(uri.getPath().split("/"))
                   .map(String::trim)
-                  .filter(s -> !s.isEmpty() && !s.isBlank())
+                  .filter(s -> !s.isEmpty())
                   .collect(Collectors.toUnmodifiableList());
           // form: /resource/target
           if (allPaths.size() == 1) return Optional.empty();

--- a/app/src/main/java/org/astraea/app/web/Channel.java
+++ b/app/src/main/java/org/astraea/app/web/Channel.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.app.web;
+
+import com.sun.net.httpserver.HttpExchange;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.astraea.app.common.Utils;
+
+interface Channel {
+
+  Channel EMPTY = Channel.builder().build();
+
+  static Builder builder() {
+    return new Builder();
+  }
+
+  static Channel ofTarget(String target) {
+    return builder().type(Type.GET).target(target).build();
+  }
+
+  static Channel ofQueries(String target, Map<String, String> queries) {
+    return builder().type(Type.GET).target(target).queries(queries).build();
+  }
+
+  static Channel ofQueries(Map<String, String> queries) {
+    return builder().type(Type.GET).queries(queries).build();
+  }
+
+  static Channel ofRequest(PostRequest request) {
+    return builder().type(Type.POST).request(request).build();
+  }
+
+  class Builder {
+    private Type type = Type.UNKNOWN;
+    private Optional<String> target = Optional.empty();
+    private Map<String, String> queries = Map.of();
+    private PostRequest request = PostRequest.EMPTY;
+    private Consumer<Response> sender = r -> {};
+
+    private Builder() {}
+
+    public Builder type(Type type) {
+      this.type = type;
+      return this;
+    }
+
+    public Builder target(String target) {
+      return target(Optional.of(target));
+    }
+
+    public Builder target(Optional<String> target) {
+      this.target = target;
+      return this;
+    }
+
+    public Builder queries(Map<String, String> queries) {
+      this.queries = queries;
+      return this;
+    }
+
+    public Builder request(Map<String, Object> request) {
+      return request(PostRequest.of(request));
+    }
+
+    public Builder request(PostRequest request) {
+      this.request = request;
+      return this;
+    }
+
+    public Builder sender(Consumer<Response> sender) {
+      this.sender = sender;
+      return this;
+    }
+
+    public Channel build() {
+      return new Channel() {
+        @Override
+        public Type type() {
+          return type;
+        }
+
+        @Override
+        public Optional<String> target() {
+          return target;
+        }
+
+        @Override
+        public PostRequest request() {
+          return request;
+        }
+
+        @Override
+        public Map<String, String> queries() {
+          return queries;
+        }
+
+        @Override
+        public void send(Response response) {
+          try {
+            sender.accept(response);
+            response.onComplete(null);
+          } catch (Throwable e) {
+            e.printStackTrace();
+            response.onComplete(e);
+          }
+        }
+      };
+    }
+  }
+
+  enum Type {
+    GET,
+    DELETE,
+    POST,
+    UNKNOWN
+  }
+
+  static Channel of(HttpExchange exchange) {
+    Function<URI, Optional<String>> parseTarget =
+        uri -> {
+          var allPaths =
+              Arrays.stream(uri.getPath().split("/"))
+                  .map(String::trim)
+                  .filter(s -> !s.isEmpty() && !s.isBlank())
+                  .collect(Collectors.toUnmodifiableList());
+          // form: /resource/target
+          if (allPaths.size() == 1) return Optional.empty();
+          else if (allPaths.size() == 2) return Optional.of(allPaths.get(1));
+          else throw new IllegalArgumentException("unsupported url: " + uri);
+        };
+
+    Function<URI, Map<String, String>> parseQueries =
+        uri -> {
+          if (uri.getQuery() == null || uri.getQuery().isEmpty()) return Map.of();
+          return Arrays.stream(uri.getQuery().split("&"))
+              .filter(pair -> pair.split("=").length == 2)
+              .collect(Collectors.toMap(p -> p.split("=")[0], p -> p.split("=")[1]));
+        };
+
+    Function<InputStream, PostRequest> parseRequest =
+        stream -> {
+          var bs = Utils.packException(stream::readAllBytes);
+          if (bs == null || bs.length == 0) return PostRequest.EMPTY;
+          return PostRequest.of(new String(bs, StandardCharsets.UTF_8));
+        };
+
+    Function<String, Type> parseType =
+        name -> {
+          switch (name.toUpperCase(Locale.ROOT)) {
+            case "GET":
+              return Type.GET;
+            case "POST":
+              return Type.POST;
+            case "DELETE":
+              return Type.DELETE;
+            default:
+              return Type.UNKNOWN;
+          }
+        };
+    return builder()
+        .type(parseType.apply(exchange.getRequestMethod()))
+        .target(parseTarget.apply(exchange.getRequestURI()))
+        .queries(parseQueries.apply(exchange.getRequestURI()))
+        .request(parseRequest.apply(exchange.getRequestBody()))
+        .sender(
+            response -> {
+              var responseData = response.json().getBytes(StandardCharsets.UTF_8);
+              exchange
+                  .getResponseHeaders()
+                  .set(
+                      "Content-Type",
+                      String.format("application/json; charset=%s", StandardCharsets.UTF_8));
+              Utils.packException(
+                  () -> {
+                    exchange.sendResponseHeaders(response.code(), responseData.length);
+                    try (var os = exchange.getResponseBody()) {
+                      os.write(responseData);
+                    }
+                  });
+            })
+        .build();
+  }
+
+  /** @return the type of HTTP method */
+  Type type();
+
+  /** @return the target from URL. The form is /{type}/target */
+  Optional<String> target();
+
+  /** @return body request */
+  PostRequest request();
+
+  /** @return the queries appended to URL */
+  Map<String, String> queries();
+
+  /**
+   * send the response to caller and then complete the response
+   *
+   * @param response to send back to caller
+   */
+  void send(Response response);
+}

--- a/app/src/main/java/org/astraea/app/web/Handler.java
+++ b/app/src/main/java/org/astraea/app/web/Handler.java
@@ -16,21 +16,12 @@
  */
 package org.astraea.app.web;
 
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Locale;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import org.astraea.app.common.Utils;
 
-interface Handler extends HttpHandler {
+interface Handler {
 
   static <T> Set<T> compare(Set<T> all, Optional<T> target) {
     var nonexistent = target.stream().filter(id -> !all.contains(id)).collect(Collectors.toSet());
@@ -38,19 +29,16 @@ interface Handler extends HttpHandler {
     return target.map(Set::of).orElse(all);
   }
 
-  default Response process(HttpExchange exchange) {
-    var method = exchange.getRequestMethod().toUpperCase(Locale.ROOT);
+  default Response process(Channel channel) {
     var start = System.currentTimeMillis();
     try {
-      switch (method) {
-        case "GET":
-          return get(parseTarget(exchange.getRequestURI()), parseQueries(exchange.getRequestURI()));
-        case "POST":
-          return post(PostRequest.of(exchange));
-        case "DELETE":
-          var target = parseTarget(exchange.getRequestURI());
-          if (target.isPresent())
-            return delete(target.get(), parseQueries(exchange.getRequestURI()));
+      switch (channel.type()) {
+        case GET:
+          return get(channel);
+        case POST:
+          return post(channel);
+        case DELETE:
+          return delete(channel);
         default:
           return Response.NOT_FOUND;
       }
@@ -62,89 +50,40 @@ interface Handler extends HttpHandler {
           "take "
               + (System.currentTimeMillis() - start)
               + "ms to process request from "
-              + exchange.getRequestURI());
+              + channel.type().name()
+              + " on "
+              + channel.target());
     }
   }
 
-  @Override
-  default void handle(HttpExchange exchange) {
-    handleResponse(
-        (response) -> {
-          var responseData = response.json().getBytes(StandardCharsets.UTF_8);
-          exchange
-              .getResponseHeaders()
-              .set(
-                  "Content-Type",
-                  String.format("application/json; charset=%s", StandardCharsets.UTF_8));
-          Utils.packException(
-              () -> {
-                exchange.sendResponseHeaders(response.code(), responseData.length);
-                try (var os = exchange.getResponseBody()) {
-                  os.write(responseData);
-                }
-              });
-        },
-        process(exchange));
-  }
-
-  // visible for testing
-  static void handleResponse(Consumer<Response> responseConsumer, Response response) {
-    Throwable error = null;
-    try {
-      responseConsumer.accept(response);
-    } catch (Throwable e) {
-      e.printStackTrace();
-      error = e;
-    } finally {
-      response.onComplete(error);
-    }
-  }
-
-  static Optional<String> parseTarget(URI uri) {
-    var allPaths =
-        Arrays.stream(uri.getPath().split("/"))
-            .map(String::trim)
-            .filter(s -> !s.isEmpty() && !s.isBlank())
-            .collect(Collectors.toUnmodifiableList());
-    // form: /resource/target
-    if (allPaths.size() == 1) return Optional.empty();
-    else if (allPaths.size() == 2) return Optional.of(allPaths.get(1));
-    else throw new IllegalArgumentException("unsupported url: " + uri);
-  }
-
-  static Map<String, String> parseQueries(URI uri) {
-    if (uri.getQuery() == null || uri.getQuery().isEmpty()) return Map.of();
-    return Arrays.stream(uri.getQuery().split("&"))
-        .filter(pair -> pair.split("=").length == 2)
-        .collect(Collectors.toMap(p -> p.split("=")[0], p -> p.split("=")[1]));
+  default Response handle(Channel channel) {
+    var response = process(channel);
+    channel.send(response);
+    return response;
   }
 
   /**
    * handle the get request.
    *
-   * @param target the last keyword of url
-   * @param queries queries from url
    * @return json object to return
    */
-  Response get(Optional<String> target, Map<String, String> queries);
+  Response get(Channel channel);
 
   /**
    * handle the post request.
    *
-   * @param request the last keyword of url
    * @return json object to return
    */
-  default Response post(PostRequest request) {
+  default Response post(Channel channel) {
     return Response.NOT_FOUND;
   }
 
   /**
    * handle the delete request.
    *
-   * @param target the last keyword of url
    * @return json object to return
    */
-  default Response delete(String target, Map<String, String> queries) {
+  default Response delete(Channel channel) {
     return Response.NOT_FOUND;
   }
 }

--- a/app/src/main/java/org/astraea/app/web/PipelineHandler.java
+++ b/app/src/main/java/org/astraea/app/web/PipelineHandler.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -39,10 +38,10 @@ class PipelineHandler implements Handler {
   }
 
   @Override
-  public Response get(Optional<String> target, Map<String, String> queries) {
+  public Response get(Channel channel) {
     var tps =
         topicPartitions(admin).stream()
-            .filter(filter(queries))
+            .filter(filter(channel.queries()))
             .collect(Collectors.toUnmodifiableList());
     return new TopicPartitions(tps);
   }

--- a/app/src/main/java/org/astraea/app/web/PostRequest.java
+++ b/app/src/main/java/org/astraea/app/web/PostRequest.java
@@ -19,9 +19,6 @@ package org.astraea.app.web;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
-import com.sun.net.httpserver.HttpExchange;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -32,9 +29,7 @@ import java.util.stream.Collectors;
 
 public interface PostRequest {
 
-  static PostRequest of(HttpExchange exchange) throws IOException {
-    return of(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
-  }
+  PostRequest EMPTY = PostRequest.of(Map.of());
 
   @SuppressWarnings("unchecked")
   static PostRequest of(String json) {

--- a/app/src/main/java/org/astraea/app/web/ProducerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/ProducerHandler.java
@@ -19,7 +19,6 @@ package org.astraea.app.web;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.astraea.app.admin.Admin;
@@ -48,9 +47,9 @@ class ProducerHandler implements Handler {
   }
 
   @Override
-  public Partitions get(Optional<String> target, Map<String, String> queries) {
+  public Partitions get(Channel channel) {
     var topics =
-        admin.producerStates(partitions(queries)).entrySet().stream()
+        admin.producerStates(partitions(channel.queries())).entrySet().stream()
             .map(e -> new Partition(e.getKey(), e.getValue()))
             .collect(Collectors.toUnmodifiableList());
     return new Partitions(topics);

--- a/app/src/main/java/org/astraea/app/web/QuotaHandler.java
+++ b/app/src/main/java/org/astraea/app/web/QuotaHandler.java
@@ -18,8 +18,6 @@ package org.astraea.app.web;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.astraea.app.admin.Admin;
 import org.astraea.app.common.DataRate;
@@ -42,46 +40,53 @@ public class QuotaHandler implements Handler {
   }
 
   @Override
-  public Quotas get(Optional<String> target, Map<String, String> queries) {
-    if (queries.containsKey(IP_KEY))
-      return new Quotas(admin.quotas(org.astraea.app.admin.Quota.Target.IP, queries.get(IP_KEY)));
-    if (queries.containsKey(CLIENT_ID_KEY))
+  public Quotas get(Channel channel) {
+    if (channel.queries().containsKey(IP_KEY))
       return new Quotas(
-          admin.quotas(org.astraea.app.admin.Quota.Target.CLIENT_ID, queries.get(CLIENT_ID_KEY)));
+          admin.quotas(org.astraea.app.admin.Quota.Target.IP, channel.queries().get(IP_KEY)));
+    if (channel.queries().containsKey(CLIENT_ID_KEY))
+      return new Quotas(
+          admin.quotas(
+              org.astraea.app.admin.Quota.Target.CLIENT_ID, channel.queries().get(CLIENT_ID_KEY)));
     return new Quotas(admin.quotas());
   }
 
   @Override
-  public Response post(PostRequest request) {
-    if (request.get(IP_KEY).isPresent()) {
+  public Response post(Channel channel) {
+    if (channel.request().get(IP_KEY).isPresent()) {
       admin
           .quotaCreator()
-          .ip(request.value(IP_KEY))
-          .connectionRate(request.getInt(CONNECTION_RATE_KEY).orElse(Integer.MAX_VALUE))
+          .ip(channel.request().value(IP_KEY))
+          .connectionRate(channel.request().getInt(CONNECTION_RATE_KEY).orElse(Integer.MAX_VALUE))
           .create();
-      return new Quotas(admin.quotas(org.astraea.app.admin.Quota.Target.IP, request.value(IP_KEY)));
+      return new Quotas(
+          admin.quotas(org.astraea.app.admin.Quota.Target.IP, channel.request().value(IP_KEY)));
     }
-    if (request.get(CLIENT_ID_KEY).isPresent()) {
+    if (channel.request().get(CLIENT_ID_KEY).isPresent()) {
       admin
           .quotaCreator()
-          .clientId(request.value(CLIENT_ID_KEY))
+          .clientId(channel.request().value(CLIENT_ID_KEY))
           // TODO: use DataRate#Field (traced https://github.com/skiptests/astraea/issues/488)
           // see https://github.com/skiptests/astraea/issues/490
           .produceRate(
-              request
+              channel
+                  .request()
                   .get(PRODUCE_RATE_KEY)
                   .map(Long::parseLong)
                   .map(v -> DataRate.Byte.of(v).perSecond())
                   .orElse(null))
           .consumeRate(
-              request
+              channel
+                  .request()
                   .get(CONSUME_RATE_KEY)
                   .map(Long::parseLong)
                   .map(v -> DataRate.Byte.of(v).perSecond())
                   .orElse(null))
           .create();
       return new Quotas(
-          admin.quotas(org.astraea.app.admin.Quota.Target.CLIENT_ID, request.value(CLIENT_ID_KEY)));
+          admin.quotas(
+              org.astraea.app.admin.Quota.Target.CLIENT_ID,
+              channel.request().value(CLIENT_ID_KEY)));
     }
     return Response.NOT_FOUND;
   }

--- a/app/src/main/java/org/astraea/app/web/ReassignmentHandler.java
+++ b/app/src/main/java/org/astraea/app/web/ReassignmentHandler.java
@@ -18,7 +18,6 @@ package org.astraea.app.web;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.astraea.app.admin.Admin;
 import org.astraea.app.admin.TopicPartition;
@@ -37,9 +36,9 @@ public class ReassignmentHandler implements Handler {
   }
 
   @Override
-  public Response post(PostRequest requests) {
+  public Response post(Channel channel) {
     var rs =
-        requests.requests(PLANS_KEY).stream()
+        channel.request().requests(PLANS_KEY).stream()
             .map(
                 request -> {
                   // case 0: move replica to another folder
@@ -66,9 +65,12 @@ public class ReassignmentHandler implements Handler {
   }
 
   @Override
-  public Reassignments get(Optional<String> target, Map<String, String> queries) {
+  public Reassignments get(Channel channel) {
     return new Reassignments(
-        admin.reassignments(Handler.compare(admin.topicNames(), target)).entrySet().stream()
+        admin
+            .reassignments(Handler.compare(admin.topicNames(), channel.target()))
+            .entrySet()
+            .stream()
             .map(e -> new Reassignment(e.getKey(), e.getValue().from(), e.getValue().to()))
             .collect(Collectors.toUnmodifiableList()));
   }

--- a/app/src/main/java/org/astraea/app/web/RecordHandler.java
+++ b/app/src/main/java/org/astraea/app/web/RecordHandler.java
@@ -33,7 +33,6 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -97,21 +96,24 @@ public class RecordHandler implements Handler {
   }
 
   @Override
-  public Response get(Optional<String> target, Map<String, String> queries) {
-    var topic = target.orElseThrow(() -> new IllegalArgumentException("topic must be set"));
+  public Response get(Channel channel) {
+    if (channel.target().isEmpty())
+      return Response.of(new IllegalArgumentException("topic must be set"));
+
+    var topic = channel.target().get();
     var seekStrategies = Set.of(DISTANCE_FROM_LATEST, DISTANCE_FROM_BEGINNING, SEEK_TO);
-    if (queries.keySet().stream().filter(seekStrategies::contains).count() > 1) {
+    if (channel.queries().keySet().stream().filter(seekStrategies::contains).count() > 1) {
       throw new IllegalArgumentException("only one seek strategy is allowed");
     }
 
-    var limit = Integer.parseInt(queries.getOrDefault(LIMIT, "1"));
+    var limit = Integer.parseInt(channel.queries().getOrDefault(LIMIT, "1"));
     var timeout =
-        Optional.ofNullable(queries.get(TIMEOUT))
+        Optional.ofNullable(channel.queries().get(TIMEOUT))
             .map(DurationField::toDuration)
             .orElse(Duration.ofSeconds(5));
 
     var consumerBuilder =
-        Optional.ofNullable(queries.get(PARTITION))
+        Optional.ofNullable(channel.queries().get(PARTITION))
             .map(Integer::valueOf)
             .map(
                 partition ->
@@ -121,17 +123,17 @@ public class RecordHandler implements Handler {
                 () -> {
                   // disable auto commit here since we commit manually in Records#onComplete
                   var builder = Consumer.forTopics(Set.of(topic)).disableAutoCommitOffsets();
-                  Optional.ofNullable(queries.get(GROUP_ID)).ifPresent(builder::groupId);
+                  Optional.ofNullable(channel.queries().get(GROUP_ID)).ifPresent(builder::groupId);
                   return builder;
                 });
 
     var keyDeserializer =
-        Optional.ofNullable(queries.get(KEY_DESERIALIZER))
+        Optional.ofNullable(channel.queries().get(KEY_DESERIALIZER))
             .map(SerDe::of)
             .orElse(SerDe.STRING)
             .deserializer;
     var valueDeserializer =
-        Optional.ofNullable(queries.get(VALUE_DESERIALIZER))
+        Optional.ofNullable(channel.queries().get(VALUE_DESERIALIZER))
             .map(SerDe::of)
             .orElse(SerDe.STRING)
             .deserializer;
@@ -140,21 +142,21 @@ public class RecordHandler implements Handler {
         .keyDeserializer(keyDeserializer)
         .valueDeserializer(valueDeserializer);
 
-    Optional.ofNullable(queries.get(DISTANCE_FROM_LATEST))
+    Optional.ofNullable(channel.queries().get(DISTANCE_FROM_LATEST))
         .map(Long::parseLong)
         .ifPresent(
             distanceFromLatest ->
                 consumerBuilder.seek(
                     Builder.SeekStrategy.DISTANCE_FROM_LATEST, distanceFromLatest));
 
-    Optional.ofNullable(queries.get(DISTANCE_FROM_BEGINNING))
+    Optional.ofNullable(channel.queries().get(DISTANCE_FROM_BEGINNING))
         .map(Long::parseLong)
         .ifPresent(
             distanceFromBeginning ->
                 consumerBuilder.seek(
                     Builder.SeekStrategy.DISTANCE_FROM_BEGINNING, distanceFromBeginning));
 
-    Optional.ofNullable(queries.get(SEEK_TO))
+    Optional.ofNullable(channel.queries().get(SEEK_TO))
         .map(Long::parseLong)
         .ifPresent(seekTo -> consumerBuilder.seek(Builder.SeekStrategy.SEEK_TO, seekTo));
 
@@ -162,16 +164,21 @@ public class RecordHandler implements Handler {
   }
 
   @Override
-  public Response post(PostRequest request) {
-    var async = request.getBoolean(ASYNC).orElse(false);
-    var timeout = request.get(TIMEOUT).map(DurationField::toDuration).orElse(Duration.ofSeconds(5));
-    var records = request.values(RECORDS, PostRecord.class);
+  public Response post(Channel channel) {
+    var async = channel.request().getBoolean(ASYNC).orElse(false);
+    var timeout =
+        channel.request().get(TIMEOUT).map(DurationField::toDuration).orElse(Duration.ofSeconds(5));
+    var records = channel.request().values(RECORDS, PostRecord.class);
     if (records.isEmpty()) {
       throw new IllegalArgumentException("records should contain at least one record");
     }
 
     var producer =
-        request.get(TRANSACTION_ID).map(transactionalProducerCache::get).orElse(this.producer);
+        channel
+            .request()
+            .get(TRANSACTION_ID)
+            .map(transactionalProducerCache::get)
+            .orElse(this.producer);
 
     var result =
         CompletableFuture.supplyAsync(
@@ -210,14 +217,16 @@ public class RecordHandler implements Handler {
   }
 
   @Override
-  public Response delete(String topic, Map<String, String> queries) {
+  public Response delete(Channel channel) {
+    if (channel.target().isEmpty()) return Response.NOT_FOUND;
+    var topic = channel.target().get();
     var partitions =
-        Optional.ofNullable(queries.get(PARTITION))
+        Optional.ofNullable(channel.queries().get(PARTITION))
             .map(x -> Set.of(TopicPartition.of(topic, x)))
             .orElseGet(() -> admin.partitions(Set.of(topic)));
 
     var deletedOffsets =
-        Optional.ofNullable(queries.get(OFFSET))
+        Optional.ofNullable(channel.queries().get(OFFSET))
             .map(Long::parseLong)
             .map(
                 offset ->
@@ -333,14 +342,13 @@ public class RecordHandler implements Handler {
 
   static class Records implements Response {
     private final Consumer<byte[], byte[]> consumer;
-    private final int limit;
-    private final Duration timeout;
-    private RecordsData records;
+    private final RecordsData records;
 
     private Records(Consumer<byte[], byte[]> consumer, int limit, Duration timeout) {
       this.consumer = requireNonNull(consumer);
-      this.limit = limit;
-      this.timeout = requireNonNull(timeout);
+      this.records =
+          new RecordsData(
+              consumer.poll(limit, timeout).stream().map(Record::new).collect(toList()));
     }
 
     @Override
@@ -366,12 +374,6 @@ public class RecordHandler implements Handler {
 
     // visible for testing
     RecordsData records() {
-      // make sure consumer poll data only once.
-      if (records == null) {
-        records =
-            new RecordsData(
-                consumer.poll(limit, timeout).stream().map(Record::new).collect(toList()));
-      }
       return records;
     }
 

--- a/app/src/main/java/org/astraea/app/web/TransactionHandler.java
+++ b/app/src/main/java/org/astraea/app/web/TransactionHandler.java
@@ -17,8 +17,6 @@
 package org.astraea.app.web;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.astraea.app.admin.Admin;
@@ -32,12 +30,15 @@ class TransactionHandler implements Handler {
   }
 
   @Override
-  public Response get(Optional<String> target, Map<String, String> queries) {
+  public Response get(Channel channel) {
     var transactions =
-        admin.transactions(Handler.compare(admin.transactionIds(), target)).entrySet().stream()
+        admin
+            .transactions(Handler.compare(admin.transactionIds(), channel.target()))
+            .entrySet()
+            .stream()
             .map(e -> new Transaction(e.getKey(), e.getValue()))
             .collect(Collectors.toUnmodifiableList());
-    if (target.isPresent() && transactions.size() == 1) return transactions.get(0);
+    if (channel.target().isPresent() && transactions.size() == 1) return transactions.get(0);
     return new Transactions(transactions);
   }
 

--- a/app/src/main/java/org/astraea/app/web/WebService.java
+++ b/app/src/main/java/org/astraea/app/web/WebService.java
@@ -17,7 +17,6 @@
 package org.astraea.app.web;
 
 import com.beust.jcommander.Parameter;
-import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
@@ -55,13 +54,7 @@ public class WebService {
   }
 
   private static HttpHandler to(Handler handler) {
-    return new HttpHandler() {
-
-      @Override
-      public void handle(HttpExchange exchange) throws IOException {
-        handler.handle(Channel.of(exchange));
-      }
-    };
+    return exchange -> handler.handle(Channel.of(exchange));
   }
 
   static class Argument extends org.astraea.app.argument.Argument {

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -18,7 +18,6 @@ package org.astraea.app.web;
 
 import java.time.Duration;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.astraea.app.admin.Admin;
 import org.astraea.app.admin.ClusterBean;
@@ -42,7 +41,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
       var report =
           Assertions.assertInstanceOf(
               BalancerHandler.Report.class,
-              handler.get(Optional.empty(), Map.of(BalancerHandler.LIMIT_KEY, "30")));
+              handler.get(Channel.ofQueries(Map.of(BalancerHandler.LIMIT_KEY, "30"))));
       Assertions.assertEquals(30, report.limit);
       Assertions.assertNotEquals(0, report.changes.size());
       Assertions.assertTrue(report.cost >= report.newCost);

--- a/app/src/test/java/org/astraea/app/web/BeanHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BeanHandlerTest.java
@@ -19,7 +19,6 @@ package org.astraea.app.web;
 import java.time.Duration;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import org.astraea.app.admin.Admin;
 import org.astraea.app.common.Utils;
 import org.astraea.app.service.RequireBrokerCluster;
@@ -52,18 +51,17 @@ public class BeanHandlerTest extends RequireBrokerCluster {
       Utils.sleep(Duration.ofSeconds(2));
       var handler = new BeanHandler(admin, name -> jmxServiceURL().getPort());
       var response =
-          Assertions.assertInstanceOf(
-              BeanHandler.NodeBeans.class, handler.get(Optional.empty(), Map.of()));
+          Assertions.assertInstanceOf(BeanHandler.NodeBeans.class, handler.get(Channel.EMPTY));
       Assertions.assertNotEquals(0, response.nodeBeans.size());
 
       var response1 =
           Assertions.assertInstanceOf(
-              BeanHandler.NodeBeans.class, handler.get(Optional.of("kafka.server"), Map.of()));
+              BeanHandler.NodeBeans.class, handler.get(Channel.ofTarget("kafka.server")));
       Assertions.assertNotEquals(0, response1.nodeBeans.size());
 
       var response2 =
           Assertions.assertInstanceOf(
-              BeanHandler.NodeBeans.class, handler.get(Optional.empty(), Map.of("topic", topic)));
+              BeanHandler.NodeBeans.class, handler.get(Channel.ofQueries(Map.of("topic", topic))));
       Assertions.assertNotEquals(0, response2.nodeBeans.size());
     }
   }

--- a/app/src/test/java/org/astraea/app/web/BrokerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BrokerHandlerTest.java
@@ -17,7 +17,6 @@
 package org.astraea.app.web;
 
 import java.time.Duration;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
@@ -37,8 +36,7 @@ public class BrokerHandlerTest extends RequireBrokerCluster {
       Utils.sleep(Duration.ofSeconds(2));
       var handler = new BrokerHandler(admin);
       var response =
-          Assertions.assertInstanceOf(
-              BrokerHandler.Brokers.class, handler.get(Optional.empty(), Map.of()));
+          Assertions.assertInstanceOf(BrokerHandler.Brokers.class, handler.get(Channel.EMPTY));
       Assertions.assertEquals(brokerIds().size(), response.brokers.size());
       brokerIds()
           .forEach(
@@ -55,7 +53,7 @@ public class BrokerHandlerTest extends RequireBrokerCluster {
     try (Admin admin = Admin.of(bootstrapServers())) {
       var handler = new BrokerHandler(admin);
       Assertions.assertThrows(
-          NoSuchElementException.class, () -> handler.get(Optional.of("99999"), Map.of()));
+          NoSuchElementException.class, () -> handler.get(Channel.ofTarget("99999")));
     }
   }
 
@@ -64,7 +62,7 @@ public class BrokerHandlerTest extends RequireBrokerCluster {
     try (Admin admin = Admin.of(bootstrapServers())) {
       var handler = new BrokerHandler(admin);
       Assertions.assertThrows(
-          NoSuchElementException.class, () -> handler.get(Optional.of("abc"), Map.of()));
+          NoSuchElementException.class, () -> handler.get(Channel.ofTarget("abc")));
     }
   }
 
@@ -78,8 +76,7 @@ public class BrokerHandlerTest extends RequireBrokerCluster {
       var handler = new BrokerHandler(admin);
       var broker =
           Assertions.assertInstanceOf(
-              BrokerHandler.Broker.class,
-              handler.get(Optional.of(String.valueOf(brokerId)), Map.of()));
+              BrokerHandler.Broker.class, handler.get(Channel.ofTarget(String.valueOf(brokerId))));
       Assertions.assertEquals(brokerId, broker.id);
       Assertions.assertNotEquals(0, broker.configs.size());
       Assertions.assertTrue(broker.topics.stream().anyMatch(t -> t.topic.equals(topic)));

--- a/app/src/test/java/org/astraea/app/web/ChannelTest.java
+++ b/app/src/test/java/org/astraea/app/web/ChannelTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.app.web;
+
+import com.sun.net.httpserver.HttpExchange;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class ChannelTest {
+
+  @Test
+  void testParse() throws IOException {
+    var inputStream = Mockito.mock(InputStream.class);
+    Mockito.when(inputStream.readAllBytes()).thenReturn(new byte[0]);
+    var exchange = Mockito.mock(HttpExchange.class);
+    Mockito.when(exchange.getRequestURI())
+        .thenReturn(URI.create("http://localhost:11111/abc/obj?a=b&c=d"));
+    Mockito.when(exchange.getRequestMethod()).thenReturn("get");
+    Mockito.when(exchange.getRequestBody()).thenReturn(inputStream);
+    var channel = Channel.of(exchange);
+    Assertions.assertEquals(Channel.Type.GET, channel.type());
+    Assertions.assertEquals(Optional.of("obj"), channel.target());
+    Assertions.assertEquals(Map.of("a", "b", "c", "d"), channel.queries());
+    Assertions.assertEquals(PostRequest.EMPTY, channel.request());
+  }
+
+  @Test
+  void testIncorrectTarget() throws IOException {
+    var inputStream = Mockito.mock(InputStream.class);
+    Mockito.when(inputStream.readAllBytes()).thenReturn(new byte[0]);
+    var exchange = Mockito.mock(HttpExchange.class);
+    Mockito.when(exchange.getRequestURI())
+        .thenReturn(URI.create("http://localhost:11111/abc/obj/incorrect"));
+    Mockito.when(exchange.getRequestMethod()).thenReturn("get");
+    Mockito.when(exchange.getRequestBody()).thenReturn(inputStream);
+    Assertions.assertThrows(IllegalArgumentException.class, () -> Channel.of(exchange));
+  }
+
+  @Test
+  void testOnComplete() {
+    var exception = new IllegalStateException("hello");
+    var channel =
+        Channel.builder()
+            .sender(
+                r -> {
+                  throw exception;
+                })
+            .build();
+    var response = Mockito.mock(Response.class);
+    channel.send(response);
+    Mockito.verify(response).onComplete(exception);
+  }
+}

--- a/app/src/test/java/org/astraea/app/web/PipelineHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/PipelineHandlerTest.java
@@ -18,7 +18,6 @@ package org.astraea.app.web;
 
 import java.time.Duration;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import org.astraea.app.admin.Admin;
 import org.astraea.app.common.Utils;
@@ -60,7 +59,7 @@ public class PipelineHandlerTest extends RequireBrokerCluster {
         var handler = new PipelineHandler(admin);
         var response =
             Assertions.assertInstanceOf(
-                PipelineHandler.TopicPartitions.class, handler.get(Optional.empty(), Map.of()));
+                PipelineHandler.TopicPartitions.class, handler.get(Channel.EMPTY));
         Assertions.assertNotEquals(0, response.topicPartitions.size());
         Assertions.assertEquals(
             1, response.topicPartitions.stream().filter(t -> t.topic.equals(topic)).count());

--- a/app/src/test/java/org/astraea/app/web/PostRequestTest.java
+++ b/app/src/test/java/org/astraea/app/web/PostRequestTest.java
@@ -16,10 +16,6 @@
  */
 package org.astraea.app.web;
 
-import com.sun.net.httpserver.HttpExchange;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -27,18 +23,12 @@ import java.util.Objects;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 public class PostRequestTest {
 
   @Test
-  void testParseHttpExchange() throws IOException {
-    var input =
-        new ByteArrayInputStream("{\"a\":\"b\",\"c\":123}".getBytes(StandardCharsets.UTF_8));
-    var exchange = Mockito.mock(HttpExchange.class);
-    Mockito.when(exchange.getRequestBody()).thenReturn(input);
-
-    var request = PostRequest.of(exchange);
+  void testParseHttpExchange() {
+    var request = PostRequest.of("{\"a\":\"b\",\"c\":123}");
     Assertions.assertEquals(2, request.raw().size());
     Assertions.assertEquals("b", request.raw().get("a"));
     Assertions.assertEquals(123, request.intValue("c"));
@@ -68,56 +58,33 @@ public class PostRequestTest {
   }
 
   @Test
-  void testStringArray() throws IOException {
-    var input =
-        new ByteArrayInputStream(
-            "{\"a\":\"b\",\"c\":[\"1\",\"2\"]}".getBytes(StandardCharsets.UTF_8));
-    var exchange = Mockito.mock(HttpExchange.class);
-    Mockito.when(exchange.getRequestBody()).thenReturn(input);
-
-    var request = PostRequest.of(exchange);
+  void testStringArray() {
+    var request = PostRequest.of("{\"a\":\"b\",\"c\":[\"1\",\"2\"]}");
     Assertions.assertEquals(2, request.values("c").size());
     Assertions.assertEquals("1", request.values("c").get(0));
     Assertions.assertEquals("2", request.values("c").get(1));
   }
 
   @Test
-  void testIntegerArray() throws IOException {
-    var input =
-        new ByteArrayInputStream("{\"a\":\"b\",\"c\":[1,2]}".getBytes(StandardCharsets.UTF_8));
-    var exchange = Mockito.mock(HttpExchange.class);
-    Mockito.when(exchange.getRequestBody()).thenReturn(input);
-
-    var request = PostRequest.of(exchange);
+  void testIntegerArray() {
+    var request = PostRequest.of("{\"a\":\"b\",\"c\":[1,2]}");
     Assertions.assertEquals(2, request.intValues("c").size());
     Assertions.assertEquals(1, request.intValues("c").get(0));
     Assertions.assertEquals(2, request.intValues("c").get(1));
   }
 
   @Test
-  void testValues() throws IOException {
-    var input =
-        new ByteArrayInputStream(
-            "{\"a\":[{\"foo\": \"r1\", \"bar\": 1},{\"foo\": \"r2\", \"bar\": 2}]}"
-                .getBytes(StandardCharsets.UTF_8));
-    var exchange = Mockito.mock(HttpExchange.class);
-    Mockito.when(exchange.getRequestBody()).thenReturn(input);
-
-    var request = PostRequest.of(exchange);
+  void testValues() {
+    var request =
+        PostRequest.of("{\"a\":[{\"foo\": \"r1\", \"bar\": 1},{\"foo\": \"r2\", \"bar\": 2}]}");
     Assertions.assertEquals(
         List.of(new ForTestValue("r1", 1), new ForTestValue("r2", 2)),
         request.values("a", ForTestValue.class));
   }
 
   @Test
-  void testValue() throws IOException {
-    var input =
-        new ByteArrayInputStream(
-            "{\"a\":{\"foo\": \"r1\", \"bar\": 1}}".getBytes(StandardCharsets.UTF_8));
-    var exchange = Mockito.mock(HttpExchange.class);
-    Mockito.when(exchange.getRequestBody()).thenReturn(input);
-
-    var request = PostRequest.of(exchange);
+  void testValue() {
+    var request = PostRequest.of("{\"a\":{\"foo\": \"r1\", \"bar\": 1}}");
     Assertions.assertEquals(new ForTestValue("r1", 1), request.value("a", ForTestValue.class));
   }
 

--- a/app/src/test/java/org/astraea/app/web/ProducerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/ProducerHandlerTest.java
@@ -18,7 +18,6 @@ package org.astraea.app.web;
 
 import java.time.Duration;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -40,8 +39,7 @@ public class ProducerHandlerTest extends RequireBrokerCluster {
       producer.sender().topic(topicName).value(new byte[1]).run().toCompletableFuture().get();
 
       var result =
-          Assertions.assertInstanceOf(
-              ProducerHandler.Partitions.class, handler.get(Optional.empty(), Map.of()));
+          Assertions.assertInstanceOf(ProducerHandler.Partitions.class, handler.get(Channel.EMPTY));
       Assertions.assertNotEquals(0, result.partitions.size());
 
       var partitions =
@@ -91,9 +89,12 @@ public class ProducerHandlerTest extends RequireBrokerCluster {
           Assertions.assertInstanceOf(
               ProducerHandler.Partitions.class,
               handler.get(
-                  Optional.empty(),
-                  Map.of(
-                      ProducerHandler.TOPIC_KEY, topicName, ProducerHandler.PARTITION_KEY, "0")));
+                  Channel.ofQueries(
+                      Map.of(
+                          ProducerHandler.TOPIC_KEY,
+                          topicName,
+                          ProducerHandler.PARTITION_KEY,
+                          "0"))));
       Assertions.assertEquals(1, result0.partitions.size());
       Assertions.assertEquals(topicName, result0.partitions.iterator().next().topic);
       Assertions.assertEquals(0, result0.partitions.iterator().next().partition);
@@ -104,7 +105,7 @@ public class ProducerHandlerTest extends RequireBrokerCluster {
       var result1 =
           Assertions.assertInstanceOf(
               ProducerHandler.Partitions.class,
-              handler.get(Optional.empty(), Map.of(ProducerHandler.TOPIC_KEY, topicName)));
+              handler.get(Channel.ofQueries(Map.of(ProducerHandler.TOPIC_KEY, topicName))));
       Assertions.assertEquals(2, result1.partitions.size());
       Assertions.assertEquals(topicName, result1.partitions.iterator().next().topic);
       Assertions.assertEquals(

--- a/app/src/test/java/org/astraea/app/web/QuotaHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/QuotaHandlerTest.java
@@ -17,7 +17,6 @@
 package org.astraea.app.web;
 
 import java.util.Map;
-import java.util.Optional;
 import org.astraea.app.admin.Admin;
 import org.astraea.app.admin.Quota;
 import org.astraea.app.service.RequireBrokerCluster;
@@ -36,8 +35,10 @@ public class QuotaHandlerTest extends RequireBrokerCluster {
           Assertions.assertInstanceOf(
               QuotaHandler.Quotas.class,
               handler.post(
-                  PostRequest.of(
-                      Map.of(QuotaHandler.IP_KEY, ip, QuotaHandler.CONNECTION_RATE_KEY, "10"))));
+                  Channel.ofRequest(
+                      PostRequest.of(
+                          Map.of(
+                              QuotaHandler.IP_KEY, ip, QuotaHandler.CONNECTION_RATE_KEY, "10")))));
       Assertions.assertEquals(1, result.quotas.size());
       Assertions.assertEquals(
           Quota.Target.IP.nameOfKafka(), result.quotas.iterator().next().target.name);
@@ -56,13 +57,17 @@ public class QuotaHandlerTest extends RequireBrokerCluster {
       var handler = new QuotaHandler(admin);
 
       handler.post(
-          PostRequest.of(Map.of(QuotaHandler.IP_KEY, ip0, QuotaHandler.CONNECTION_RATE_KEY, "10")));
+          Channel.ofRequest(
+              PostRequest.of(
+                  Map.of(QuotaHandler.IP_KEY, ip0, QuotaHandler.CONNECTION_RATE_KEY, "10"))));
       handler.post(
-          PostRequest.of(Map.of(QuotaHandler.IP_KEY, ip1, QuotaHandler.CONNECTION_RATE_KEY, "20")));
+          Channel.ofRequest(
+              PostRequest.of(
+                  Map.of(QuotaHandler.IP_KEY, ip1, QuotaHandler.CONNECTION_RATE_KEY, "20"))));
       Assertions.assertEquals(
-          1, handler.get(Optional.empty(), Map.of(QuotaHandler.IP_KEY, ip0)).quotas.size());
+          1, handler.get(Channel.ofQueries(Map.of(QuotaHandler.IP_KEY, ip0))).quotas.size());
       Assertions.assertEquals(
-          1, handler.get(Optional.empty(), Map.of(QuotaHandler.IP_KEY, ip1)).quotas.size());
+          1, handler.get(Channel.ofQueries(Map.of(QuotaHandler.IP_KEY, ip1))).quotas.size());
     }
   }
 
@@ -74,7 +79,7 @@ public class QuotaHandlerTest extends RequireBrokerCluster {
           0,
           Assertions.assertInstanceOf(
                   QuotaHandler.Quotas.class,
-                  handler.get(Optional.empty(), Map.of(Quota.Target.IP.nameOfKafka(), "unknown")))
+                  handler.get(Channel.ofQueries(Map.of(Quota.Target.IP.nameOfKafka(), "unknown"))))
               .quotas
               .size());
 
@@ -83,7 +88,7 @@ public class QuotaHandlerTest extends RequireBrokerCluster {
           Assertions.assertInstanceOf(
                   QuotaHandler.Quotas.class,
                   handler.get(
-                      Optional.empty(), Map.of(Quota.Target.CLIENT_ID.nameOfKafka(), "unknown")))
+                      Channel.ofQueries(Map.of(Quota.Target.CLIENT_ID.nameOfKafka(), "unknown"))))
               .quotas
               .size());
     }

--- a/app/src/test/java/org/astraea/app/web/ReassignmentHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/ReassignmentHandlerTest.java
@@ -17,8 +17,6 @@
 package org.astraea.app.web;
 
 import java.time.Duration;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import org.astraea.app.admin.Admin;
 import org.astraea.app.admin.TopicPartition;
@@ -52,10 +50,11 @@ public class ReassignmentHandlerTest extends RequireBrokerCluster {
               ReassignmentHandler.TO_KEY,
               nextBroker);
 
-      Assertions.assertEquals(Response.ACCEPT, handler.post(PostRequest.of(body)));
+      Assertions.assertEquals(
+          Response.ACCEPT, handler.post(Channel.ofRequest(PostRequest.of(body))));
 
       Utils.sleep(Duration.ofSeconds(2));
-      var reassignments = handler.get(Optional.of(topicName), Map.of());
+      var reassignments = handler.get(Channel.EMPTY);
       // the reassignment should be completed
       Assertions.assertEquals(0, reassignments.reassignments.size());
 
@@ -96,10 +95,11 @@ public class ReassignmentHandlerTest extends RequireBrokerCluster {
               ReassignmentHandler.TO_KEY,
               nextPath);
 
-      Assertions.assertEquals(Response.ACCEPT, handler.post(PostRequest.of(body)));
+      Assertions.assertEquals(
+          Response.ACCEPT, handler.post(Channel.ofRequest(PostRequest.of(body))));
 
       Utils.sleep(Duration.ofSeconds(2));
-      var reassignments = handler.get(Optional.of(topicName), Map.of());
+      var reassignments = handler.get(Channel.ofTarget(topicName));
       // the reassignment should be completed
       Assertions.assertEquals(0, reassignments.reassignments.size());
 
@@ -118,7 +118,8 @@ public class ReassignmentHandlerTest extends RequireBrokerCluster {
       Utils.sleep(Duration.ofSeconds(3));
       var body = "{\"plans\": []}";
 
-      Assertions.assertEquals(Response.BAD_REQUEST, handler.post(PostRequest.of(body)));
+      Assertions.assertEquals(
+          Response.BAD_REQUEST, handler.post(Channel.ofRequest(PostRequest.of(body))));
     }
   }
 }

--- a/app/src/test/java/org/astraea/app/web/RecordHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/RecordHandlerTest.java
@@ -306,15 +306,14 @@ public class RecordHandlerTest extends RequireBrokerCluster {
     var handler = getRecordHandler();
     var response =
         Assertions.assertInstanceOf(
-            RecordHandler.Records.class,
+            RecordHandler.GetResponse.class,
             handler.get(
                 Channel.ofQueries(
                     topic, Map.of(DISTANCE_FROM_LATEST, "2", VALUE_DESERIALIZER, "integer"))));
 
-    Assertions.assertEquals(2, response.records.data.size());
+    Assertions.assertEquals(2, response.records.size());
     Assertions.assertEquals(
-        List.of(8, 9),
-        response.records.data.stream().map(record -> record.value).collect(toList()));
+        List.of(8, 9), response.records.stream().map(record -> record.value).collect(toList()));
 
     // close consumer
     response.onComplete(null);
@@ -328,15 +327,14 @@ public class RecordHandlerTest extends RequireBrokerCluster {
     var handler = getRecordHandler();
     var response =
         Assertions.assertInstanceOf(
-            RecordHandler.Records.class,
+            RecordHandler.GetResponse.class,
             handler.get(
                 Channel.ofQueries(
                     topic, Map.of(DISTANCE_FROM_BEGINNING, "8", VALUE_DESERIALIZER, "integer"))));
 
-    Assertions.assertEquals(2, response.records.data.size());
+    Assertions.assertEquals(2, response.records.size());
     Assertions.assertEquals(
-        List.of(8, 9),
-        response.records.data.stream().map(record -> record.value).collect(toList()));
+        List.of(8, 9), response.records.stream().map(record -> record.value).collect(toList()));
 
     // close consumer
     response.onComplete(null);
@@ -350,14 +348,13 @@ public class RecordHandlerTest extends RequireBrokerCluster {
     var handler = getRecordHandler();
     var response =
         Assertions.assertInstanceOf(
-            RecordHandler.Records.class,
+            RecordHandler.GetResponse.class,
             handler.get(
                 Channel.ofQueries(topic, Map.of(SEEK_TO, "3", VALUE_DESERIALIZER, "integer"))));
 
-    Assertions.assertEquals(2, response.records.data.size());
+    Assertions.assertEquals(2, response.records.size());
     Assertions.assertEquals(
-        List.of(3, 4),
-        response.records.data.stream().map(record -> record.value).collect(toList()));
+        List.of(3, 4), response.records.stream().map(record -> record.value).collect(toList()));
 
     // close consumer
     response.onComplete(null);
@@ -388,16 +385,12 @@ public class RecordHandlerTest extends RequireBrokerCluster {
     var handler = getRecordHandler();
     var response =
         Assertions.assertInstanceOf(
-            RecordHandler.Records.class,
+            RecordHandler.GetResponse.class,
             handler.get(
                 Channel.ofQueries(topic, Map.of(DISTANCE_FROM_BEGINNING, "1", PARTITION, "1"))));
 
     Assertions.assertTrue(
-        response.records.data.stream()
-            .map(r -> r.partition)
-            .filter(p -> p != 1)
-            .findAny()
-            .isEmpty());
+        response.records.stream().map(r -> r.partition).filter(p -> p != 1).findAny().isEmpty());
 
     // close consumer
     response.onComplete(null);
@@ -411,7 +404,7 @@ public class RecordHandlerTest extends RequireBrokerCluster {
     var handler = getRecordHandler();
     var response =
         Assertions.assertInstanceOf(
-            RecordHandler.Records.class,
+            RecordHandler.GetResponse.class,
             handler.get(
                 Channel.ofQueries(
                     topic,
@@ -419,10 +412,10 @@ public class RecordHandlerTest extends RequireBrokerCluster {
                         DISTANCE_FROM_BEGINNING, "2", LIMIT, "3", VALUE_DESERIALIZER, "integer"))));
 
     // limit is just a recommended size here, we might get more records than limit
-    Assertions.assertEquals(8, response.records.data.size());
+    Assertions.assertEquals(8, response.records.size());
     Assertions.assertEquals(
         List.of(2, 3, 4, 5, 6, 7, 8, 9),
-        response.records.data.stream().map(record -> record.value).collect(toList()));
+        response.records.stream().map(record -> record.value).collect(toList()));
 
     // close consumer
     response.onComplete(null);
@@ -440,12 +433,12 @@ public class RecordHandlerTest extends RequireBrokerCluster {
     var handler = getRecordHandler();
     var response =
         Assertions.assertInstanceOf(
-            RecordHandler.Records.class,
+            RecordHandler.GetResponse.class,
             handler.get(
                 Channel.ofQueries(
                     topic,
                     Map.of(DISTANCE_FROM_LATEST, "1", VALUE_DESERIALIZER, valueDeserializer))));
-    var records = List.copyOf(response.records.data);
+    var records = List.copyOf(response.records);
     Assertions.assertEquals(1, records.size());
 
     if (valueDeserializer.equals("bytearray")) {
@@ -498,7 +491,7 @@ public class RecordHandlerTest extends RequireBrokerCluster {
     var handler = getRecordHandler();
     var response =
         Assertions.assertInstanceOf(
-            RecordHandler.Records.class,
+            RecordHandler.GetResponse.class,
             handler.get(
                 Channel.ofQueries(
                     topic,
@@ -509,8 +502,8 @@ public class RecordHandlerTest extends RequireBrokerCluster {
                         "string",
                         VALUE_DESERIALIZER,
                         "integer"))));
-    Assertions.assertEquals(1, response.records.data.size());
-    var recordDto = response.records.data.iterator().next();
+    Assertions.assertEquals(1, response.records.size());
+    var recordDto = response.records.iterator().next();
     Assertions.assertEquals(topic, recordDto.topic);
     Assertions.assertEquals(0, recordDto.partition);
     Assertions.assertEquals(0, recordDto.offset);
@@ -548,7 +541,7 @@ public class RecordHandlerTest extends RequireBrokerCluster {
     var handler = getRecordHandler();
     var response =
         Assertions.assertInstanceOf(
-            RecordHandler.Records.class,
+            RecordHandler.GetResponse.class,
             handler.get(
                 Channel.ofQueries(
                     topic,
@@ -627,9 +620,9 @@ public class RecordHandlerTest extends RequireBrokerCluster {
                                         "100",
                                         currentTimestamp))))))));
 
-    var records =
+    var response =
         Assertions.assertInstanceOf(
-            RecordHandler.Records.class,
+            RecordHandler.GetResponse.class,
             handler.get(
                 Channel.ofQueries(
                     topic,
@@ -642,7 +635,7 @@ public class RecordHandlerTest extends RequireBrokerCluster {
                         "integer",
                         PARTITION,
                         "0"))));
-    var record = records.records.data.iterator().next();
+    var record = response.records.iterator().next();
     Assertions.assertEquals(topic, record.topic);
     Assertions.assertEquals(0, record.partition);
     Assertions.assertEquals(0, record.offset);
@@ -655,7 +648,7 @@ public class RecordHandlerTest extends RequireBrokerCluster {
     Assertions.assertEquals(List.of(), record.headers);
 
     // close consumer
-    records.onComplete(null);
+    response.onComplete(null);
   }
 
   @Test
@@ -664,7 +657,7 @@ public class RecordHandlerTest extends RequireBrokerCluster {
         IllegalArgumentException.class,
         () -> getRecordHandler().get(Channel.ofQueries("test", Map.of(TIMEOUT, "foo"))));
     var response = getRecordHandler().get(Channel.ofQueries("test", Map.of(TIMEOUT, "10s")));
-    Assertions.assertInstanceOf(RecordHandler.Records.class, response);
+    Assertions.assertInstanceOf(RecordHandler.GetResponse.class, response);
     // close consumer
     response.onComplete(null);
   }
@@ -771,10 +764,10 @@ public class RecordHandlerTest extends RequireBrokerCluster {
     var groupId = Utils.randomString(10);
     var recordHandler = getRecordHandler();
 
-    Function<Boolean, RecordHandler.Records> getRecords =
+    Function<Boolean, RecordHandler.GetResponse> getRecords =
         needError ->
             Assertions.assertInstanceOf(
-                RecordHandler.Records.class,
+                RecordHandler.GetResponse.class,
                 recordHandler.handle(
                     Channel.builder()
                         .type(Channel.Type.GET)
@@ -787,20 +780,20 @@ public class RecordHandlerTest extends RequireBrokerCluster {
                         .build()));
 
     // send this request to register consumer group
-    Assertions.assertEquals(getRecords.apply(false).records.data.size(), 0);
+    Assertions.assertEquals(getRecords.apply(false).records.size(), 0);
 
     produceData(topic, 5);
-    Assertions.assertEquals(getRecords.apply(false).records.data.size(), 5);
+    Assertions.assertEquals(getRecords.apply(false).records.size(), 5);
 
     // can't send data to caller, so the offsets are not committed
     produceData(topic, 2);
-    Assertions.assertEquals(getRecords.apply(true).records.data.size(), 2);
+    Assertions.assertEquals(getRecords.apply(true).records.size(), 2);
 
     // ok, offsets are committed
-    Assertions.assertEquals(getRecords.apply(false).records.data.size(), 2);
+    Assertions.assertEquals(getRecords.apply(false).records.size(), 2);
 
     // all offsets are committed, so this group id can't get more data
-    Assertions.assertEquals(getRecords.apply(false).records.data.size(), 0);
+    Assertions.assertEquals(getRecords.apply(false).records.size(), 0);
   }
 
   // test consumer in different modes, subscribe and assignment
@@ -817,8 +810,7 @@ public class RecordHandlerTest extends RequireBrokerCluster {
 
     var response =
         Assertions.assertInstanceOf(
-            RecordHandler.Records.class, recordHandler.handle(Channel.ofQueries(topic, args)));
-    @SuppressWarnings("resource") // consumer already closed in Response#onComplete
+            RecordHandler.GetResponse.class, recordHandler.handle(Channel.ofQueries(topic, args)));
     var error =
         Assertions.assertThrows(
             IllegalStateException.class, () -> response.consumer.poll(Duration.ofSeconds(1)));
@@ -826,7 +818,7 @@ public class RecordHandlerTest extends RequireBrokerCluster {
 
     var response2 =
         Assertions.assertInstanceOf(
-            RecordHandler.Records.class,
+            RecordHandler.GetResponse.class,
             recordHandler.handle(
                 Channel.builder()
                     .type(Channel.Type.GET)
@@ -837,7 +829,6 @@ public class RecordHandlerTest extends RequireBrokerCluster {
                           throw new RuntimeException();
                         })
                     .build()));
-    @SuppressWarnings("resource") // consumer already closed in Response#onComplete
     var error2 =
         Assertions.assertThrows(
             IllegalStateException.class, () -> response2.consumer.poll(Duration.ofSeconds(1)));

--- a/app/src/test/java/org/astraea/app/web/RecordHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/RecordHandlerTest.java
@@ -554,7 +554,7 @@ public class RecordHandlerTest extends RequireBrokerCluster {
                         "integer"))));
 
     Assertions.assertEquals(
-        "{\"data\":[{"
+        "{\"records\":[{"
             + "\"topic\":\""
             + topic
             + "\","

--- a/app/src/test/java/org/astraea/app/web/RecordHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/RecordHandlerTest.java
@@ -798,7 +798,7 @@ public class RecordHandlerTest extends RequireBrokerCluster {
     // ok, offsets are committed
     Assertions.assertEquals(getRecords.apply(false).records().data.size(), 2);
 
-    // all offsets are committed, so no data get backed.
+    // all offsets are committed, so this group id can't get more data
     Assertions.assertEquals(getRecords.apply(false).records().data.size(), 0);
   }
 

--- a/app/src/test/java/org/astraea/app/web/TransactionHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/TransactionHandlerTest.java
@@ -16,9 +16,7 @@
  */
 package org.astraea.app.web;
 
-import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import org.astraea.app.admin.Admin;
 import org.astraea.app.common.Utils;
@@ -40,7 +38,7 @@ public class TransactionHandlerTest extends RequireBrokerCluster {
 
       var result =
           Assertions.assertInstanceOf(
-              TransactionHandler.Transactions.class, handler.get(Optional.empty(), Map.of()));
+              TransactionHandler.Transactions.class, handler.get(Channel.EMPTY));
       var transaction =
           result.transactions.stream()
               .filter(t -> t.id.equals(producer.transactionId().get()))
@@ -62,7 +60,7 @@ public class TransactionHandlerTest extends RequireBrokerCluster {
       var transaction =
           Assertions.assertInstanceOf(
               TransactionHandler.Transaction.class,
-              handler.get(Optional.of(producer.transactionId().get()), Map.of()));
+              handler.get(Channel.ofTarget(producer.transactionId().get())));
 
       Assertions.assertEquals(0, transaction.topicPartitions.size());
     }
@@ -79,7 +77,7 @@ public class TransactionHandlerTest extends RequireBrokerCluster {
 
       Assertions.assertThrows(
           NoSuchElementException.class,
-          () -> handler.get(Optional.of(Utils.randomString(10)), Map.of()));
+          () -> handler.get(Channel.ofTarget(Utils.randomString(10))));
     }
   }
 }

--- a/docs/web_server/web_api_records_chinese.md
+++ b/docs/web_server/web_api_records_chinese.md
@@ -155,7 +155,7 @@ JSON Response
 
 ```json
 {
-  "data": [
+  "records": [
     {
       "topic": "test",
       "partition": 0,
@@ -198,7 +198,7 @@ JSON Response
 
 ```json
 {
-  "data": [
+  "records": [
     {
       "topic": "test",
       "partition": 0,
@@ -241,7 +241,7 @@ JSON Response
 
 ```json
 {
-  "data": [
+  "records": [
     {
       "topic": "test",
       "partition": 0,


### PR DESCRIPTION
重構了幾個項目，包含：
1. 新增`Channel`介面，該介面負責request/response的進出，如此`Handler`只需要負責與sub classes互動即可
2. `get`, `post`, and `delete`都改用`Channel`作為輸入參數，如此之後要新增任何東西都不需要再更改大量`Handler`
3. 移除所有`HttpExchange`從所有介面