### PR TITLE
Don't mock ClusterInfo anymore

### DIFF
--- a/app/src/main/java/org/astraea/app/admin/ClusterInfo.java
+++ b/app/src/main/java/org/astraea/app/admin/ClusterInfo.java
@@ -60,6 +60,19 @@ public interface ClusterInfo<T extends ReplicaInfo> {
             .collect(Collectors.toUnmodifiableList()));
   }
 
+  /**
+   * build a cluster info based on replicas. Noted that the node info are collected by the replicas.
+   *
+   * @param replicas used to build cluster info
+   * @return cluster info
+   * @param <T> ReplicaInfo or Replica
+   */
+  static <T extends ReplicaInfo> ClusterInfo<T> of(List<T> replicas) {
+    return of(
+        replicas.stream().map(ReplicaInfo::nodeInfo).collect(Collectors.toUnmodifiableList()),
+        replicas);
+  }
+
   static <T extends ReplicaInfo> ClusterInfo<T> of(List<NodeInfo> nodes, List<T> replicas) {
     var topics = replicas.stream().map(ReplicaInfo::topic).collect(Collectors.toUnmodifiableSet());
     var replicasForTopic = replicas.stream().collect(Collectors.groupingBy(ReplicaInfo::topic));
@@ -125,7 +138,10 @@ public interface ClusterInfo<T extends ReplicaInfo> {
    * @return A list of {@link ReplicaInfo}.
    */
   default List<T> replicaLeaders() {
-    return replicaStream().filter(ReplicaInfo::isLeader).collect(Collectors.toUnmodifiableList());
+    return replicaStream()
+        .filter(ReplicaInfo::isLeader)
+        .filter(ReplicaInfo::isOnline)
+        .collect(Collectors.toUnmodifiableList());
   }
 
   /**
@@ -138,6 +154,7 @@ public interface ClusterInfo<T extends ReplicaInfo> {
     return replicaStream()
         .filter(r -> r.topic().equals(topic))
         .filter(ReplicaInfo::isLeader)
+        .filter(ReplicaInfo::isOnline)
         .collect(Collectors.toUnmodifiableList());
   }
 
@@ -153,6 +170,7 @@ public interface ClusterInfo<T extends ReplicaInfo> {
         .filter(r -> r.nodeInfo().id() == broker)
         .filter(r -> r.topic().equals(topic))
         .filter(ReplicaInfo::isLeader)
+        .filter(ReplicaInfo::isOnline)
         .collect(Collectors.toUnmodifiableList());
   }
 
@@ -166,6 +184,7 @@ public interface ClusterInfo<T extends ReplicaInfo> {
     return replicaStream()
         .filter(r -> r.topicPartition().equals(topicPartition))
         .filter(ReplicaInfo::isLeader)
+        .filter(ReplicaInfo::isOnline)
         .findFirst();
   }
 

--- a/app/src/test/java/org/astraea/app/cost/CpuCostTest.java
+++ b/app/src/test/java/org/astraea/app/cost/CpuCostTest.java
@@ -43,7 +43,7 @@ public class CpuCostTest {
                 4,
                 List.of()));
     var cpuCost = new CpuCost();
-    var result = cpuCost.brokerCost(Mockito.mock(ClusterInfo.class), clusterBean);
+    var result = cpuCost.brokerCost(ClusterInfo.empty(), clusterBean);
     Assertions.assertEquals(0.5, result.value().get(1));
     Assertions.assertEquals(0.6, result.value().get(2));
     Assertions.assertEquals(0.7, result.value().get(3));

--- a/app/src/test/java/org/astraea/app/cost/MemoryCostTest.java
+++ b/app/src/test/java/org/astraea/app/cost/MemoryCostTest.java
@@ -43,7 +43,7 @@ public class MemoryCostTest {
                 3,
                 List.of()));
     var memoryCost = new MemoryCost();
-    var scores = memoryCost.brokerCost(Mockito.mock(ClusterInfo.class), clusterBean);
+    var scores = memoryCost.brokerCost(ClusterInfo.empty(), clusterBean);
     Assertions.assertEquals(0.4, scores.value().get(1));
     Assertions.assertEquals(0.5, scores.value().get(2));
     Assertions.assertEquals(0, scores.value().get(3));

--- a/app/src/test/java/org/astraea/app/cost/NeutralIntegratedCostTest.java
+++ b/app/src/test/java/org/astraea/app/cost/NeutralIntegratedCostTest.java
@@ -29,7 +29,6 @@ public class NeutralIntegratedCostTest {
   @Test
   void testSetBrokerMetrics() {
     var neutralIntegratedCost = new NeutralIntegratedCost();
-    var clusterInfo = Mockito.mock(ClusterInfo.class);
     neutralIntegratedCost.brokersMetric =
         new HashMap<>(
             Map.of(
@@ -50,14 +49,18 @@ public class NeutralIntegratedCostTest {
     var outputBrokerCost = getBrokerCost(new HashMap<>(Map.of(0, 500.0, 1, 1000.0, 2, 1500.0)));
     var cpuBrokerCost = getBrokerCost(new HashMap<>(Map.of(0, 0.05, 1, 0.1, 2, 0.15)));
     var memoryBrokerCost = getBrokerCost(new HashMap<>(Map.of(0, 0.1, 1, 0.3, 2, 0.5)));
-    Mockito.when(input.brokerCost(clusterInfo, ClusterBean.EMPTY)).thenReturn(inputBrokerCost);
-    Mockito.when(output.brokerCost(clusterInfo, ClusterBean.EMPTY)).thenReturn(outputBrokerCost);
-    Mockito.when(memory.brokerCost(clusterInfo, ClusterBean.EMPTY)).thenReturn(memoryBrokerCost);
-    Mockito.when(cpu.brokerCost(clusterInfo, ClusterBean.EMPTY)).thenReturn(cpuBrokerCost);
+    Mockito.when(input.brokerCost(ClusterInfo.empty(), ClusterBean.EMPTY))
+        .thenReturn(inputBrokerCost);
+    Mockito.when(output.brokerCost(ClusterInfo.empty(), ClusterBean.EMPTY))
+        .thenReturn(outputBrokerCost);
+    Mockito.when(memory.brokerCost(ClusterInfo.empty(), ClusterBean.EMPTY))
+        .thenReturn(memoryBrokerCost);
+    Mockito.when(cpu.brokerCost(ClusterInfo.empty(), ClusterBean.EMPTY)).thenReturn(cpuBrokerCost);
     List<HasBrokerCost> metricsCost = List.of(input, output, cpu, memory);
     metricsCost.forEach(
         hasBrokerCost ->
-            neutralIntegratedCost.setBrokerMetrics(hasBrokerCost, clusterInfo, ClusterBean.EMPTY));
+            neutralIntegratedCost.setBrokerMetrics(
+                hasBrokerCost, ClusterInfo.empty(), ClusterBean.EMPTY));
 
     Assertions.assertEquals(neutralIntegratedCost.brokersMetric.get(0).inputScore, 50.0);
     Assertions.assertEquals(neutralIntegratedCost.brokersMetric.get(1).inputScore, 100.0);

--- a/app/src/test/java/org/astraea/app/cost/NodeLatencyCostTest.java
+++ b/app/src/test/java/org/astraea/app/cost/NodeLatencyCostTest.java
@@ -44,7 +44,7 @@ public class NodeLatencyCostTest extends RequireBrokerCluster {
     Mockito.when(bean.requestLatencyAvg()).thenReturn(Double.NaN);
     var clusterBean = ClusterBean.of(Map.of(-1, List.of(bean)));
     var function = new NodeLatencyCost();
-    var result = function.brokerCost(Mockito.mock(ClusterInfo.class), clusterBean);
+    var result = function.brokerCost(ClusterInfo.empty(), clusterBean);
     Assertions.assertEquals(0, result.value().size());
   }
 
@@ -55,7 +55,7 @@ public class NodeLatencyCostTest extends RequireBrokerCluster {
     Mockito.when(bean.requestLatencyAvg()).thenReturn(10D);
     var clusterBean = ClusterBean.of(Map.of(-1, List.of(bean)));
     var function = new NodeLatencyCost();
-    var result = function.brokerCost(Mockito.mock(ClusterInfo.class), clusterBean);
+    var result = function.brokerCost(ClusterInfo.empty(), clusterBean);
     Assertions.assertEquals(1, result.value().size());
     Assertions.assertEquals(10D, result.value().get(1));
   }
@@ -77,7 +77,7 @@ public class NodeLatencyCostTest extends RequireBrokerCluster {
           () ->
               function
                       .brokerCost(
-                          Mockito.mock(ClusterInfo.class),
+                          ClusterInfo.empty(),
                           ClusterBean.of(
                               Map.of(
                                   -1,

--- a/app/src/test/java/org/astraea/app/cost/NodeThroughputCostTest.java
+++ b/app/src/test/java/org/astraea/app/cost/NodeThroughputCostTest.java
@@ -37,7 +37,7 @@ public class NodeThroughputCostTest {
     Mockito.when(bean.outgoingByteRate()).thenReturn(Double.NaN);
     var clusterBean = ClusterBean.of(Map.of(-1, List.of(bean)));
     var function = new NodeThroughputCost();
-    var result = function.brokerCost(Mockito.mock(ClusterInfo.class), clusterBean);
+    var result = function.brokerCost(ClusterInfo.empty(), clusterBean);
     Assertions.assertEquals(0, result.value().size());
   }
 
@@ -49,7 +49,7 @@ public class NodeThroughputCostTest {
     Mockito.when(bean.outgoingByteRate()).thenReturn(10D);
     var clusterBean = ClusterBean.of(Map.of(-1, List.of(bean)));
     var function = new NodeThroughputCost();
-    var result = function.brokerCost(Mockito.mock(ClusterInfo.class), clusterBean);
+    var result = function.brokerCost(ClusterInfo.empty(), clusterBean);
     Assertions.assertEquals(1, result.value().size());
     Assertions.assertEquals(20D, result.value().get(1));
   }
@@ -66,8 +66,7 @@ public class NodeThroughputCostTest {
     Mockito.when(bean1.outgoingByteRate()).thenReturn(3D);
     Mockito.when(bean1.brokerId()).thenReturn(11);
     var clusterBean = ClusterBean.of(Map.of(0, List.of(bean0), 1, List.of(bean1)));
-    var clusterInfo = Mockito.mock(ClusterInfo.class);
-    var cost = throughputCost.brokerCost(clusterInfo, clusterBean);
+    var cost = throughputCost.brokerCost(ClusterInfo.empty(), clusterBean);
     Assertions.assertEquals(30D, cost.value().get(10));
     Assertions.assertEquals(5D, cost.value().get(11));
   }

--- a/app/src/test/java/org/astraea/app/cost/NodeTopicSizeCostTest.java
+++ b/app/src/test/java/org/astraea/app/cost/NodeTopicSizeCostTest.java
@@ -16,8 +16,6 @@
  */
 package org.astraea.app.cost;
 
-import static org.mockito.Mockito.mock;
-
 import java.util.List;
 import java.util.Map;
 import org.astraea.app.admin.ClusterBean;
@@ -36,8 +34,7 @@ class NodeTopicSizeCostTest {
   void testBrokerCost() {
     var meter = new LogMetrics.Log.Gauge(bean);
     var cost = new NodeTopicSizeCost();
-    var result =
-        cost.brokerCost(mock(ClusterInfo.class), ClusterBean.of(Map.of(1, List.of(meter))));
+    var result = cost.brokerCost(ClusterInfo.empty(), ClusterBean.of(Map.of(1, List.of(meter))));
     Assertions.assertEquals(1, result.value().size());
     Assertions.assertEquals(777, result.value().entrySet().iterator().next().getValue());
   }

--- a/app/src/test/java/org/astraea/app/cost/ReplicaDiskInCostTest.java
+++ b/app/src/test/java/org/astraea/app/cost/ReplicaDiskInCostTest.java
@@ -19,7 +19,6 @@ package org.astraea.app.cost;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.astraea.app.admin.ClusterBean;
 import org.astraea.app.admin.ClusterInfo;
 import org.astraea.app.admin.NodeInfo;
@@ -32,7 +31,6 @@ import org.astraea.app.partitioner.Configuration;
 import org.astraea.app.service.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class ReplicaDiskInCostTest extends RequireBrokerCluster {
   private static final HasGauge OLD_TP1_0 =
@@ -80,90 +78,81 @@ class ReplicaDiskInCostTest extends RequireBrokerCluster {
   }
 
   private ClusterInfo<Replica> clusterInfo() {
-    var clusterInfo = (ClusterInfo<Replica>) Mockito.mock(ClusterInfo.class);
-    Mockito.when(clusterInfo.nodes())
-        .thenReturn(
-            List.of(NodeInfo.of(1, "", -1), NodeInfo.of(2, "", -1), NodeInfo.of(3, "", -1)));
-    Mockito.when(clusterInfo.topics()).thenReturn(Set.of("test-1", "test-2"));
-    Mockito.when(clusterInfo.replicas(Mockito.anyString()))
-        .thenAnswer(
-            topic ->
-                topic.getArgument(0).equals("test-1")
-                    ? List.of(
-                        Replica.of(
-                            "test-1",
-                            0,
-                            NodeInfo.of(1, "", -1),
-                            0,
-                            100,
-                            true,
-                            true,
-                            false,
-                            false,
-                            true,
-                            "/tmp/aa"),
-                        Replica.of(
-                            "test-1",
-                            0,
-                            NodeInfo.of(2, "", -1),
-                            0,
-                            100,
-                            false,
-                            true,
-                            false,
-                            false,
-                            false,
-                            "/tmp/aa"),
-                        Replica.of(
-                            "test-1",
-                            1,
-                            NodeInfo.of(2, "", -1),
-                            0,
-                            100,
-                            false,
-                            true,
-                            false,
-                            false,
-                            false,
-                            "/tmp/aa"),
-                        Replica.of(
-                            "test-1",
-                            1,
-                            NodeInfo.of(3, "", -1),
-                            0,
-                            100,
-                            true,
-                            true,
-                            false,
-                            false,
-                            true,
-                            "/tmp/aa"))
-                    : List.of(
-                        Replica.of(
-                            "test-2",
-                            0,
-                            NodeInfo.of(1, "", -1),
-                            0,
-                            100,
-                            false,
-                            true,
-                            false,
-                            false,
-                            false,
-                            "/tmp/aa"),
-                        Replica.of(
-                            "test-2",
-                            0,
-                            NodeInfo.of(3, "", -1),
-                            0,
-                            100,
-                            true,
-                            true,
-                            false,
-                            false,
-                            true,
-                            "/tmp/aa")));
-    return clusterInfo;
+    return ClusterInfo.of(
+        List.of(NodeInfo.of(1, "", -1), NodeInfo.of(2, "", -1), NodeInfo.of(3, "", -1)),
+        List.of(
+            Replica.of(
+                "test-1",
+                0,
+                NodeInfo.of(1, "", -1),
+                0,
+                100,
+                true,
+                true,
+                false,
+                false,
+                true,
+                "/tmp/aa"),
+            Replica.of(
+                "test-1",
+                0,
+                NodeInfo.of(2, "", -1),
+                0,
+                100,
+                false,
+                true,
+                false,
+                false,
+                false,
+                "/tmp/aa"),
+            Replica.of(
+                "test-1",
+                1,
+                NodeInfo.of(2, "", -1),
+                0,
+                100,
+                false,
+                true,
+                false,
+                false,
+                false,
+                "/tmp/aa"),
+            Replica.of(
+                "test-1",
+                1,
+                NodeInfo.of(3, "", -1),
+                0,
+                100,
+                true,
+                true,
+                false,
+                false,
+                true,
+                "/tmp/aa"),
+            Replica.of(
+                "test-2",
+                0,
+                NodeInfo.of(1, "", -1),
+                0,
+                100,
+                false,
+                true,
+                false,
+                false,
+                false,
+                "/tmp/aa"),
+            Replica.of(
+                "test-2",
+                0,
+                NodeInfo.of(3, "", -1),
+                0,
+                100,
+                true,
+                true,
+                false,
+                false,
+                true,
+                "/tmp/aa")));
   }
 
   private static ClusterBean clusterBean() {

--- a/app/src/test/java/org/astraea/app/cost/ReplicaLeaderCostTest.java
+++ b/app/src/test/java/org/astraea/app/cost/ReplicaLeaderCostTest.java
@@ -35,9 +35,9 @@ public class ReplicaLeaderCostTest {
   void testNoMetrics() {
     var replicas =
         List.of(
-            ReplicaInfo.of("topic", 0, NodeInfo.of(10, "broker0", 1111), true, true, true),
-            ReplicaInfo.of("topic", 0, NodeInfo.of(10, "broker0", 1111), true, true, true),
-            ReplicaInfo.of("topic", 0, NodeInfo.of(11, "broker1", 1111), true, true, true));
+            ReplicaInfo.of("topic", 0, NodeInfo.of(10, "broker0", 1111), true, true, false),
+            ReplicaInfo.of("topic", 0, NodeInfo.of(10, "broker0", 1111), true, true, false),
+            ReplicaInfo.of("topic", 0, NodeInfo.of(11, "broker1", 1111), true, true, false));
     var clusterInfo = ClusterInfo.of(replicas);
     var cost = ReplicaLeaderCost.leaderCount(clusterInfo);
     Assertions.assertTrue(cost.containsKey(10));

--- a/app/src/test/java/org/astraea/app/cost/ReplicaLeaderCostTest.java
+++ b/app/src/test/java/org/astraea/app/cost/ReplicaLeaderCostTest.java
@@ -38,9 +38,7 @@ public class ReplicaLeaderCostTest {
             ReplicaInfo.of("topic", 0, NodeInfo.of(10, "broker0", 1111), true, true, true),
             ReplicaInfo.of("topic", 0, NodeInfo.of(10, "broker0", 1111), true, true, true),
             ReplicaInfo.of("topic", 0, NodeInfo.of(11, "broker1", 1111), true, true, true));
-    @SuppressWarnings("unchecked")
-    ClusterInfo<ReplicaInfo> clusterInfo = Mockito.mock(ClusterInfo.class);
-    Mockito.when(clusterInfo.replicaLeaders()).thenReturn(replicas);
+    var clusterInfo = ClusterInfo.of(replicas);
     var cost = ReplicaLeaderCost.leaderCount(clusterInfo);
     Assertions.assertTrue(cost.containsKey(10));
     Assertions.assertTrue(cost.containsKey(11));

--- a/app/src/test/java/org/astraea/app/partitioner/smooth/SmoothWeightRoundRobinDispatchTest.java
+++ b/app/src/test/java/org/astraea/app/partitioner/smooth/SmoothWeightRoundRobinDispatchTest.java
@@ -270,23 +270,18 @@ public class SmoothWeightRoundRobinDispatchTest extends RequireBrokerCluster {
   public void testGetAndChoose() {
     var topic = "test";
     var smoothWeight = new SmoothWeightRoundRobin(Map.of(1, 5.0, 2, 3.0, 3, 1.0));
-    var re1 = Mockito.mock(ReplicaInfo.class);
     var node1 = Mockito.mock(NodeInfo.class);
-    Mockito.when(re1.nodeInfo()).thenReturn(node1);
     Mockito.when(node1.id()).thenReturn(1);
+    var re1 = ReplicaInfo.of(topic, 0, node1, true, true, false);
 
-    var re2 = Mockito.mock(ReplicaInfo.class);
     var node2 = Mockito.mock(NodeInfo.class);
-    Mockito.when(re2.nodeInfo()).thenReturn(node2);
     Mockito.when(node2.id()).thenReturn(2);
+    var re2 = ReplicaInfo.of(topic, 1, node2, true, true, false);
 
-    var re3 = Mockito.mock(ReplicaInfo.class);
     var node3 = Mockito.mock(NodeInfo.class);
-    Mockito.when(re3.nodeInfo()).thenReturn(node3);
     Mockito.when(node3.id()).thenReturn(3);
-    var testCluster = Mockito.mock(ClusterInfo.class);
-    Mockito.when(testCluster.replicaLeaders(Mockito.anyString()))
-        .thenReturn(List.of(re1, re2, re3));
+    var re3 = ReplicaInfo.of(topic, 2, node3, true, true, false);
+    var testCluster = ClusterInfo.of(List.of(re1, re2, re3));
     Assertions.assertEquals(1, smoothWeight.getAndChoose(topic, testCluster));
     Assertions.assertEquals(2, smoothWeight.getAndChoose(topic, testCluster));
     Assertions.assertEquals(3, smoothWeight.getAndChoose(topic, testCluster));

--- a/app/src/test/java/org/astraea/app/partitioner/smooth/SmoothWeightRoundRobinTest.java
+++ b/app/src/test/java/org/astraea/app/partitioner/smooth/SmoothWeightRoundRobinTest.java
@@ -23,14 +23,13 @@ import org.astraea.app.admin.NodeInfo;
 import org.astraea.app.admin.ReplicaInfo;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 public class SmoothWeightRoundRobinTest {
   @Test
   void testGetAndChoose() {
     var topic = "test";
     var smoothWeight = new SmoothWeightRoundRobin(Map.of(1, 5.0, 2, 3.0, 3, 1.0));
-    var testCluster = mockResult();
+    var testCluster = clusterInfo();
 
     Assertions.assertEquals(1, smoothWeight.getAndChoose(topic, testCluster));
     Assertions.assertEquals(2, smoothWeight.getAndChoose(topic, testCluster));
@@ -45,7 +44,7 @@ public class SmoothWeightRoundRobinTest {
   void testPartOfBrokerGetAndChoose() {
     var topic = "test";
     var smoothWeight = new SmoothWeightRoundRobin(Map.of(1, 5.0, 2, 3.0, 3, 1.0, 4, 1.0));
-    var testCluster = mockResult();
+    var testCluster = clusterInfo();
 
     Assertions.assertEquals(1, smoothWeight.getAndChoose(topic, testCluster));
     Assertions.assertEquals(2, smoothWeight.getAndChoose(topic, testCluster));
@@ -56,24 +55,11 @@ public class SmoothWeightRoundRobinTest {
     Assertions.assertEquals(1, smoothWeight.getAndChoose(topic, testCluster));
   }
 
-  ClusterInfo mockResult() {
-    var re1 = Mockito.mock(ReplicaInfo.class);
-    var node1 = Mockito.mock(NodeInfo.class);
-    Mockito.when(re1.nodeInfo()).thenReturn(node1);
-    Mockito.when(node1.id()).thenReturn(1);
-
-    var re2 = Mockito.mock(ReplicaInfo.class);
-    var node2 = Mockito.mock(NodeInfo.class);
-    Mockito.when(re2.nodeInfo()).thenReturn(node2);
-    Mockito.when(node2.id()).thenReturn(2);
-
-    var re3 = Mockito.mock(ReplicaInfo.class);
-    var node3 = Mockito.mock(NodeInfo.class);
-    Mockito.when(re3.nodeInfo()).thenReturn(node3);
-    Mockito.when(node3.id()).thenReturn(3);
-    var clusterInfo = Mockito.mock(ClusterInfo.class);
-    Mockito.when(clusterInfo.replicaLeaders(Mockito.anyString()))
-        .thenReturn(List.of(re1, re2, re3));
-    return clusterInfo;
+  ClusterInfo<ReplicaInfo> clusterInfo() {
+    return ClusterInfo.of(
+        List.of(
+            ReplicaInfo.of("test", 1, NodeInfo.of(1, "host", 1111), true, true, false),
+            ReplicaInfo.of("test", 2, NodeInfo.of(2, "host", 1111), true, true, false),
+            ReplicaInfo.of("test", 3, NodeInfo.of(3, "host", 1111), true, true, false)));
   }
 }


### PR DESCRIPTION
現在`ClusterInfo`是個具有豐富介面但方便實作的類別，因此不再需要使用`mock`的方式