### PR TITLE
Add gradle to deps base

### DIFF
--- a/docker/build_deps_image.sh
+++ b/docker/build_deps_image.sh
@@ -36,12 +36,17 @@ RUN apt-get update && apt-get install -y \
   libncurses5 \
   curl
 
+# download gradle 5 for previous kafka having no built-in gradlew
+WORKDIR /tmp
+RUN wget https://downloads.gradle-dn.com/distributions/gradle-5.6.4-bin.zip
+RUN unzip gradle-5.6.4-bin.zip
+
 # build code and download dependencies
 WORKDIR /astraea
 RUN git clone https://github.com/skiptests/astraea.git /astraea
 RUN ./gradlew clean build -x test
 # trigger download of database
-RUN ./gradlew cleanTest test --tests DatabaseTest
+RUN ./gradlew cleanTest app:test --tests DatabaseTest
 
 WORKDIR /root
 " >"$DOCKERFILE"

--- a/docker/start_broker.sh
+++ b/docker/start_broker.sh
@@ -129,7 +129,7 @@ RUN git checkout $VERSION
 RUN cp /tmp/kafka/gradlew /tmp/gradlew || /tmp/gradle-5.6.4/bin/gradle
 RUN ./gradlew clean releaseTarGz
 RUN mkdir /opt/kafka
-RUN tar -zxvf \$(find ./core/build/distributions/ -maxdepth 1 -type f -name kafka_*SNAPSHOT.tgz) -C /opt/kafka --strip-components=1
+RUN tar -zxvf \$(find ./core/build/distributions/ -maxdepth 1 -type f \( -iname \"kafka*tgz\" ! -iname \"*sit*\" \)) -C /opt/kafka --strip-components=1
 
 FROM ubuntu:22.04
 

--- a/docker/start_broker.sh
+++ b/docker/start_broker.sh
@@ -18,6 +18,7 @@ declare -r DOCKER_FOLDER=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null
 source $DOCKER_FOLDER/docker_build_common.sh
 
 # ===============================[global variables]===============================
+declare -r ACCOUNT=${ACCOUNT:-skiptests}
 declare -r VERSION=${REVISION:-${VERSION:-3.2.1}}
 declare -r DOCKERFILE=$DOCKER_FOLDER/broker.dockerfile
 declare -r CONFLUENT_BROKER=${CONFLUENT_BROKER:-false}
@@ -44,12 +45,10 @@ declare -r ZOOKEEPER_CONNECT=$(echo $1 | sed -n 's/^zookeeper.connect=\(.\+\)$/\
 declare -r HEAP_OPTS="${HEAP_OPTS:-"-Xmx2G -Xms2G"}"
 declare -r BROKER_PROPERTIES="/tmp/server-${BROKER_PORT}.properties"
 if [[ "$CONFLUENT_BROKER" = "true" ]]; then
-    declare -r REPO=${REPO:-ghcr.io/skiptests/astraea/confluent.broker}
-    declare -r IMAGE_NAME="$REPO:$CONFLUENT_VERSION"
+    declare -r IMAGE_NAME="ghcr.io/${ACCOUNT}/astraea/confluent.broker:$CONFLUENT_VERSION"
     declare -r SCRIPT_LOCATION_IN_CONTAINER="./bin/kafka-server-start"
 else
-    declare -r REPO=${REPO:-ghcr.io/skiptests/astraea/broker}
-    declare -r IMAGE_NAME="$REPO:$VERSION"
+    declare -r IMAGE_NAME="ghcr.io/${ACCOUNT}/astraea/broker:$VERSION"
     declare -r SCRIPT_LOCATION_IN_CONTAINER="./bin/kafka-server-start.sh"
 fi
 # cleanup the file if it is existent
@@ -65,7 +64,7 @@ function showHelp() {
   echo "    num.io.threads=10                        set broker I/O threads"
   echo "    num.network.threads=10                   set broker network threads"
   echo "ENV: "
-  echo "    REPO=astraea/broker                      set the docker repo"
+  echo "    ACCOUNT=skiptests                      set the github account"
   echo "    HEAP_OPTS=\"-Xmx2G -Xms2G\"                set broker JVM memory"
   echo "    REVISION=trunk                           set revision of kafka source code to build container"
   echo "    VERSION=3.2.1                            set version of kafka distribution"
@@ -114,13 +113,7 @@ WORKDIR /
 
 function generateDockerfileBySource() {
   echo "# this dockerfile is generated dynamically
-FROM ubuntu:22.04 AS build
-
-# install tools
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-11-jdk wget git curl
-
-# add user
-RUN groupadd $USER && useradd -ms /bin/bash -g $USER $USER
+FROM ghcr.io/skiptests/astraea/deps AS build
 
 # download jmx exporter
 RUN mkdir /opt/jmx_exporter
@@ -132,6 +125,8 @@ RUN wget https://REPO1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaage
 RUN git clone https://github.com/apache/kafka /tmp/kafka
 WORKDIR /tmp/kafka
 RUN git checkout $VERSION
+# generate gradlew for previous
+RUN cp /tmp/kafka/gradlew /tmp/gradlew || /tmp/gradle-5.6.4/bin/gradle
 RUN ./gradlew clean releaseTarGz
 RUN mkdir /opt/kafka
 RUN tar -zxvf \$(find ./core/build/distributions/ -maxdepth 1 -type f -name kafka_*SNAPSHOT.tgz) -C /opt/kafka --strip-components=1


### PR DESCRIPTION
早期的`kafka`並沒有放置`gradlew`，因此我們新增`gradle 5`到映像檔幫助建立早期的`kafka`版本