### PR TITLE
增加 `RebalanceAdmin#wait*Synced` 的 debounce 次數

### DIFF
--- a/app/src/main/java/org/astraea/app/balancer/executor/RebalanceAdminImpl.java
+++ b/app/src/main/java/org/astraea/app/balancer/executor/RebalanceAdminImpl.java
@@ -21,8 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.astraea.app.admin.Admin;
 import org.astraea.app.admin.ClusterInfo;
@@ -160,16 +160,9 @@ class RebalanceAdminImpl implements RebalanceAdmin {
     ensureTopicPermitted(log.topic());
 
     return CompletableFuture.supplyAsync(
-        () -> {
-          // due to the state consistency issue in Kafka broker design. the cluster state returned
-          // from the API might bounce between the `old state` and the `new state` during the very
-          // beginning and accomplishment of the cluster state alteration API. to fix this we use
-          // debounce technique, to ensure the target condition is held over a few successive tries,
-          // which mean the cluster state alteration is considered stable.
-          var debounce = 2;
-          var endTime = getEndTime(timeout);
-          while (!Thread.currentThread().isInterrupted()) {
-            boolean synced =
+        debounceCheck(
+            timeout,
+            () ->
                 admin.replicas(Set.of(log.topic())).entrySet().stream()
                     .filter(x -> x.getKey().partition() == log.partition())
                     .filter(x -> x.getKey().topic().equals(log.topic()))
@@ -177,17 +170,7 @@ class RebalanceAdminImpl implements RebalanceAdmin {
                     .filter(x -> x.broker() == log.brokerId())
                     .findFirst()
                     .map(x -> x.inSync() && !x.isFuture())
-                    .orElse(false);
-            // debounce & retrial interval
-            Utils.sleep(retrialTime.get());
-            debounce = synced ? (debounce - 1) : 2;
-            // synced
-            if (synced && debounce <= 0) return true;
-            // timeout
-            if (System.currentTimeMillis() > endTime) return false;
-          }
-          return false;
-        });
+                    .orElse(false)));
   }
 
   @Override
@@ -196,16 +179,9 @@ class RebalanceAdminImpl implements RebalanceAdmin {
     ensureTopicPermitted(topicPartition.topic());
 
     return CompletableFuture.supplyAsync(
-        () -> {
-          // due to the state consistency issue in Kafka broker design. the cluster state returned
-          // from the API might bounce between the `old state` and the `new state` during the very
-          // beginning and accomplishment of the cluster state alteration API. to fix this we use
-          // debounce technique, to ensure the target condition is held over a few successive tries,
-          // which mean the cluster state alteration is considered stable.
-          var debounce = 2;
-          var endTime = getEndTime(timeout);
-          while (!Thread.currentThread().isInterrupted()) {
-            var synced =
+        debounceCheck(
+            timeout,
+            () ->
                 admin.replicas(Set.of(topicPartition.topic())).entrySet().stream()
                     .filter(x -> x.getKey().equals(topicPartition))
                     .findFirst()
@@ -219,17 +195,31 @@ class RebalanceAdminImpl implements RebalanceAdmin {
                                   .orElseThrow();
                           return preferred.leader();
                         })
-                    .orElseThrow();
-            // debounce & retrial interval
-            Utils.sleep(retrialTime.get());
-            debounce = synced ? (debounce - 1) : 2;
-            // synced
-            if (synced && debounce <= 0) return true;
-            // timeout
-            if (System.currentTimeMillis() > endTime) return false;
-          }
-          return false;
-        });
+                    .orElseThrow()));
+  }
+
+  private Supplier<Boolean> debounceCheck(Duration timeout, Supplier<Boolean> testDone) {
+    var debounceInitialCount = 10;
+    return () -> {
+      // due to the state consistency issue in Kafka broker design. the cluster state returned
+      // from the API might bounce between the `old state` and the `new state` during the very
+      // beginning and accomplishment of the cluster state alteration API. to fix this we use
+      // debounce technique, to ensure the target condition is held over a few successive tries,
+      // which mean the cluster state alteration is considered stable.
+      var debounce = debounceInitialCount;
+      var endTime = getEndTime(timeout);
+      while (!Thread.currentThread().isInterrupted()) {
+        // debounce & retrial interval
+        Utils.sleep(Duration.ofMillis(100));
+        var isDone = testDone.get();
+        debounce = isDone ? (debounce - 1) : debounceInitialCount;
+        // synced
+        if (isDone && debounce <= 0) return true;
+        // timeout
+        if (System.currentTimeMillis() > endTime) return false;
+      }
+      return false;
+    };
   }
 
   @Override
@@ -250,13 +240,5 @@ class RebalanceAdminImpl implements RebalanceAdmin {
   @Override
   public Predicate<String> topicFilter() {
     return topicFilter;
-  }
-
-  private static final AtomicReference<Duration> retrialTime =
-      new AtomicReference<>(Duration.ofSeconds(1));
-
-  // visible for test
-  static void changeRetrialTime(Duration newDebounceTime) {
-    retrialTime.set(newDebounceTime);
   }
 }

--- a/app/src/test/java/org/astraea/app/balancer/executor/RebalanceAdminTest.java
+++ b/app/src/test/java/org/astraea/app/balancer/executor/RebalanceAdminTest.java
@@ -53,7 +53,6 @@ class RebalanceAdminTest extends RequireBrokerCluster {
     try (var admin = Admin.of(bootstrapServers())) {
       var topic = prepareTopic(admin, 1, (short) 1);
       var rebalanceAdmin = prepareRebalanceAdmin(admin);
-      RebalanceAdminImpl.changeRetrialTime(Duration.ofMillis(50));
 
       // scale the replica size from 1 to 3, to the following data dir
       var logFolder0 = randomElement(logFolders().get(0));
@@ -92,7 +91,6 @@ class RebalanceAdminTest extends RequireBrokerCluster {
       var topicPartition = TopicPartition.of(topic, 0);
       var rebalanceAdmin = prepareRebalanceAdmin(admin);
       // decrease the debouncing time so the test has higher chance to fail
-      RebalanceAdminImpl.changeRetrialTime(Duration.ofMillis(150));
       prepareData(topic, 0, DataSize.MiB.of(256));
       Supplier<Replica> replicaNow = () -> admin.replicas(Set.of(topic)).get(topicPartition).get(0);
       var originalReplica = replicaNow.get();
@@ -147,7 +145,6 @@ class RebalanceAdminTest extends RequireBrokerCluster {
               .filter(dir -> !dir.equals(beginReplica.path()))
               .findAny()
               .orElseThrow();
-      RebalanceAdminImpl.changeRetrialTime(Duration.ofMillis(150));
       prepareData(topic, 0, DataSize.MiB.of(32));
       // let two brokers join the replica list
       admin.migrator().partition(topic, 0).moveTo(List.of(0, 1, 2));


### PR DESCRIPTION
resolve #622 

* debounce 檢查做得更頻繁（連續成功 10 次，每次間隔 100ms），這樣取樣的次數比較多，比較能撞到這個狀態彈跳的問題
* 整理重複的程式碼