### PR TITLE
Refactor ClusterInfo

### DIFF
--- a/app/src/main/java/org/astraea/app/admin/Builder.java
+++ b/app/src/main/java/org/astraea/app/admin/Builder.java
@@ -463,8 +463,8 @@ public class Builder {
         }
 
         @Override
-        public List<Replica> replicas() {
-          return replicas;
+        public Stream<Replica> replicaStream() {
+          return replicas.stream();
         }
       };
     }

--- a/app/src/main/java/org/astraea/app/admin/ReplicaInfo.java
+++ b/app/src/main/java/org/astraea/app/admin/ReplicaInfo.java
@@ -114,6 +114,15 @@ public interface ReplicaInfo {
   }
 
   /**
+   * a helper to build TopicPartition quickly
+   *
+   * @return TopicPartition
+   */
+  default TopicPartition topicPartition() {
+    return TopicPartition.of(topic(), partition());
+  }
+
+  /**
    * a helper to build TopicPartitionReplica quickly
    *
    * @return TopicPartitionReplica

--- a/app/src/main/java/org/astraea/app/balancer/BalancerUtils.java
+++ b/app/src/main/java/org/astraea/app/balancer/BalancerUtils.java
@@ -26,6 +26,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.astraea.app.admin.ClusterBean;
 import org.astraea.app.admin.ClusterInfo;
 import org.astraea.app.admin.NodeInfo;
@@ -136,8 +137,8 @@ public class BalancerUtils {
       }
 
       @Override
-      public List<Replica> replicas() {
-        return replicas;
+      public Stream<Replica> replicaStream() {
+        return replicas.stream();
       }
     };
   }

--- a/app/src/main/java/org/astraea/app/cost/ReplicaLeaderCost.java
+++ b/app/src/main/java/org/astraea/app/cost/ReplicaLeaderCost.java
@@ -72,8 +72,7 @@ public class ReplicaLeaderCost implements HasBrokerCost, HasClusterCost {
   }
 
   static Map<Integer, Integer> leaderCount(ClusterInfo<? extends ReplicaInfo> clusterInfo) {
-    return clusterInfo.topics().stream()
-        .flatMap(t -> clusterInfo.availableReplicaLeaders(t).stream())
+    return clusterInfo.replicaLeaders().stream()
         .collect(Collectors.groupingBy(r -> r.nodeInfo().id()))
         .entrySet()
         .stream()

--- a/app/src/main/java/org/astraea/app/partitioner/StrictCostDispatcher.java
+++ b/app/src/main/java/org/astraea/app/partitioner/StrictCostDispatcher.java
@@ -105,7 +105,7 @@ public class StrictCostDispatcher implements Dispatcher {
   @Override
   public int partition(
       String topic, byte[] key, byte[] value, ClusterInfo<ReplicaInfo> clusterInfo) {
-    var partitionLeaders = clusterInfo.availableReplicaLeaders(topic);
+    var partitionLeaders = clusterInfo.replicaLeaders(topic);
     // just return first partition if there is no available partitions
     if (partitionLeaders.isEmpty()) return 0;
 
@@ -121,8 +121,7 @@ public class StrictCostDispatcher implements Dispatcher {
             next.getAndUpdate(previous -> previous >= roundRobin.length - 1 ? 0 : previous + 1)];
 
     // TODO: if the topic partitions are existent in fewer brokers, the target gets -1 in most cases
-    var candidate =
-        target < 0 ? partitionLeaders : clusterInfo.availableReplicaLeaders(target, topic);
+    var candidate = target < 0 ? partitionLeaders : clusterInfo.replicaLeaders(target, topic);
     candidate = candidate.isEmpty() ? partitionLeaders : candidate;
     return candidate.get((int) (Math.random() * candidate.size())).partition();
   }

--- a/app/src/main/java/org/astraea/app/partitioner/smooth/SmoothWeightRoundRobin.java
+++ b/app/src/main/java/org/astraea/app/partitioner/smooth/SmoothWeightRoundRobin.java
@@ -120,7 +120,7 @@ public final class SmoothWeightRoundRobin
         brokersIDofTopic.computeIfAbsent(
             topic,
             e ->
-                clusterInfo.availableReplicaLeaders(topic).stream()
+                clusterInfo.replicaLeaders(topic).stream()
                     .map(replicaInfo -> replicaInfo.nodeInfo().id())
                     .collect(Collectors.toList()));
     this.currentWeight =

--- a/app/src/test/java/org/astraea/app/admin/ClusterInfoWithOfflineNodeTest.java
+++ b/app/src/test/java/org/astraea/app/admin/ClusterInfoWithOfflineNodeTest.java
@@ -46,7 +46,7 @@ public class ClusterInfoWithOfflineNodeTest extends RequireBrokerCluster {
           before.replicas(topicName).stream().filter(x -> !x.isOffline()).count());
       Assertions.assertEquals(
           partitionCount * replicaCount, before.availableReplicas(topicName).size());
-      Assertions.assertEquals(partitionCount, before.availableReplicaLeaders(topicName).size());
+      Assertions.assertEquals(partitionCount, before.replicaLeaders(topicName).size());
 
       // act
       int brokerToClose = ThreadLocalRandom.current().nextInt(0, 3);
@@ -62,13 +62,13 @@ public class ClusterInfoWithOfflineNodeTest extends RequireBrokerCluster {
           partitionCount * (replicaCount - 1), after.availableReplicas(topicName).size());
       Assertions.assertEquals(
           partitionCount,
-          after.availableReplicaLeaders(topicName).size(),
+          after.replicaLeaders(topicName).size(),
           "One of the rest replicas should take over the leadership");
       Assertions.assertTrue(
           after.availableReplicas(topicName).stream()
               .allMatch(x -> x.nodeInfo().id() != brokerToClose));
       Assertions.assertTrue(
-          after.availableReplicaLeaders(topicName).stream()
+          after.replicaLeaders(topicName).stream()
               .allMatch(x -> x.nodeInfo().id() != brokerToClose));
       Assertions.assertTrue(
           after.replicas(topicName).stream()

--- a/app/src/test/java/org/astraea/app/balancer/FakeClusterInfo.java
+++ b/app/src/test/java/org/astraea/app/balancer/FakeClusterInfo.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.astraea.app.admin.ClusterInfo;
 import org.astraea.app.admin.NodeInfo;
 import org.astraea.app.admin.Replica;
@@ -127,7 +128,7 @@ public class FakeClusterInfo implements ClusterInfo<Replica> {
   }
 
   @Override
-  public List<Replica> replicas() {
-    return replicas;
+  public Stream<Replica> replicaStream() {
+    return replicas.stream();
   }
 }

--- a/app/src/test/java/org/astraea/app/cost/ClusterInfoIntegratedTest.java
+++ b/app/src/test/java/org/astraea/app/cost/ClusterInfoIntegratedTest.java
@@ -51,8 +51,7 @@ public class ClusterInfoIntegratedTest extends RequireBrokerCluster {
           .forEach(t -> Assertions.assertNotEquals(0, clusterInfo.availableReplicas(t).size()));
       clusterInfo
           .topics()
-          .forEach(
-              t -> Assertions.assertNotEquals(0, clusterInfo.availableReplicaLeaders(t).size()));
+          .forEach(t -> Assertions.assertNotEquals(0, clusterInfo.replicaLeaders(t).size()));
     }
   }
 }

--- a/app/src/test/java/org/astraea/app/cost/ClusterInfoTest.java
+++ b/app/src/test/java/org/astraea/app/cost/ClusterInfoTest.java
@@ -48,8 +48,7 @@ public class ClusterInfoTest {
     Assertions.assertEquals(
         NodeInfo.of(node), clusterInfo.availableReplicas(partition.topic()).get(0).nodeInfo());
     Assertions.assertEquals(
-        NodeInfo.of(node),
-        clusterInfo.availableReplicaLeaders(partition.topic()).get(0).nodeInfo());
+        NodeInfo.of(node), clusterInfo.replicaLeaders(partition.topic()).get(0).nodeInfo());
     Assertions.assertEquals(
         NodeInfo.of(node), clusterInfo.replicas(partition.topic()).get(0).nodeInfo());
   }
@@ -60,6 +59,6 @@ public class ClusterInfoTest {
     Assertions.assertEquals(0, clusterInfo.replicas("unknown").size());
     Assertions.assertThrows(NoSuchElementException.class, () -> clusterInfo.node(0));
     Assertions.assertEquals(0, clusterInfo.availableReplicas("unknown").size());
-    Assertions.assertEquals(0, clusterInfo.availableReplicaLeaders("unknown").size());
+    Assertions.assertEquals(0, clusterInfo.replicaLeaders("unknown").size());
   }
 }

--- a/app/src/test/java/org/astraea/app/cost/ReplicaLeaderCostTest.java
+++ b/app/src/test/java/org/astraea/app/cost/ReplicaLeaderCostTest.java
@@ -18,7 +18,6 @@ package org.astraea.app.cost;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.astraea.app.admin.ClusterBean;
 import org.astraea.app.admin.ClusterInfo;
 import org.astraea.app.admin.NodeInfo;
@@ -41,8 +40,7 @@ public class ReplicaLeaderCostTest {
             ReplicaInfo.of("topic", 0, NodeInfo.of(11, "broker1", 1111), true, true, true));
     @SuppressWarnings("unchecked")
     ClusterInfo<ReplicaInfo> clusterInfo = Mockito.mock(ClusterInfo.class);
-    Mockito.when(clusterInfo.topics()).thenReturn(Set.of("topic"));
-    Mockito.when(clusterInfo.availableReplicaLeaders(Mockito.anyString())).thenReturn(replicas);
+    Mockito.when(clusterInfo.replicaLeaders()).thenReturn(replicas);
     var cost = ReplicaLeaderCost.leaderCount(clusterInfo);
     Assertions.assertTrue(cost.containsKey(10));
     Assertions.assertTrue(cost.containsKey(11));

--- a/app/src/test/java/org/astraea/app/partitioner/StrictCostDispatcherTest.java
+++ b/app/src/test/java/org/astraea/app/partitioner/StrictCostDispatcherTest.java
@@ -105,7 +105,7 @@ public class StrictCostDispatcherTest {
   @Test
   void testNoAvailableBrokers() {
     var clusterInfo = Mockito.mock(ClusterInfo.class);
-    Mockito.when(clusterInfo.availableReplicaLeaders(Mockito.anyString())).thenReturn(List.of());
+    Mockito.when(clusterInfo.replicaLeaders(Mockito.anyString())).thenReturn(List.of());
     try (var dispatcher = new StrictCostDispatcher()) {
       dispatcher.configure(Map.of(), Optional.empty(), Map.of(), Duration.ofSeconds(10));
       Assertions.assertEquals(
@@ -118,8 +118,7 @@ public class StrictCostDispatcherTest {
     var nodeInfo = NodeInfo.of(10, "host", 11111);
     var replicaInfo = ReplicaInfo.of("topic", 10, nodeInfo, true, true, true);
     var clusterInfo = Mockito.mock(ClusterInfo.class);
-    Mockito.when(clusterInfo.availableReplicaLeaders(Mockito.anyString()))
-        .thenReturn(List.of(replicaInfo));
+    Mockito.when(clusterInfo.replicaLeaders(Mockito.anyString())).thenReturn(List.of(replicaInfo));
     try (var dispatcher = new StrictCostDispatcher()) {
       dispatcher.configure(Map.of(), Optional.empty(), Map.of(), Duration.ofSeconds(10));
       Assertions.assertEquals(
@@ -172,7 +171,7 @@ public class StrictCostDispatcherTest {
     var replicaInfo1 =
         ReplicaInfo.of("topic", 1, NodeInfo.of(12, "host2", 11111), true, true, true);
     var clusterInfo = Mockito.mock(ClusterInfo.class);
-    Mockito.when(clusterInfo.availableReplicaLeaders(Mockito.anyString()))
+    Mockito.when(clusterInfo.replicaLeaders(Mockito.anyString()))
         .thenReturn(List.of(replicaInfo0, replicaInfo1));
     try (var dispatcher = new StrictCostDispatcher()) {
       dispatcher.configure(
@@ -216,7 +215,7 @@ public class StrictCostDispatcherTest {
         ReplicaInfo.of("topic", 1, NodeInfo.of(11, "host2", 11111), true, true, true);
     var rs = List.of(replicaInfo0, replicaInfo1, replicaInfo2);
     var clusterInfo = Mockito.mock(ClusterInfo.class);
-    Mockito.when(clusterInfo.availableReplicaLeaders(Mockito.anyString())).thenReturn(rs);
+    Mockito.when(clusterInfo.replicaLeaders(Mockito.anyString())).thenReturn(rs);
     Mockito.when(clusterInfo.nodes())
         .thenReturn(
             rs.stream().map(ReplicaInfo::nodeInfo).collect(Collectors.toUnmodifiableList()));
@@ -278,14 +277,14 @@ public class StrictCostDispatcherTest {
       var replicaInfo1 =
           ReplicaInfo.of("topic", 1, NodeInfo.of(1111, "host2", 11111), true, true, true);
       var clusterInfo = Mockito.mock(ClusterInfo.class);
-      Mockito.when(clusterInfo.availableReplicaLeaders(Mockito.anyString()))
+      Mockito.when(clusterInfo.replicaLeaders(Mockito.anyString()))
           .thenReturn(List.of(replicaInfo0, replicaInfo1));
       Mockito.when(clusterInfo.nodes())
           .thenReturn(
               Stream.of(replicaInfo0, replicaInfo1)
                   .map(ReplicaInfo::nodeInfo)
                   .collect(Collectors.toUnmodifiableList()));
-      Mockito.when(clusterInfo.availableReplicaLeaders(Mockito.anyInt(), Mockito.anyString()))
+      Mockito.when(clusterInfo.replicaLeaders(Mockito.anyInt(), Mockito.anyString()))
           .thenReturn(List.of(replicaInfo0));
       Assertions.assertEquals(
           partitionId, dispatcher.partition("topic", new byte[0], new byte[0], clusterInfo));

--- a/app/src/test/java/org/astraea/app/partitioner/smooth/SmoothWeightRoundRobinDispatchTest.java
+++ b/app/src/test/java/org/astraea/app/partitioner/smooth/SmoothWeightRoundRobinDispatchTest.java
@@ -285,7 +285,7 @@ public class SmoothWeightRoundRobinDispatchTest extends RequireBrokerCluster {
     Mockito.when(re3.nodeInfo()).thenReturn(node3);
     Mockito.when(node3.id()).thenReturn(3);
     var testCluster = Mockito.mock(ClusterInfo.class);
-    Mockito.when(testCluster.availableReplicaLeaders(Mockito.anyString()))
+    Mockito.when(testCluster.replicaLeaders(Mockito.anyString()))
         .thenReturn(List.of(re1, re2, re3));
     Assertions.assertEquals(1, smoothWeight.getAndChoose(topic, testCluster));
     Assertions.assertEquals(2, smoothWeight.getAndChoose(topic, testCluster));

--- a/app/src/test/java/org/astraea/app/partitioner/smooth/SmoothWeightRoundRobinTest.java
+++ b/app/src/test/java/org/astraea/app/partitioner/smooth/SmoothWeightRoundRobinTest.java
@@ -72,7 +72,7 @@ public class SmoothWeightRoundRobinTest {
     Mockito.when(re3.nodeInfo()).thenReturn(node3);
     Mockito.when(node3.id()).thenReturn(3);
     var clusterInfo = Mockito.mock(ClusterInfo.class);
-    Mockito.when(clusterInfo.availableReplicaLeaders(Mockito.anyString()))
+    Mockito.when(clusterInfo.replicaLeaders(Mockito.anyString()))
         .thenReturn(List.of(re1, re2, re3));
     return clusterInfo;
   }


### PR DESCRIPTION
1. `availableReplicaLeaders` 重新命名為 `replicaLeaders` 因為 current leader 應該總是 available
2. 將各個方法重新排序
3. 補上一些測試