### PR TITLE
Add ClusterInfo#replicas to show all cached replicas

### DIFF
--- a/app/src/main/java/org/astraea/app/admin/ClusterInfo.java
+++ b/app/src/main/java/org/astraea/app/admin/ClusterInfo.java
@@ -32,44 +32,39 @@ public interface ClusterInfo {
         }
 
         @Override
-        public Set<String> topics() {
-          return Set.of();
-        }
-
-        @Override
-        public List<ReplicaInfo> replicas(String topic) {
+        public List<ReplicaInfo> replicas() {
           return List.of();
         }
       };
 
   /**
-   * convert the kafka Cluster to our ClusterInfo. All data structure are converted immediately, so
-   * you should cache the result if the performance is critical
+   * convert the kafka Cluster to our ClusterInfo. Noted: this method is used by {@link
+   * org.astraea.app.cost.HasBrokerCost} normally, so all data structure are converted immediately
    *
    * @param cluster kafka ClusterInfo
-   * @return astraea ClusterInfo
+   * @return ClusterInfo
    */
   static ClusterInfo of(org.apache.kafka.common.Cluster cluster) {
     var nodes = cluster.nodes().stream().map(NodeInfo::of).collect(Collectors.toUnmodifiableList());
     var topics = cluster.topics();
-    var allReplicas =
+    var replicas =
         topics.stream()
             .flatMap(t -> cluster.partitionsForTopic(t).stream())
             .flatMap(p -> ReplicaInfo.of(p).stream())
             .collect(Collectors.toUnmodifiableList());
-    var replicasForTopic = allReplicas.stream().collect(Collectors.groupingBy(ReplicaInfo::topic));
+    var replicasForTopic = replicas.stream().collect(Collectors.groupingBy(ReplicaInfo::topic));
     var availableReplicasForTopic =
-        allReplicas.stream()
+        replicas.stream()
             .filter(ReplicaInfo::isOnlineReplica)
             .collect(Collectors.groupingBy(ReplicaInfo::topic));
     var availableReplicaLeadersForTopics =
-        allReplicas.stream()
+        replicas.stream()
             .filter(ReplicaInfo::isOnlineReplica)
             .filter(ReplicaInfo::isLeader)
             .collect(Collectors.groupingBy(ReplicaInfo::topic));
     // This group is used commonly, so we cache it.
     var availableLeaderReplicasForBrokersTopics =
-        allReplicas.stream()
+        replicas.stream()
             .filter(ReplicaInfo::isOnlineReplica)
             .filter(ReplicaInfo::isLeader)
             .collect(Collectors.groupingBy(r -> Map.entry(r.nodeInfo().id(), r.topic())));
@@ -103,6 +98,11 @@ public interface ClusterInfo {
       @Override
       public List<ReplicaInfo> replicas(String topic) {
         return replicasForTopic.getOrDefault(topic, List.of());
+      }
+
+      @Override
+      public List<ReplicaInfo> replicas() {
+        return replicas;
       }
     };
   }
@@ -168,7 +168,9 @@ public interface ClusterInfo {
    *
    * @return return a set of topic names
    */
-  Set<String> topics();
+  default Set<String> topics() {
+    return replicas().stream().map(ReplicaInfo::topic).collect(Collectors.toUnmodifiableSet());
+  }
 
   /**
    * Get the list of replica information of each partition/replica pair for the given topic
@@ -176,5 +178,12 @@ public interface ClusterInfo {
    * @param topic The topic name
    * @return A list of {@link ReplicaInfo}.
    */
-  List<ReplicaInfo> replicas(String topic);
+  default List<ReplicaInfo> replicas(String topic) {
+    return replicas().stream()
+        .filter(r -> r.topic().equals(topic))
+        .collect(Collectors.toUnmodifiableList());
+  }
+
+  /** @return all replicas cached by this cluster info. */
+  List<ReplicaInfo> replicas();
 }

--- a/app/src/main/java/org/astraea/app/balancer/BalancerUtils.java
+++ b/app/src/main/java/org/astraea/app/balancer/BalancerUtils.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -31,7 +30,6 @@ import org.astraea.app.admin.ClusterBean;
 import org.astraea.app.admin.ClusterInfo;
 import org.astraea.app.admin.NodeInfo;
 import org.astraea.app.admin.ReplicaInfo;
-import org.astraea.app.admin.TopicPartition;
 import org.astraea.app.balancer.log.ClusterLogAllocation;
 import org.astraea.app.cost.HasClusterCost;
 import org.astraea.app.metrics.HasBeanObject;
@@ -54,6 +52,29 @@ public class BalancerUtils {
   public static ClusterInfo merge(ClusterInfo clusterInfo, ClusterLogAllocation allocation) {
     return new ClusterInfo() {
       // TODO: maybe add a field to tell if this cluster info is mocked.
+      private final Map<Integer, NodeInfo> nodeIdMap =
+          nodes().stream().collect(Collectors.toUnmodifiableMap(NodeInfo::id, Function.identity()));
+      private final List<ReplicaInfo> replicas =
+          allocation.topicPartitions().stream()
+              .map(tp -> Map.entry(tp, allocation.logPlacements(tp)))
+              .flatMap(
+                  entry -> {
+                    var tp = entry.getKey();
+                    var logs = entry.getValue();
+
+                    return IntStream.range(0, logs.size())
+                        .mapToObj(
+                            i ->
+                                ReplicaInfo.of(
+                                    tp.topic(),
+                                    tp.partition(),
+                                    nodeIdMap.get(logs.get(i).broker()),
+                                    i == 0,
+                                    true,
+                                    false,
+                                    logs.get(i).logDirectory().orElse(null)));
+                  })
+              .collect(Collectors.toUnmodifiableList());
 
       @Override
       public List<NodeInfo> nodes() {
@@ -61,38 +82,8 @@ public class BalancerUtils {
       }
 
       @Override
-      public Set<String> topics() {
-        return allocation.topicPartitions().stream()
-            .map(TopicPartition::topic)
-            .collect(Collectors.toUnmodifiableSet());
-      }
-
-      @Override
-      public List<ReplicaInfo> replicas(String topic) {
-        var nodeIdMap =
-            nodes().stream()
-                .collect(Collectors.toUnmodifiableMap(NodeInfo::id, Function.identity()));
-        return allocation.topicPartitions().stream()
-            .filter(tp -> tp.topic().equals(topic))
-            .map(tp -> Map.entry(tp, allocation.logPlacements(tp)))
-            .flatMap(
-                entry -> {
-                  var tp = entry.getKey();
-                  var logs = entry.getValue();
-
-                  return IntStream.range(0, logs.size())
-                      .mapToObj(
-                          i ->
-                              ReplicaInfo.of(
-                                  tp.topic(),
-                                  tp.partition(),
-                                  nodeIdMap.get(logs.get(i).broker()),
-                                  i == 0,
-                                  true,
-                                  false,
-                                  logs.get(i).logDirectory().orElse(null)));
-                })
-            .collect(Collectors.toUnmodifiableList());
+      public List<ReplicaInfo> replicas() {
+        return replicas;
       }
     };
   }

--- a/app/src/test/java/org/astraea/app/balancer/FakeClusterInfo.java
+++ b/app/src/test/java/org/astraea/app/balancer/FakeClusterInfo.java
@@ -93,29 +93,23 @@ public class FakeClusterInfo implements ClusterInfo {
                                     false,
                                     dataDirectoryList.get(
                                         tp.partition() % dataDirectories.size()))))
-            .collect(Collectors.groupingBy(ReplicaInfo::topic));
+            .collect(Collectors.toUnmodifiableList());
 
     return new FakeClusterInfo(
         nodes,
         nodes.stream()
             .collect(Collectors.toMap(NodeInfo::id, n -> new HashSet<String>(dataDirectories))),
-        topics,
         replicas);
   }
 
   private final List<NodeInfo> nodes;
   private final Map<Integer, Set<String>> dataDirectories;
-  private final Set<String> topics;
-  private final Map<String, List<ReplicaInfo>> replicas;
+  private final List<ReplicaInfo> replicas;
 
   FakeClusterInfo(
-      List<NodeInfo> nodes,
-      Map<Integer, Set<String>> dataDirectories,
-      Set<String> topics,
-      Map<String, List<ReplicaInfo>> replicas) {
+      List<NodeInfo> nodes, Map<Integer, Set<String>> dataDirectories, List<ReplicaInfo> replicas) {
     this.nodes = nodes;
     this.dataDirectories = dataDirectories;
-    this.topics = topics;
     this.replicas = replicas;
   }
 
@@ -129,12 +123,7 @@ public class FakeClusterInfo implements ClusterInfo {
   }
 
   @Override
-  public Set<String> topics() {
-    return topics;
-  }
-
-  @Override
-  public List<ReplicaInfo> replicas(String topic) {
-    return replicas.getOrDefault(topic, List.of());
+  public List<ReplicaInfo> replicas() {
+    return replicas;
   }
 }


### PR DESCRIPTION
新增一個方法讓使用者可以取得所有`replicas`，並且用該方法來提供預設實作以簡化`ClusterInfo`的建構