### PR TITLE
Avoid null data directory by making Replica be the subclass of Replic…

### DIFF
--- a/app/src/main/java/org/astraea/app/admin/Builder.java
+++ b/app/src/main/java/org/astraea/app/admin/Builder.java
@@ -333,9 +333,9 @@ public class Builder {
         Set<String> topics, Set<Integer> brokerIds) {
       return replicas(topics).entrySet().stream()
           .flatMap(
-              e -> e.getValue().stream().map(replica -> Map.entry(replica.broker(), e.getKey())))
-          .filter(e -> brokerIds.contains(e.getKey()))
-          .collect(Collectors.groupingBy(Map.Entry::getKey))
+              e -> e.getValue().stream().map(replica -> Map.entry(replica.nodeInfo(), e.getKey())))
+          .filter(e -> brokerIds.contains(e.getKey().id()))
+          .collect(Collectors.groupingBy(e -> e.getKey().id()))
           .entrySet()
           .stream()
           .collect(
@@ -373,8 +373,8 @@ public class Builder {
                                 }))
                 .collect(
                     Collectors.toUnmodifiableMap(
-                        Map.Entry::getKey,
-                        (entry) -> {
+                        e -> e.getKey(),
+                        entry -> {
                           var topicPartition = entry.getKey();
                           var tpInfo = entry.getValue();
                           var replicaLeaderId = tpInfo.leader() != null ? tpInfo.leader().id() : -1;
@@ -406,8 +406,10 @@ public class Builder {
                                     boolean future = replicaInfo != null && replicaInfo.isFuture();
                                     boolean offline = node.isEmpty();
                                     boolean isPreferredLeader = preferredLeader.id() == broker;
-                                    return new Replica(
-                                        broker,
+                                    return Replica.of(
+                                        topicPartition.topic(),
+                                        topicPartition.partition(),
+                                        NodeInfo.of(node),
                                         lag,
                                         size,
                                         isLeader,
@@ -464,23 +466,9 @@ public class Builder {
       var replicas =
           Utils.packException(
               () ->
-                  this.replicas(topics).entrySet().stream()
-                      .flatMap(
-                          e ->
-                              e.getValue().stream()
-                                  .map(
-                                      replica ->
-                                          ReplicaInfo.of(
-                                              e.getKey().topic(),
-                                              e.getKey().partition(),
-                                              nodeInfo.stream()
-                                                  .filter(x -> x.id() == replica.broker())
-                                                  .findFirst()
-                                                  .orElse(NodeInfo.ofOfflineNode(replica.broker())),
-                                              replica.leader(),
-                                              replica.inSync(),
-                                              replica.isOffline(),
-                                              replica.path())))
+                  replicas(topics).values().stream()
+                      .flatMap(Collection::stream)
+                      .map(r -> (ReplicaInfo) r)
                       .collect(Collectors.toUnmodifiableList()));
 
       return new ClusterInfo() {
@@ -583,7 +571,7 @@ public class Builder {
                                                   new org.apache.kafka.common.TopicPartitionReplica(
                                                       e.getKey().topic(),
                                                       e.getKey().partition(),
-                                                      r.broker())))
+                                                      r.nodeInfo().id())))
                               .collect(Collectors.toUnmodifiableList()))
                       .all()
                       .get());
@@ -683,14 +671,14 @@ public class Builder {
                   (tp, replicas) -> {
                     replicas.forEach(
                         replica -> {
-                          if (replica.leader())
+                          if (replica.isLeader())
                             leaders.add(
                                 TopicPartitionReplica.of(
-                                    tp.topic(), tp.partition(), replica.broker()));
+                                    tp.topic(), tp.partition(), replica.nodeInfo().id()));
                           else
                             followers.add(
                                 TopicPartitionReplica.of(
-                                    tp.topic(), tp.partition(), replica.broker()));
+                                    tp.topic(), tp.partition(), replica.nodeInfo().id()));
                         });
                   });
           return this;
@@ -702,14 +690,18 @@ public class Builder {
               replicas(Set.of(topicPartition.topic())).getOrDefault(topicPartition, List.of());
           replicas.forEach(
               replica -> {
-                if (replica.leader())
+                if (replica.isLeader())
                   leaders.add(
                       TopicPartitionReplica.of(
-                          topicPartition.topic(), topicPartition.partition(), replica.broker()));
+                          topicPartition.topic(),
+                          topicPartition.partition(),
+                          replica.nodeInfo().id()));
                 else
                   followers.add(
                       TopicPartitionReplica.of(
-                          topicPartition.topic(), topicPartition.partition(), replica.broker()));
+                          topicPartition.topic(),
+                          topicPartition.partition(),
+                          replica.nodeInfo().id()));
               });
           return this;
         }
@@ -882,7 +874,7 @@ public class Builder {
     public void clearReplicationThrottle(TopicPartition topicPartition) {
       var configValue =
           replicas(Set.of(topicPartition.topic())).get(topicPartition).stream()
-              .map(replica -> topicPartition.partition() + ":" + replica.broker())
+              .map(replica -> topicPartition.partition() + ":" + replica.nodeInfo().id())
               .collect(Collectors.joining(","));
       var configEntry0 = new ConfigEntry("leader.replication.throttled.replicas", configValue);
       var configEntry1 = new ConfigEntry("follower.replication.throttled.replicas", configValue);

--- a/app/src/main/java/org/astraea/app/admin/ClusterInfo.java
+++ b/app/src/main/java/org/astraea/app/admin/ClusterInfo.java
@@ -55,17 +55,17 @@ public interface ClusterInfo {
     var replicasForTopic = replicas.stream().collect(Collectors.groupingBy(ReplicaInfo::topic));
     var availableReplicasForTopic =
         replicas.stream()
-            .filter(ReplicaInfo::isOnlineReplica)
+            .filter(ReplicaInfo::isOnline)
             .collect(Collectors.groupingBy(ReplicaInfo::topic));
     var availableReplicaLeadersForTopics =
         replicas.stream()
-            .filter(ReplicaInfo::isOnlineReplica)
+            .filter(ReplicaInfo::isOnline)
             .filter(ReplicaInfo::isLeader)
             .collect(Collectors.groupingBy(ReplicaInfo::topic));
     // This group is used commonly, so we cache it.
     var availableLeaderReplicasForBrokersTopics =
         replicas.stream()
-            .filter(ReplicaInfo::isOnlineReplica)
+            .filter(ReplicaInfo::isOnline)
             .filter(ReplicaInfo::isLeader)
             .collect(Collectors.groupingBy(r -> Map.entry(r.nodeInfo().id(), r.topic())));
 
@@ -156,7 +156,7 @@ public interface ClusterInfo {
    */
   default List<ReplicaInfo> availableReplicas(String topic) {
     return replicas(topic).stream()
-        .filter(ReplicaInfo::isOnlineReplica)
+        .filter(ReplicaInfo::isOnline)
         .collect(Collectors.toUnmodifiableList());
   }
 

--- a/app/src/main/java/org/astraea/app/admin/Reassignment.java
+++ b/app/src/main/java/org/astraea/app/admin/Reassignment.java
@@ -58,19 +58,19 @@ public class Reassignment {
 
   public static class Location {
     private final int broker;
-    private final String path;
+    private final String dataFolder;
 
-    public Location(int broker, String path) {
+    public Location(int broker, String dataFolder) {
       this.broker = broker;
-      this.path = Objects.requireNonNull(path);
+      this.dataFolder = Objects.requireNonNull(dataFolder);
     }
 
     public int broker() {
       return broker;
     }
 
-    public String path() {
-      return path;
+    public String dataFolder() {
+      return dataFolder;
     }
 
     @Override
@@ -78,17 +78,17 @@ public class Reassignment {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       Location location = (Location) o;
-      return broker == location.broker && path.equals(location.path);
+      return broker == location.broker && dataFolder.equals(location.dataFolder);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(broker, path);
+      return Objects.hash(broker, dataFolder);
     }
 
     @Override
     public String toString() {
-      return "Location{" + "broker=" + broker + ", path='" + path + '\'' + '}';
+      return "Location{" + "broker=" + broker + ", dataFolder='" + dataFolder + '\'' + '}';
     }
   }
 }

--- a/app/src/main/java/org/astraea/app/admin/ReplicaInfo.java
+++ b/app/src/main/java/org/astraea/app/admin/ReplicaInfo.java
@@ -17,7 +17,6 @@
 package org.astraea.app.admin;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -48,18 +47,7 @@ public interface ReplicaInfo {
       NodeInfo nodeInfo,
       boolean isLeader,
       boolean isSynced,
-      boolean isOfflineReplica) {
-    return of(topic, partition, nodeInfo, isLeader, isSynced, isOfflineReplica, null);
-  }
-
-  static ReplicaInfo of(
-      String topic,
-      int partition,
-      NodeInfo nodeInfo,
-      boolean isLeader,
-      boolean isSynced,
-      boolean isOfflineReplica,
-      String dataFolder) {
+      boolean isOffline) {
     return new ReplicaInfo() {
       @Override
       public String topic() {
@@ -87,13 +75,8 @@ public interface ReplicaInfo {
       }
 
       @Override
-      public boolean isOfflineReplica() {
-        return isOfflineReplica;
-      }
-
-      @Override
-      public Optional<String> dataFolder() {
-        return Optional.ofNullable(dataFolder);
+      public boolean isOffline() {
+        return isOffline;
       }
 
       @Override
@@ -105,12 +88,10 @@ public interface ReplicaInfo {
             + partition
             + " replicaAtBroker="
             + nodeInfo.id()
-            + " dataFolder="
-            + (dataFolder().map(x -> "\"" + x + "\"").orElse("unknown"))
             + (isLeader() ? " leader" : "")
             + (isFollower() ? " follower" : "")
             + (inSync() ? ":synced" : "")
-            + (isOfflineReplica() ? ":offline" : "")
+            + (isOffline() ? ":offline" : "")
             + "}";
       }
 
@@ -125,8 +106,7 @@ public interface ReplicaInfo {
               && this.isLeader() == that.isLeader()
               && this.isFollower() == that.isFollower()
               && this.inSync() == that.inSync()
-              && this.isOfflineReplica() == that.isOfflineReplica()
-              && this.dataFolder().equals(that.dataFolder());
+              && this.isOffline() == that.isOffline();
         }
         return false;
       }
@@ -154,21 +134,10 @@ public interface ReplicaInfo {
   boolean inSync();
 
   /** @return true if this replica is offline */
-  boolean isOfflineReplica();
+  boolean isOffline();
 
   /** @return true if this replica is online */
-  default boolean isOnlineReplica() {
-    return !isOfflineReplica();
+  default boolean isOnline() {
+    return !isOffline();
   }
-
-  /**
-   * The path to the data folder which hosts this replica. Since this information is not very openly
-   * available. An application might find it hard to retrieve this information(for example, the
-   * producer client might need to initialize an AdminClient to access this information). To provide
-   * this information or not is totally up to the caller.
-   *
-   * @return a {@link Optional<String>} that indicates the data folder path which stored this
-   *     replica on a specific Kafka node.
-   */
-  Optional<String> dataFolder();
 }

--- a/app/src/main/java/org/astraea/app/balancer/BalancerUtils.java
+++ b/app/src/main/java/org/astraea/app/balancer/BalancerUtils.java
@@ -29,6 +29,7 @@ import java.util.stream.IntStream;
 import org.astraea.app.admin.ClusterBean;
 import org.astraea.app.admin.ClusterInfo;
 import org.astraea.app.admin.NodeInfo;
+import org.astraea.app.admin.Replica;
 import org.astraea.app.admin.ReplicaInfo;
 import org.astraea.app.balancer.log.ClusterLogAllocation;
 import org.astraea.app.cost.HasClusterCost;
@@ -65,14 +66,20 @@ public class BalancerUtils {
                     return IntStream.range(0, logs.size())
                         .mapToObj(
                             i ->
-                                ReplicaInfo.of(
+                                // TODO: too many fake data!!! we should use another data structure
+                                // https://github.com/skiptests/astraea/issues/526
+                                Replica.of(
                                     tp.topic(),
                                     tp.partition(),
                                     nodeIdMap.get(logs.get(i).broker()),
+                                    0,
+                                    -1,
                                     i == 0,
                                     true,
                                     false,
-                                    logs.get(i).logDirectory().orElse(null)));
+                                    false,
+                                    false,
+                                    logs.get(i).logDirectory()));
                   })
               .collect(Collectors.toUnmodifiableList());
 

--- a/app/src/main/java/org/astraea/app/balancer/BalancerUtils.java
+++ b/app/src/main/java/org/astraea/app/balancer/BalancerUtils.java
@@ -79,7 +79,7 @@ public class BalancerUtils {
                                     false,
                                     false,
                                     false,
-                                    logs.get(i).logDirectory()));
+                                    logs.get(i).dataFolder()));
                   })
               .collect(Collectors.toUnmodifiableList());
 

--- a/app/src/main/java/org/astraea/app/balancer/executor/RebalanceAdminImpl.java
+++ b/app/src/main/java/org/astraea/app/balancer/executor/RebalanceAdminImpl.java
@@ -89,8 +89,7 @@ class RebalanceAdminImpl implements RebalanceAdmin {
     final var declareMap =
         preferredPlacements.stream()
             .filter(futurePlacement -> !currentBrokerAllocation.contains(futurePlacement.broker()))
-            .collect(
-                Collectors.toUnmodifiableMap(LogPlacement::broker, LogPlacement::logDirectory));
+            .collect(Collectors.toUnmodifiableMap(LogPlacement::broker, LogPlacement::dataFolder));
 
     admin
         .migrator()
@@ -127,8 +126,7 @@ class RebalanceAdminImpl implements RebalanceAdmin {
     var forCrossDirMigration =
         expectedPlacement.stream()
             .filter(placement -> currentReplicaBrokers.contains(placement.broker()))
-            .collect(
-                Collectors.toUnmodifiableMap(LogPlacement::broker, LogPlacement::logDirectory));
+            .collect(Collectors.toUnmodifiableMap(LogPlacement::broker, LogPlacement::dataFolder));
     admin
         .migrator()
         .partition(topicPartition.topic(), topicPartition.partition())

--- a/app/src/main/java/org/astraea/app/balancer/log/ClusterLogAllocation.java
+++ b/app/src/main/java/org/astraea/app/balancer/log/ClusterLogAllocation.java
@@ -149,7 +149,7 @@ public interface ClusterLogAllocation {
                   .forEach(
                       log ->
                           stringBuilder.append(
-                              String.format("(%s, %s) ", log.broker(), log.logDirectory())));
+                              String.format("(%s, %s) ", log.broker(), log.dataFolder())));
 
               stringBuilder.append(System.lineSeparator());
             });

--- a/app/src/main/java/org/astraea/app/balancer/log/LogPlacement.java
+++ b/app/src/main/java/org/astraea/app/balancer/log/LogPlacement.java
@@ -17,7 +17,6 @@
 package org.astraea.app.balancer.log;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.IntStream;
 
 /** This class describe the placement state of one kafka log. */
@@ -25,7 +24,7 @@ public interface LogPlacement {
 
   int broker();
 
-  Optional<String> logDirectory();
+  String logDirectory();
 
   static boolean isMatch(List<LogPlacement> sourcePlacements, List<LogPlacement> targetPlacements) {
     if (sourcePlacements.size() != targetPlacements.size()) return false;
@@ -42,31 +41,14 @@ public interface LogPlacement {
         IntStream.range(0, sourcePlacements.size())
             .allMatch(
                 index ->
-                    meetLogDirectoryMigrationRequirement(
-                        sourcePlacements.get(index).logDirectory(),
-                        targetPlacements.get(index).logDirectory()));
+                    sourcePlacements
+                        .get(index)
+                        .logDirectory()
+                        .equals(targetPlacements.get(index).logDirectory()));
     //noinspection RedundantIfStatement
     if (!logDirectoryMatch) return false;
 
     return true;
-  }
-
-  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-  private static boolean meetLogDirectoryMigrationRequirement(
-      Optional<String> sourceDir, Optional<String> targetDir) {
-    // don't care which log directory will eventually be in the destination.
-    if (targetDir.isEmpty()) return true;
-
-    // we care which data directory the target will eventually be, but we don't know.
-    if (sourceDir.isEmpty()) return false;
-
-    // both candidate is specified, if and only if two paths match, will consider as a requirement
-    // meet.
-    return sourceDir.get().equals(targetDir.get());
-  }
-
-  static LogPlacement of(int broker) {
-    return of(broker, null);
   }
 
   static LogPlacement of(int broker, String logDirectory) {
@@ -77,8 +59,8 @@ public interface LogPlacement {
       }
 
       @Override
-      public Optional<String> logDirectory() {
-        return Optional.ofNullable(logDirectory);
+      public String logDirectory() {
+        return logDirectory;
       }
 
       @Override

--- a/app/src/main/java/org/astraea/app/balancer/log/LogPlacement.java
+++ b/app/src/main/java/org/astraea/app/balancer/log/LogPlacement.java
@@ -24,7 +24,7 @@ public interface LogPlacement {
 
   int broker();
 
-  String logDirectory();
+  String dataFolder();
 
   static boolean isMatch(List<LogPlacement> sourcePlacements, List<LogPlacement> targetPlacements) {
     if (sourcePlacements.size() != targetPlacements.size()) return false;
@@ -43,15 +43,15 @@ public interface LogPlacement {
                 index ->
                     sourcePlacements
                         .get(index)
-                        .logDirectory()
-                        .equals(targetPlacements.get(index).logDirectory()));
+                        .dataFolder()
+                        .equals(targetPlacements.get(index).dataFolder()));
     //noinspection RedundantIfStatement
     if (!logDirectoryMatch) return false;
 
     return true;
   }
 
-  static LogPlacement of(int broker, String logDirectory) {
+  static LogPlacement of(int broker, String dataFolder) {
     return new LogPlacement() {
       @Override
       public int broker() {
@@ -59,22 +59,22 @@ public interface LogPlacement {
       }
 
       @Override
-      public String logDirectory() {
-        return logDirectory;
+      public String dataFolder() {
+        return dataFolder;
       }
 
       @Override
       public boolean equals(Object obj) {
         if (obj instanceof LogPlacement) {
           final var that = (LogPlacement) obj;
-          return this.broker() == that.broker() && this.logDirectory().equals(that.logDirectory());
+          return this.broker() == that.broker() && this.dataFolder().equals(that.dataFolder());
         }
         return false;
       }
 
       @Override
       public String toString() {
-        return "LogPlacement{broker=" + broker() + " logDir=" + logDirectory() + "}";
+        return "LogPlacement{broker=" + broker() + " dataFolder=" + dataFolder() + "}";
       }
     };
   }

--- a/app/src/main/java/org/astraea/app/web/BalancerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BalancerHandler.java
@@ -103,7 +103,7 @@ class BalancerHandler implements Handler {
 
     Placement(LogPlacement lp) {
       this.brokerId = lp.broker();
-      this.directory = lp.logDirectory().orElse(null);
+      this.directory = lp.logDirectory();
     }
   }
 

--- a/app/src/main/java/org/astraea/app/web/BalancerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BalancerHandler.java
@@ -103,7 +103,7 @@ class BalancerHandler implements Handler {
 
     Placement(LogPlacement lp) {
       this.brokerId = lp.broker();
-      this.directory = lp.logDirectory();
+      this.directory = lp.dataFolder();
     }
   }
 

--- a/app/src/main/java/org/astraea/app/web/ReassignmentHandler.java
+++ b/app/src/main/java/org/astraea/app/web/ReassignmentHandler.java
@@ -81,7 +81,7 @@ public class ReassignmentHandler implements Handler {
 
     Location(org.astraea.app.admin.Reassignment.Location location) {
       this.broker = location.broker();
-      this.path = location.path();
+      this.path = location.dataFolder();
     }
   }
 

--- a/app/src/main/java/org/astraea/app/web/TopicHandler.java
+++ b/app/src/main/java/org/astraea/app/web/TopicHandler.java
@@ -190,13 +190,13 @@ class TopicHandler implements Handler {
 
     Replica(org.astraea.app.admin.Replica replica) {
       this(
-          replica.broker(),
+          replica.nodeInfo().id(),
           replica.lag(),
           replica.size(),
-          replica.leader(),
+          replica.isLeader(),
           replica.inSync(),
           replica.isFuture(),
-          replica.path());
+          replica.dataFolder());
     }
 
     Replica(

--- a/app/src/test/java/org/astraea/app/admin/AdminTest.java
+++ b/app/src/test/java/org/astraea/app/admin/AdminTest.java
@@ -148,7 +148,7 @@ public class AdminTest extends RequireBrokerCluster {
                   replicas.forEach(
                       replica ->
                           Assertions.assertTrue(
-                              logFolders.stream().anyMatch(replica.path()::contains))));
+                              logFolders.stream().anyMatch(replica.dataFolder()::contains))));
     }
   }
 
@@ -223,11 +223,16 @@ public class AdminTest extends RequireBrokerCluster {
             var partitionReplicas = replicas.entrySet().iterator().next().getValue();
             return replicas.size() == 1
                 && partitionReplicas.size() == 1
-                && partitionReplicas.get(0).broker() == broker;
+                && partitionReplicas.get(0).nodeInfo().id() == broker;
           });
 
       var currentBroker =
-          admin.replicas(Set.of(topicName)).get(TopicPartition.of(topicName, 0)).get(0).broker();
+          admin
+              .replicas(Set.of(topicName))
+              .get(TopicPartition.of(topicName, 0))
+              .get(0)
+              .nodeInfo()
+              .id();
       var allPath = admin.brokerFolders(Set.of(currentBroker));
       var otherPath =
           allPath.get(currentBroker).stream()
@@ -238,7 +243,7 @@ public class AdminTest extends RequireBrokerCluster {
                               .replicas(Set.of(topicName))
                               .get(TopicPartition.of(topicName, 0))
                               .get(0)
-                              .path()))
+                              .dataFolder()))
               .collect(Collectors.toSet());
       admin
           .migrator()
@@ -250,7 +255,7 @@ public class AdminTest extends RequireBrokerCluster {
             var partitionReplicas = replicas.entrySet().iterator().next().getValue();
             return replicas.size() == 1
                 && partitionReplicas.size() == 1
-                && partitionReplicas.get(0).path().equals(otherPath.iterator().next());
+                && partitionReplicas.get(0).dataFolder().equals(otherPath.iterator().next());
           });
     }
   }
@@ -263,7 +268,7 @@ public class AdminTest extends RequireBrokerCluster {
       var topicPartition = TopicPartition.of(topic, 0);
       admin.creator().topic(topic).numberOfPartitions(1).numberOfReplicas((short) 1).create();
       Utils.sleep(Duration.ofSeconds(1));
-      var originalBroker = admin.replicas(Set.of(topic)).get(topicPartition).get(0).broker();
+      var originalBroker = admin.replicas(Set.of(topic)).get(topicPartition).get(0).nodeInfo().id();
       var nextBroker = (originalBroker + 1) % brokerIds().size();
       var nextDir = logFolders().get(nextBroker).stream().findAny().orElseThrow();
       Supplier<Replica> replicaNow = () -> admin.replicas(Set.of(topic)).get(topicPartition).get(0);
@@ -276,16 +281,16 @@ public class AdminTest extends RequireBrokerCluster {
       Utils.sleep(Duration.ofSeconds(1));
 
       // assert, nothing happened until the actual movement
-      Assertions.assertNotEquals(nextBroker, replicaNow.get().broker());
-      Assertions.assertNotEquals(nextDir, replicaNow.get().path());
+      Assertions.assertNotEquals(nextBroker, replicaNow.get().nodeInfo().id());
+      Assertions.assertNotEquals(nextDir, replicaNow.get().dataFolder());
 
       // act, perform the actual movement
       admin.migrator().partition(topic, 0).moveTo(List.of(nextBroker));
       Utils.sleep(Duration.ofSeconds(1));
 
       // assert, everything on the exact broker & dir
-      Assertions.assertEquals(nextBroker, replicaNow.get().broker());
-      Assertions.assertEquals(nextDir, replicaNow.get().path());
+      Assertions.assertEquals(nextBroker, replicaNow.get().nodeInfo().id());
+      Assertions.assertEquals(nextDir, replicaNow.get().dataFolder());
     }
   }
 
@@ -297,7 +302,7 @@ public class AdminTest extends RequireBrokerCluster {
       admin.creator().topic(topic).numberOfPartitions(1).numberOfReplicas((short) 1).create();
       Utils.sleep(Duration.ofSeconds(1));
       var currentReplica = admin.replicas(Set.of(topic)).get(topicPartition).get(0);
-      var currentBroker = currentReplica.broker();
+      var currentBroker = currentReplica.nodeInfo().id();
       var notExistReplica = (currentBroker + 1) % brokerIds().size();
       var nextDir = logFolders().get(notExistReplica).iterator().next();
 
@@ -315,7 +320,7 @@ public class AdminTest extends RequireBrokerCluster {
       admin.creator().topic(topic).numberOfPartitions(1).numberOfReplicas((short) 1).create();
       Utils.sleep(Duration.ofSeconds(1));
       var currentReplica = admin.replicas(Set.of(topic)).get(topicPartition).get(0);
-      var currentBroker = currentReplica.broker();
+      var currentBroker = currentReplica.nodeInfo().id();
       var nextDir = logFolders().get(currentBroker).iterator().next();
 
       Assertions.assertThrows(
@@ -376,7 +381,7 @@ public class AdminTest extends RequireBrokerCluster {
             if (replicas.size() != 3) return false;
             if (!replicas.values().stream().allMatch(rs -> rs.size() == 1)) return false;
             return replicas.values().stream()
-                .allMatch(rs -> rs.stream().allMatch(r -> r.broker() == broker));
+                .allMatch(rs -> rs.stream().allMatch(r -> r.nodeInfo().id() == broker));
           });
     }
   }
@@ -521,7 +526,8 @@ public class AdminTest extends RequireBrokerCluster {
                               entry ->
                                   entry.getValue().stream()
                                       .filter(Replica::isPreferredLeader)
-                                      .map(Replica::broker)
+                                      .map(Replica::nodeInfo)
+                                      .map(NodeInfo::id)
                                       .collect(Collectors.toUnmodifiableList())));
 
       // act, make 0 be the preferred leader of every partition
@@ -755,10 +761,11 @@ public class AdminTest extends RequireBrokerCluster {
                               Map.Entry::getKey,
                               e ->
                                   e.getValue().stream()
-                                      .filter(Replica::leader)
+                                      .filter(Replica::isLeader)
                                       .findFirst()
                                       .orElseThrow()
-                                      .broker()));
+                                      .nodeInfo()
+                                      .id()));
       var expectedReplicaList =
           currentLeaderMap.get().entrySet().stream()
               .collect(
@@ -996,7 +1003,12 @@ public class AdminTest extends RequireBrokerCluster {
       Utils.sleep(Duration.ofSeconds(3));
 
       var currentBroker =
-          admin.replicas(Set.of(topicName)).get(TopicPartition.of(topicName, 0)).get(0).broker();
+          admin
+              .replicas(Set.of(topicName))
+              .get(TopicPartition.of(topicName, 0))
+              .get(0)
+              .nodeInfo()
+              .id();
       var nextBroker = brokerIds().stream().filter(i -> i != currentBroker).findAny().get();
 
       try (var producer = Producer.of(bootstrapServers())) {
@@ -1039,8 +1051,8 @@ public class AdminTest extends RequireBrokerCluster {
 
       var currentReplica =
           admin.replicas(Set.of(topicName)).get(TopicPartition.of(topicName, 0)).get(0);
-      var currentBroker = currentReplica.broker();
-      var currentPath = currentReplica.path();
+      var currentBroker = currentReplica.nodeInfo().id();
+      var currentPath = currentReplica.dataFolder();
       var nextPath =
           logFolders().get(currentBroker).stream()
               .filter(p -> !p.equals(currentPath))
@@ -1058,7 +1070,10 @@ public class AdminTest extends RequireBrokerCluster {
                 });
 
         try {
-          admin.migrator().topic(topicName).moveTo(Map.of(currentReplica.broker(), nextPath));
+          admin
+              .migrator()
+              .topic(topicName)
+              .moveTo(Map.of(currentReplica.nodeInfo().id(), nextPath));
           var reassignment =
               admin.reassignments(Set.of(topicName)).get(TopicPartition.of(topicName, 0));
           // Don't verify the result if the migration is done
@@ -1266,13 +1281,13 @@ public class AdminTest extends RequireBrokerCluster {
         .flatMap(
             entry ->
                 entry.getValue().stream()
-                    .filter(Replica::leader)
+                    .filter(Replica::isLeader)
                     .map(
                         replica ->
                             TopicPartitionReplica.of(
                                 entry.getKey().topic(),
                                 entry.getKey().partition(),
-                                replica.broker())))
+                                replica.nodeInfo().id())))
         .collect(Collectors.toUnmodifiableSet());
   }
 
@@ -1281,13 +1296,13 @@ public class AdminTest extends RequireBrokerCluster {
         .flatMap(
             entry ->
                 entry.getValue().stream()
-                    .filter(replica -> !replica.leader())
+                    .filter(replica -> !replica.isLeader())
                     .map(
                         replica ->
                             TopicPartitionReplica.of(
                                 entry.getKey().topic(),
                                 entry.getKey().partition(),
-                                replica.broker())))
+                                replica.nodeInfo().id())))
         .collect(Collectors.toUnmodifiableSet());
   }
 
@@ -1476,23 +1491,22 @@ public class AdminTest extends RequireBrokerCluster {
   }
 
   private Set<TopicPartitionReplica> fetchLogThrottleConfig(String configKey, String topicName) {
-    try (AdminClient adminClient =
-        AdminClient.create(
-            Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers()))) {
-      var resource = new ConfigResource(ConfigResource.Type.TOPIC, topicName);
-      var stringValue =
-          Utils.packException(() -> adminClient.describeConfigs(List.of(resource)).all().get())
-              .get(resource)
-              .get(configKey)
-              .value();
-      if (stringValue.isEmpty()) return Set.of();
-      return Arrays.stream(stringValue.split(","))
-          .map(x -> x.split(":"))
+    try (var admin = Admin.of(bootstrapServers())) {
+      return admin
+          .topics(Set.of(topicName))
+          .get(topicName)
+          .value(configKey)
+          .filter(v -> !v.isEmpty())
           .map(
-              x ->
-                  TopicPartitionReplica.of(
-                      topicName, Integer.parseInt(x[0]), Integer.parseInt(x[1])))
-          .collect(Collectors.toUnmodifiableSet());
+              value ->
+                  Arrays.stream(value.split(","))
+                      .map(x -> x.split(":"))
+                      .map(
+                          x ->
+                              TopicPartitionReplica.of(
+                                  topicName, Integer.parseInt(x[0]), Integer.parseInt(x[1])))
+                      .collect(Collectors.toUnmodifiableSet()))
+          .orElse(Set.of());
     }
   }
 

--- a/app/src/test/java/org/astraea/app/admin/AdminTest.java
+++ b/app/src/test/java/org/astraea/app/admin/AdminTest.java
@@ -1081,11 +1081,11 @@ public class AdminTest extends RequireBrokerCluster {
             Assertions.assertEquals(1, reassignment.from().size());
             var from = reassignment.from().iterator().next();
             Assertions.assertEquals(currentBroker, from.broker());
-            Assertions.assertEquals(currentPath, from.path());
+            Assertions.assertEquals(currentPath, from.dataFolder());
             Assertions.assertEquals(1, reassignment.to().size());
             var to = reassignment.to().iterator().next();
             Assertions.assertEquals(currentBroker, to.broker());
-            Assertions.assertEquals(nextPath, to.path());
+            Assertions.assertEquals(nextPath, to.dataFolder());
           }
         } finally {
           done.set(true);

--- a/app/src/test/java/org/astraea/app/admin/ClusterInfoWithOfflineNodeTest.java
+++ b/app/src/test/java/org/astraea/app/admin/ClusterInfoWithOfflineNodeTest.java
@@ -43,7 +43,7 @@ public class ClusterInfoWithOfflineNodeTest extends RequireBrokerCluster {
       var before = admin.clusterInfo(Set.of(topicName));
       Assertions.assertEquals(
           partitionCount * replicaCount,
-          before.replicas(topicName).stream().filter(x -> !x.isOfflineReplica()).count());
+          before.replicas(topicName).stream().filter(x -> !x.isOffline()).count());
       Assertions.assertEquals(
           partitionCount * replicaCount, before.availableReplicas(topicName).size());
       Assertions.assertEquals(partitionCount, before.availableReplicaLeaders(topicName).size());
@@ -57,7 +57,7 @@ public class ClusterInfoWithOfflineNodeTest extends RequireBrokerCluster {
       var after = admin.clusterInfo(Set.of(topicName));
       Assertions.assertEquals(
           partitionCount * (replicaCount - 1),
-          after.replicas(topicName).stream().filter(x -> !x.isOfflineReplica()).count());
+          after.replicas(topicName).stream().filter(x -> !x.isOffline()).count());
       Assertions.assertEquals(
           partitionCount * (replicaCount - 1), after.availableReplicas(topicName).size());
       Assertions.assertEquals(
@@ -72,11 +72,11 @@ public class ClusterInfoWithOfflineNodeTest extends RequireBrokerCluster {
               .allMatch(x -> x.nodeInfo().id() != brokerToClose));
       Assertions.assertTrue(
           after.replicas(topicName).stream()
-              .filter(ReplicaInfo::isOfflineReplica)
+              .filter(ReplicaInfo::isOffline)
               .allMatch(x -> x.nodeInfo().id() == brokerToClose));
       Assertions.assertTrue(
           after.replicas(topicName).stream()
-              .filter(x -> !x.isOfflineReplica())
+              .filter(x -> !x.isOffline())
               .allMatch(x -> x.nodeInfo().id() != brokerToClose));
     }
   }

--- a/app/src/test/java/org/astraea/app/admin/ReplicationThrottlerTest.java
+++ b/app/src/test/java/org/astraea/app/admin/ReplicationThrottlerTest.java
@@ -85,7 +85,7 @@ public class ReplicationThrottlerTest extends RequireBrokerCluster {
       Utils.waitFor(
           () ->
               admin.replicas(Set.of(topicName)).get(TopicPartition.of(topicName, 0)).stream()
-                  .filter(x -> x.broker() == 1)
+                  .filter(x -> x.nodeInfo().id() == 1)
                   .findFirst()
                   .map(Replica::inSync)
                   .orElse(false),

--- a/app/src/test/java/org/astraea/app/admin/SomePartitionOfflineTest.java
+++ b/app/src/test/java/org/astraea/app/admin/SomePartitionOfflineTest.java
@@ -36,7 +36,7 @@ public class SomePartitionOfflineTest extends RequireBrokerCluster {
       Utils.sleep(Duration.ofSeconds(3));
       var replicaOnBroker0 =
           admin.replicas(admin.topicNames()).entrySet().stream()
-              .filter(replica -> replica.getValue().get(0).broker() == 0)
+              .filter(replica -> replica.getValue().get(0).nodeInfo().id() == 0)
               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
       replicaOnBroker0.forEach((tp, replica) -> Assertions.assertFalse(replica.get(0).isOffline()));
       closeBroker(0);
@@ -45,7 +45,7 @@ public class SomePartitionOfflineTest extends RequireBrokerCluster {
       Assertions.assertNotNull(logFolders().get(2));
       var offlineReplicaOnBroker0 =
           admin.replicas(admin.topicNames()).entrySet().stream()
-              .filter(replica -> replica.getValue().get(0).broker() == 0)
+              .filter(replica -> replica.getValue().get(0).nodeInfo().id() == 0)
               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
       offlineReplicaOnBroker0.forEach(
           (tp, replica) -> Assertions.assertTrue(replica.get(0).isOffline()));

--- a/app/src/test/java/org/astraea/app/balancer/BalancerUtilsTest.java
+++ b/app/src/test/java/org/astraea/app/balancer/BalancerUtilsTest.java
@@ -66,8 +66,8 @@ class BalancerUtilsTest {
   void testMockClusterInfoAllocation() {
     var tp1 = TopicPartition.of("testMockCluster", 1);
     var tp2 = TopicPartition.of("testMockCluster", 0);
-    var logPlacement1 = List.of(LogPlacement.of(0), LogPlacement.of(1));
-    var logPlacement2 = List.of(LogPlacement.of(1), LogPlacement.of(2));
+    var logPlacement1 = List.of(LogPlacement.of(0, "/data"), LogPlacement.of(1, "/data"));
+    var logPlacement2 = List.of(LogPlacement.of(1, "/data1"), LogPlacement.of(2, "/data1"));
     var nodes =
         new Node[] {
           new Node(0, "localhost", 9092),

--- a/app/src/test/java/org/astraea/app/balancer/FakeClusterInfo.java
+++ b/app/src/test/java/org/astraea/app/balancer/FakeClusterInfo.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.astraea.app.admin.ClusterInfo;
 import org.astraea.app.admin.NodeInfo;
+import org.astraea.app.admin.Replica;
 import org.astraea.app.admin.ReplicaInfo;
 import org.astraea.app.admin.TopicPartition;
 
@@ -84,15 +85,20 @@ public class FakeClusterInfo implements ClusterInfo {
                     IntStream.range(0, replicaCount)
                         .mapToObj(
                             r ->
-                                ReplicaInfo.of(
-                                    tp.topic(),
-                                    tp.partition(),
-                                    nodes.get(r),
-                                    r == 0,
-                                    true,
-                                    false,
-                                    dataDirectoryList.get(
-                                        tp.partition() % dataDirectories.size()))))
+                                (ReplicaInfo)
+                                    Replica.of(
+                                        tp.topic(),
+                                        tp.partition(),
+                                        nodes.get(r),
+                                        0,
+                                        -1,
+                                        r == 0,
+                                        true,
+                                        false,
+                                        false,
+                                        false,
+                                        dataDirectoryList.get(
+                                            tp.partition() % dataDirectories.size()))))
             .collect(Collectors.toUnmodifiableList());
 
     return new FakeClusterInfo(

--- a/app/src/test/java/org/astraea/app/balancer/executor/RebalanceAdminTest.java
+++ b/app/src/test/java/org/astraea/app/balancer/executor/RebalanceAdminTest.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.astraea.app.admin.Admin;
+import org.astraea.app.admin.NodeInfo;
 import org.astraea.app.admin.Replica;
 import org.astraea.app.admin.TopicPartition;
 import org.astraea.app.admin.TopicPartitionReplica;
@@ -75,10 +76,11 @@ class RebalanceAdminTest extends RequireBrokerCluster {
       var replicas = admin.replicas(Set.of(topic)).get(topicPartition);
 
       Assertions.assertEquals(
-          List.of(0, 1, 2), replicas.stream().map(Replica::broker).collect(Collectors.toList()));
-      Assertions.assertEquals(logFolder0, replicas.get(0).path());
-      Assertions.assertEquals(logFolder1, replicas.get(1).path());
-      Assertions.assertEquals(logFolder2, replicas.get(2).path());
+          List.of(0, 1, 2),
+          replicas.stream().map(Replica::nodeInfo).map(NodeInfo::id).collect(Collectors.toList()));
+      Assertions.assertEquals(logFolder0, replicas.get(0).dataFolder());
+      Assertions.assertEquals(logFolder1, replicas.get(1).dataFolder());
+      Assertions.assertEquals(logFolder2, replicas.get(2).dataFolder());
     }
   }
 
@@ -95,11 +97,11 @@ class RebalanceAdminTest extends RequireBrokerCluster {
       Supplier<Replica> replicaNow = () -> admin.replicas(Set.of(topic)).get(topicPartition).get(0);
       var originalReplica = replicaNow.get();
       var nextDir =
-          logFolders().get(originalReplica.broker()).stream()
-              .filter(name -> !name.equals(originalReplica.path()))
+          logFolders().get(originalReplica.nodeInfo().id()).stream()
+              .filter(name -> !name.equals(originalReplica.dataFolder()))
               .findAny()
               .orElseThrow();
-      var expectedPlacement = LogPlacement.of(originalReplica.broker(), nextDir);
+      var expectedPlacement = LogPlacement.of(originalReplica.nodeInfo().id(), nextDir);
 
       // act, change the dir of the only replica
       var task =
@@ -110,7 +112,7 @@ class RebalanceAdminTest extends RequireBrokerCluster {
       var finalReplica = replicaNow.get();
       Assertions.assertTrue(finalReplica.inSync());
       Assertions.assertFalse(finalReplica.isFuture());
-      Assertions.assertEquals(originalReplica.broker(), finalReplica.broker());
+      Assertions.assertEquals(originalReplica.nodeInfo(), finalReplica.nodeInfo());
     }
   }
 
@@ -141,15 +143,18 @@ class RebalanceAdminTest extends RequireBrokerCluster {
       var rebalanceAdmin = prepareRebalanceAdmin(admin);
       var beginReplica = admin.replicas().get(topicPartition).get(0);
       var otherDataDir =
-          admin.brokerFolders().get(beginReplica.broker()).stream()
-              .filter(dir -> !dir.equals(beginReplica.path()))
+          admin.brokerFolders().get(beginReplica.nodeInfo().id()).stream()
+              .filter(dir -> !dir.equals(beginReplica.dataFolder()))
               .findAny()
               .orElseThrow();
       prepareData(topic, 0, DataSize.MiB.of(32));
       // let two brokers join the replica list
       admin.migrator().partition(topic, 0).moveTo(List.of(0, 1, 2));
       // let the existing replica change its directory
-      admin.migrator().partition(topic, 0).moveTo(Map.of(beginReplica.broker(), otherDataDir));
+      admin
+          .migrator()
+          .partition(topic, 0)
+          .moveTo(Map.of(beginReplica.nodeInfo().id(), otherDataDir));
 
       // act
       long time0 = System.currentTimeMillis();
@@ -187,10 +192,11 @@ class RebalanceAdminTest extends RequireBrokerCluster {
                       .filter(x -> x.getKey().topic().equals(topic))
                       .filter(x -> x.getKey().partition() == 0)
                       .flatMap(x -> x.getValue().stream())
-                      .filter(Replica::leader)
+                      .filter(Replica::isLeader)
                       .findFirst()
                       .orElseThrow()
-                      .broker();
+                      .nodeInfo()
+                      .id();
 
       int oldLeader = leaderNow.get();
 
@@ -229,10 +235,11 @@ class RebalanceAdminTest extends RequireBrokerCluster {
                       .filter(x -> x.getKey().topic().equals(topic))
                       .filter(x -> x.getKey().partition() == 0)
                       .flatMap(x -> x.getValue().stream())
-                      .filter(Replica::leader)
+                      .filter(Replica::isLeader)
                       .findFirst()
                       .orElseThrow()
-                      .broker();
+                      .nodeInfo()
+                      .id();
 
       int oldLeader = leaderNow.get();
 

--- a/app/src/test/java/org/astraea/app/balancer/log/ClusterLogAllocationTest.java
+++ b/app/src/test/java/org/astraea/app/balancer/log/ClusterLogAllocationTest.java
@@ -83,7 +83,7 @@ class ClusterLogAllocationTest {
         1, clusterLogAllocation.logPlacements(sourceTopicPartition0).get(0).broker());
     Assertions.assertEquals(
         dataDirectory,
-        clusterLogAllocation.logPlacements(sourceTopicPartition0).get(0).logDirectory());
+        clusterLogAllocation.logPlacements(sourceTopicPartition0).get(0).dataFolder());
 
     final var sourceTopicPartition1 = TopicPartition.of("topic", "0");
     clusterLogAllocation =
@@ -92,7 +92,7 @@ class ClusterLogAllocationTest {
         1, clusterLogAllocation.logPlacements(sourceTopicPartition1).get(0).broker());
     Assertions.assertEquals(
         dataDirectory,
-        clusterLogAllocation.logPlacements(sourceTopicPartition1).get(0).logDirectory());
+        clusterLogAllocation.logPlacements(sourceTopicPartition1).get(0).dataFolder());
   }
 
   @Test
@@ -119,8 +119,7 @@ class ClusterLogAllocationTest {
     Assertions.assertEquals(
         0, allocation.logPlacements(TopicPartition.of("topic", "0")).get(0).broker());
     Assertions.assertEquals(
-        "/nowhere",
-        allocation.logPlacements(TopicPartition.of("topic", "0")).get(0).logDirectory());
+        "/nowhere", allocation.logPlacements(TopicPartition.of("topic", "0")).get(0).dataFolder());
     Assertions.assertEquals(0, allocation.logPlacements(TopicPartition.of("no", "0")).size());
     allocation.logPlacements(TopicPartition.of("no", "0"));
   }

--- a/app/src/test/java/org/astraea/app/balancer/log/ClusterLogAllocationTest.java
+++ b/app/src/test/java/org/astraea/app/balancer/log/ClusterLogAllocationTest.java
@@ -38,7 +38,8 @@ class ClusterLogAllocationTest {
         IllegalArgumentException.class, () -> ClusterLogAllocation.of(badAllocation0));
 
     // partial topic/partition
-    var badAllocation1 = Map.of(TopicPartition.of("topic", "999"), List.of(LogPlacement.of(1001)));
+    var badAllocation1 =
+        Map.of(TopicPartition.of("topic", "999"), List.of(LogPlacement.of(1001, "xx")));
     Assertions.assertThrows(
         IllegalArgumentException.class, () -> ClusterLogAllocation.of(badAllocation1));
 
@@ -46,7 +47,10 @@ class ClusterLogAllocationTest {
     var badAllocation2 =
         Map.of(
             TopicPartition.of("topic", "0"),
-            List.of(LogPlacement.of(1001), LogPlacement.of(1001), LogPlacement.of(1001)));
+            List.of(
+                LogPlacement.of(1001, "xx"),
+                LogPlacement.of(1001, "xx"),
+                LogPlacement.of(1001, "xx")));
     Assertions.assertThrows(
         IllegalArgumentException.class, () -> ClusterLogAllocation.of(badAllocation2));
   }
@@ -61,12 +65,6 @@ class ClusterLogAllocationTest {
 
     Assertions.assertEquals(
         1, clusterLogAllocation.logPlacements(sourceTopicPartition).get(0).broker());
-    Assertions.assertNull(
-        clusterLogAllocation
-            .logPlacements(sourceTopicPartition)
-            .get(0)
-            .logDirectory()
-            .orElse(null));
   }
 
   @ParameterizedTest
@@ -85,11 +83,7 @@ class ClusterLogAllocationTest {
         1, clusterLogAllocation.logPlacements(sourceTopicPartition0).get(0).broker());
     Assertions.assertEquals(
         dataDirectory,
-        clusterLogAllocation
-            .logPlacements(sourceTopicPartition0)
-            .get(0)
-            .logDirectory()
-            .orElse(null));
+        clusterLogAllocation.logPlacements(sourceTopicPartition0).get(0).logDirectory());
 
     final var sourceTopicPartition1 = TopicPartition.of("topic", "0");
     clusterLogAllocation =
@@ -98,11 +92,7 @@ class ClusterLogAllocationTest {
         1, clusterLogAllocation.logPlacements(sourceTopicPartition1).get(0).broker());
     Assertions.assertEquals(
         dataDirectory,
-        clusterLogAllocation
-            .logPlacements(sourceTopicPartition1)
-            .get(0)
-            .logDirectory()
-            .orElse(null));
+        clusterLogAllocation.logPlacements(sourceTopicPartition1).get(0).logDirectory());
   }
 
   @Test
@@ -130,11 +120,7 @@ class ClusterLogAllocationTest {
         0, allocation.logPlacements(TopicPartition.of("topic", "0")).get(0).broker());
     Assertions.assertEquals(
         "/nowhere",
-        allocation
-            .logPlacements(TopicPartition.of("topic", "0"))
-            .get(0)
-            .logDirectory()
-            .orElseThrow());
+        allocation.logPlacements(TopicPartition.of("topic", "0")).get(0).logDirectory());
     Assertions.assertEquals(0, allocation.logPlacements(TopicPartition.of("no", "0")).size());
     allocation.logPlacements(TopicPartition.of("no", "0"));
   }

--- a/app/src/test/java/org/astraea/app/balancer/log/LogPlacementTest.java
+++ b/app/src/test/java/org/astraea/app/balancer/log/LogPlacementTest.java
@@ -52,26 +52,4 @@ class LogPlacementTest {
         List.of(LogPlacement.of(0, "/Aaa"), LogPlacement.of(1, "/B"), LogPlacement.of(2, "/C"));
     Assertions.assertFalse(LogPlacement.isMatch(placement0, placement1));
   }
-
-  @Test
-  @DisplayName("Optional log dir")
-  void noMatch2() {
-    final var sourcePlacement =
-        List.of(LogPlacement.of(0, "/A"), LogPlacement.of(1, "/B"), LogPlacement.of(2, "/C"));
-    final var targetPlacement =
-        List.of(LogPlacement.of(0), LogPlacement.of(1, "/B"), LogPlacement.of(2, "/C"));
-    // don't care which log dir placement[0] will eventually be.
-    Assertions.assertTrue(LogPlacement.isMatch(sourcePlacement, targetPlacement));
-  }
-
-  @Test
-  @DisplayName("Optional log dir")
-  void noMatch3() {
-    final var sourcePlacement =
-        List.of(LogPlacement.of(0), LogPlacement.of(1, "/B"), LogPlacement.of(2, "/C"));
-    final var targetPlacement =
-        List.of(LogPlacement.of(0, "/A"), LogPlacement.of(1, "/B"), LogPlacement.of(2, "/C"));
-    // do care which log dir placement[0] will eventually be.
-    Assertions.assertFalse(LogPlacement.isMatch(sourcePlacement, targetPlacement));
-  }
 }

--- a/app/src/test/java/org/astraea/app/metrics/client/consumer/ConsumerMetricsTest.java
+++ b/app/src/test/java/org/astraea/app/metrics/client/consumer/ConsumerMetricsTest.java
@@ -38,7 +38,8 @@ public class ConsumerMetricsTest extends RequireBrokerCluster {
             Consumer.forTopics(Set.of(topic)).bootstrapServers(bootstrapServers()).build()) {
       admin.creator().topic(topic).numberOfPartitions(1).create();
       Utils.sleep(Duration.ofSeconds(3));
-      var owner = admin.replicas(Set.of(topic)).get(TopicPartition.of(topic, 0)).get(0).broker();
+      var owner =
+          admin.replicas(Set.of(topic)).get(TopicPartition.of(topic, 0)).get(0).nodeInfo().id();
       consumer.poll(Duration.ofSeconds(5));
       var metrics = ConsumerMetrics.node(MBeanClient.local(), owner);
       Assertions.assertEquals(1, metrics.size());

--- a/app/src/test/java/org/astraea/app/metrics/client/producer/ProducerMetricsTest.java
+++ b/app/src/test/java/org/astraea/app/metrics/client/producer/ProducerMetricsTest.java
@@ -39,7 +39,8 @@ public class ProducerMetricsTest extends RequireBrokerCluster {
         var producer = Producer.of(bootstrapServers())) {
       admin.creator().topic(topic).numberOfPartitions(1).create();
       Utils.sleep(Duration.ofSeconds(3));
-      var owner = admin.replicas(Set.of(topic)).get(TopicPartition.of(topic, 0)).get(0).broker();
+      var owner =
+          admin.replicas(Set.of(topic)).get(TopicPartition.of(topic, 0)).get(0).nodeInfo().id();
       producer.sender().topic(topic).run().toCompletableFuture().get();
       var metrics = ProducerMetrics.node(MBeanClient.local(), owner);
       Assertions.assertEquals(1, metrics.size());

--- a/app/src/test/java/org/astraea/app/web/ReassignmentHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/ReassignmentHandlerTest.java
@@ -36,7 +36,12 @@ public class ReassignmentHandlerTest extends RequireBrokerCluster {
       Utils.sleep(Duration.ofSeconds(3));
 
       var currentBroker =
-          admin.replicas(Set.of(topicName)).get(TopicPartition.of(topicName, 0)).get(0).broker();
+          admin
+              .replicas(Set.of(topicName))
+              .get(TopicPartition.of(topicName, 0))
+              .get(0)
+              .nodeInfo()
+              .id();
       var nextBroker = brokerIds().stream().filter(i -> i != currentBroker).findAny().get();
 
       var body =
@@ -60,7 +65,12 @@ public class ReassignmentHandlerTest extends RequireBrokerCluster {
 
       Assertions.assertEquals(
           nextBroker,
-          admin.replicas(Set.of(topicName)).get(TopicPartition.of(topicName, 0)).get(0).broker());
+          admin
+              .replicas(Set.of(topicName))
+              .get(TopicPartition.of(topicName, 0))
+              .get(0)
+              .nodeInfo()
+              .id());
     }
   }
 
@@ -74,8 +84,8 @@ public class ReassignmentHandlerTest extends RequireBrokerCluster {
 
       var currentReplica =
           admin.replicas(Set.of(topicName)).get(TopicPartition.of(topicName, 0)).get(0);
-      var currentBroker = currentReplica.broker();
-      var currentPath = currentReplica.path();
+      var currentBroker = currentReplica.nodeInfo().id();
+      var currentPath = currentReplica.dataFolder();
       var nextPath =
           logFolders().get(currentBroker).stream()
               .filter(p -> !p.equals(currentPath))
@@ -105,7 +115,11 @@ public class ReassignmentHandlerTest extends RequireBrokerCluster {
 
       Assertions.assertEquals(
           nextPath,
-          admin.replicas(Set.of(topicName)).get(TopicPartition.of(topicName, 0)).get(0).path());
+          admin
+              .replicas(Set.of(topicName))
+              .get(TopicPartition.of(topicName, 0))
+              .get(0)
+              .dataFolder());
     }
   }
 

--- a/app/src/test/java/org/astraea/app/web/ThrottleHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/ThrottleHandlerTest.java
@@ -90,10 +90,10 @@ public class ThrottleHandlerTest extends RequireBrokerCluster {
           var theReplica = replica;
           var isLeader =
               currentReplicas.get(TopicPartition.of(topicName, partition)).stream()
-                  .filter(r -> r.broker() == theReplica)
+                  .filter(r -> r.nodeInfo().id() == theReplica)
                   .findFirst()
                   .orElseThrow()
-                  .leader();
+                  .isLeader();
           var expected = new JsonObject();
           expected.add("name", new JsonPrimitive(topicName));
           expected.add("partition", new JsonPrimitive(partition));


### PR DESCRIPTION
1. `Replica`成為`ReplicaInfo`的繼承者，提供更多細緻的資訊
2. `dataFolder`成為`Replica`的方法
3. `balancer`會將`ReplicaInfo`轉型成`Replica`，如此可以移除有許多檢查`data folder`是否為`null`的邏輯
4. 將所有稱呼資料路徑的方法都改成`dataFolder`
5. `LogPlacement#dataFolder`從`Optional<String>`改成`String`