### PR TITLE
Mount while `--report.path` occur

### DIFF
--- a/docker/start_app.sh
+++ b/docker/start_app.sh
@@ -33,7 +33,7 @@ declare -r HEAP_OPTS="${HEAP_OPTS:-"-Xmx2G -Xms2G"}"
 function showHelp() {
   echo "Usage: [ENV] start_app.sh"
   echo "ENV: "
-  echo "    ACCOUNT=skiptests          set the docker repo"
+  echo "    ACCOUNT=skiptests          set the account to clone from"
   echo "    BUILD=false                set true if you want to build image locally"
   echo "    RUN=false                  set false if you want to build/pull image only"
 }
@@ -117,7 +117,7 @@ function runContainer() {
     fi
     # this element must be something to mount
     if [[ "$defined_file" == "true" ]]; then
-      need_to_bind_file="${need_to_bind_file} -v  $word:$word"
+      need_to_bind_file="${need_to_bind_file} -v $word:$word"
       defined_file="false"
     fi
   done


### PR DESCRIPTION
源自 [這裡](https://github.com/skiptests/astraea/pull/619#discussion_r953819994) 的需求
目前的 start_app.sh 腳本缺乏了
1. 當參數有檔案路徑時，無法讀取 (因為沒有 mount 進 container)
2. 執行時輸出的檔案會留在 container 內
3. 腳本只能選擇 skiptests/astraea 的版本來跑，測試起來不方便

---

為此，
1. 在 start_app.sh 內新增新的參數，`ACCOUNT` 用來指定 github clone 的位置。
2. 判定輸入的參數內是否有包含 `--report.path` 並將下一個值 mount 進去。
