### PR TITLE
[Fix Flaky] Test no target when specify broker and topic

### DIFF
--- a/app/src/test/java/org/astraea/app/performance/PerformanceTest.java
+++ b/app/src/test/java/org/astraea/app/performance/PerformanceTest.java
@@ -276,6 +276,14 @@ public class PerformanceTest extends RequireBrokerCluster {
       var topicName3 = Utils.randomString(10);
       admin.creator().topic(topicName3).numberOfPartitions(1).create();
       Utils.sleep(Duration.ofSeconds(2));
+      var validBroker =
+          admin.replicas(Set.of(topicName3)).values().stream()
+              .findAny()
+              .get()
+              .get(0)
+              .nodeInfo()
+              .id();
+      var noPartitionBroker = (validBroker == 3) ? 1 : validBroker + 1;
       args =
           Argument.parse(
               new Performance.Argument(),
@@ -285,7 +293,7 @@ public class PerformanceTest extends RequireBrokerCluster {
                 "--topics",
                 topicName3,
                 "--specify.brokers",
-                "4"
+                Integer.toString(noPartitionBroker)
               });
       Assertions.assertThrows(IllegalArgumentException.class, args::topicPartitionSelector);
 


### PR DESCRIPTION
#687 
雖然 #690 已經有幫忙把測試做修改 (指定不存在的 broker ID，以測試 exception)，不過原來的想法是 "同時指定 broker ID 和 topic 導致 沒有合適的目標"，故仍予以修正。

測試的方式是，建立一個 1 partition 的 topic ，然後 **指定該 topic** 且 **指定 沒有 partition 的 broker ID**。這樣的話，雖然 topic 和 broker ID 都是合法的，但同時指定的話是沒有交集的。

原先測試會出錯是因為 在抓 `validBroker` 時沒有指定 topic ，導致先前建立的 topic 也混入其中。