### PR TITLE
Always move nodes first when running reassignments

### DIFF
--- a/app/src/main/java/org/astraea/app/admin/Builder.java
+++ b/app/src/main/java/org/astraea/app/admin/Builder.java
@@ -1091,7 +1091,7 @@ public class Builder {
     public void moveTo(Map<Integer, String> brokerFolders) {
       // ensure this partition is host on the given map
       var topicPartition = partitions.iterator().next();
-      var currentReplicas =
+      var currentBrokers =
           Utils.packException(
                   () -> admin.describeTopics(Set.of(topicPartition.topic())).allTopicNames().get())
               .get(topicPartition.topic())
@@ -1103,12 +1103,14 @@ public class Builder {
               .collect(Collectors.toUnmodifiableSet());
       var notHere =
           brokerFolders.keySet().stream()
-              .filter(id -> !currentReplicas.contains(id))
+              .filter(id -> !currentBrokers.contains(id))
               .collect(Collectors.toUnmodifiableSet());
 
       if (!notHere.isEmpty())
         throw new IllegalStateException(
-            "The following specified broker is not part of the replica list: " + notHere);
+            String.format(
+                "brokers: %s does not host %s, current brokers are %s",
+                notHere, topicPartition, currentBrokers));
 
       var payload =
           brokerFolders.entrySet().stream()

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -39,7 +39,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
       var report =
           Assertions.assertInstanceOf(
               BalancerHandler.Report.class,
-              handler.get(Channel.ofQueries(Map.of(BalancerHandler.LIMIT_KEY, "30"))));
+              handler.get(Channel.ofQueries(Map.of(BalancerHandler.LIMIT_KEY, "60"))));
       Assertions.assertEquals(30, report.limit);
       Assertions.assertNotEquals(0, report.changes.size());
       Assertions.assertTrue(report.cost >= report.newCost);

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -68,7 +68,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                   Channel.ofQueries(
                       Map.of(
                           BalancerHandler.LIMIT_KEY,
-                          "30",
+                          "100",
                           BalancerHandler.TOPICS_KEY,
                           topicNames.get(0)))));
       var actual =

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -40,7 +40,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
           Assertions.assertInstanceOf(
               BalancerHandler.Report.class,
               handler.get(Channel.ofQueries(Map.of(BalancerHandler.LIMIT_KEY, "60"))));
-      Assertions.assertEquals(30, report.limit);
+      Assertions.assertEquals(60, report.limit);
       Assertions.assertNotEquals(0, report.changes.size());
       Assertions.assertTrue(report.cost >= report.newCost);
       Assertions.assertEquals(handler.costFunction.getClass().getSimpleName(), report.function);
@@ -91,7 +91,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                   Channel.ofQueries(
                       Map.of(
                           BalancerHandler.LIMIT_KEY,
-                          "30",
+                          "60",
                           BalancerHandler.TOPICS_KEY,
                           topicNames.get(0) + "," + topicNames.get(1)))));
       var actual =

--- a/app/src/test/java/org/astraea/app/web/ReassignmentHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/ReassignmentHandlerTest.java
@@ -192,8 +192,6 @@ public class ReassignmentHandlerTest extends RequireBrokerCluster {
               ReassignmentHandler.TO_KEY,
               "[" + nextBroker + "]");
 
-      System.out.println(body);
-
       Assertions.assertEquals(
           Response.ACCEPT, handler.post(Channel.ofRequest(PostRequest.of(body))));
 


### PR DESCRIPTION
當多個`reassignments`執行時，我們應該要先執行節點搬移，否則後續的目錄搬移就會出錯。此外當有節點搬移發生時，我們必須要等待一下才能執行目錄搬移，否則在metadata還沒更新時可能會遭遇unknown錯誤