### PR TITLE
implementation of `Scenario`

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,6 +32,7 @@ def versions = [
     slf4j: project.properties['slf4j.version'] ?: "1.7.36",
     gson: project.properties['gson.version'] ?: "2.9.0",
     "commons-io": project.properties['commons-io.version'] ?: "2.11.0",
+    "math3": project.properties['math3.version'] ?: "3.6.1",
 ]
 
 dependencies {
@@ -48,6 +49,7 @@ dependencies {
     // we don't use slf4j actually, and it is used by kafka so we swallow the log.
     implementation "org.slf4j:slf4j-nop:${versions["slf4j"]}"
     implementation "com.google.code.gson:gson:${versions["gson"]}"
+    implementation "org.apache.commons:commons-math3:${versions["math3"]}"
 }
 
 application {

--- a/app/src/main/java/org/astraea/app/App.java
+++ b/app/src/main/java/org/astraea/app/App.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.astraea.app.automation.Automation;
 import org.astraea.app.balancer.BalanceProcessDemo;
 import org.astraea.app.performance.Performance;
+import org.astraea.app.scenario.ScenarioMain;
 import org.astraea.app.web.WebService;
 
 public class App {
@@ -32,7 +33,8 @@ public class App {
           "performance", Performance.class,
           "automation", Automation.class,
           "web", WebService.class,
-          "balance-demo", BalanceProcessDemo.class);
+          "balance-demo", BalanceProcessDemo.class,
+          "scenario", ScenarioMain.class);
 
   static void execute(Map<String, Class<?>> mains, List<String> args) throws Throwable {
 

--- a/app/src/main/java/org/astraea/app/scenario/Scenario.java
+++ b/app/src/main/java/org/astraea/app/scenario/Scenario.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.app.scenario;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import org.astraea.common.Utils;
+import org.astraea.common.admin.Admin;
+
+/**
+ * The subclass of this class should contain the logic to fulfill a scenario.
+ *
+ * @param <T> the return result after applying this scenario to the specific Kafka cluster. This
+ *     result might be print on the program output. Or being serialized to json and transmit by web
+ *     API.
+ */
+public abstract class Scenario<T> {
+
+  /**
+   * This field is here for serialization purpose. It should be the class name of the concrete
+   * scenario implementation. The {@link Scenario.GeneralDeserializer} take advantage of this field
+   * to classify which scenario class it should deserialize to.
+   */
+  private final String scenarioName;
+
+  /** @param classPath the classpath to the concrete implementation of the scenario */
+  public Scenario(String classPath) {
+    this.scenarioName = classPath;
+  }
+
+  /** Apply this scenario to the Kafka cluster */
+  public abstract T apply(Admin admin);
+
+  public static class GeneralDeserializer implements JsonDeserializer<Scenario<?>> {
+
+    @Override
+    public Scenario<?> deserialize(
+        JsonElement json, Type typeOfT, JsonDeserializationContext context)
+        throws JsonParseException {
+      final var name = json.getAsJsonObject().get("scenarioName").getAsString();
+      final var theClass = Utils.packException(() -> Class.forName(name));
+      return context.deserialize(json, theClass);
+    }
+  }
+}

--- a/app/src/main/java/org/astraea/app/scenario/Scenario.java
+++ b/app/src/main/java/org/astraea/app/scenario/Scenario.java
@@ -27,24 +27,12 @@ import org.astraea.common.cost.Configuration;
  *     result might be print on the program output. Or being serialized to json and transmit by web
  *     API.
  */
-public abstract class Scenario<T> {
+public interface Scenario<T> {
 
-  /**
-   * This field is here for serialization purpose. It should be the class name of the concrete
-   * scenario implementation. Gson can take advantage of this field to classify which scenario class
-   * it should deserialize to.
-   */
-  private final String scenarioName;
-
-  /** @param classPath the classpath to the concrete implementation of the scenario */
-  public Scenario(String classPath) {
-    this.scenarioName = classPath;
-  }
-
-  public static Scenario<?> of(Class<Scenario<?>> theClass, Configuration configuration) {
+  static Scenario<?> of(Class<Scenario<?>> theClass, Configuration configuration) {
     return Utils.construct(theClass, configuration);
   }
 
   /** Apply this scenario to the Kafka cluster */
-  public abstract T apply(Admin admin);
+  T apply(Admin admin);
 }

--- a/app/src/main/java/org/astraea/app/scenario/ScenarioMain.java
+++ b/app/src/main/java/org/astraea/app/scenario/ScenarioMain.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.app.scenario;
+
+import com.beust.jcommander.Parameter;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.astraea.common.admin.Admin;
+import org.astraea.common.argument.Argument;
+
+public class ScenarioMain extends Argument {
+
+  @Parameter(
+      names = {"--scenario.file"},
+      description = "A JSON file that contains the scenario definition")
+  private Path scenarioFile;
+
+  private static final Gson gson =
+      new GsonBuilder()
+          .registerTypeAdapter(Scenario.class, new Scenario.GeneralDeserializer())
+          .setPrettyPrinting()
+          .create();
+
+  public void execute(Scenario<?> scenario) {
+    System.out.println("Accept scenario: " + scenario.getClass().getName());
+    try (Admin admin = Admin.of(bootstrapServers())) {
+      System.out.println(gson.toJson(scenario.apply(admin)));
+    }
+  }
+
+  Scenario<?> readScenario() {
+    try (var reader = Files.newBufferedReader(scenarioFile)) {
+      return gson.fromJson(reader, Scenario.class);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public static void main(String[] args) {
+    var main = Argument.parse(new ScenarioMain(), args);
+    main.execute(main.readScenario());
+  }
+}

--- a/app/src/main/java/org/astraea/app/scenario/impl/SkewedPartitionScenario.java
+++ b/app/src/main/java/org/astraea/app/scenario/impl/SkewedPartitionScenario.java
@@ -51,9 +51,9 @@ public class SkewedPartitionScenario extends Scenario<SkewedPartitionScenario.Re
   public SkewedPartitionScenario(Configuration configuration) {
     this(
         configuration.requireString("topicName"),
-        configuration.string("partitions").map(Integer::parseInt).orElse(10),
+        configuration.string("partitions").map(Integer::parseInt).orElseThrow(),
         configuration.string("replicas").map(Short::parseShort).orElse((short) 1),
-        configuration.string("binomialProbability").map(Double::parseDouble).orElse(0.5));
+        configuration.string("binomialProbability").map(Double::parseDouble).orElseThrow());
   }
 
   private SkewedPartitionScenario(

--- a/app/src/main/java/org/astraea/app/scenario/impl/SkewedPartitionScenario.java
+++ b/app/src/main/java/org/astraea/app/scenario/impl/SkewedPartitionScenario.java
@@ -37,7 +37,7 @@ import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.admin.TopicPartitionReplica;
 import org.astraea.common.cost.Configuration;
 
-public class SkewedPartitionScenario extends Scenario<SkewedPartitionScenario.Result> {
+public class SkewedPartitionScenario implements Scenario<SkewedPartitionScenario.Result> {
 
   final String topicName;
   final int partitions;
@@ -54,7 +54,6 @@ public class SkewedPartitionScenario extends Scenario<SkewedPartitionScenario.Re
 
   private SkewedPartitionScenario(
       String topicName, int partitions, short replicas, double binomialProbability) {
-    super(SkewedPartitionScenario.class.getName());
     this.topicName = topicName;
     this.partitions = partitions;
     this.replicas = replicas;

--- a/app/src/main/java/org/astraea/app/scenario/impl/SkewedPartitionScenario.java
+++ b/app/src/main/java/org/astraea/app/scenario/impl/SkewedPartitionScenario.java
@@ -35,6 +35,7 @@ import org.astraea.common.admin.Admin;
 import org.astraea.common.admin.ReplicaInfo;
 import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.admin.TopicPartitionReplica;
+import org.astraea.common.cost.Configuration;
 
 public class SkewedPartitionScenario extends Scenario<SkewedPartitionScenario.Result> {
 
@@ -43,7 +44,19 @@ public class SkewedPartitionScenario extends Scenario<SkewedPartitionScenario.Re
   final short replicas;
   final double binomialProbability;
 
-  public SkewedPartitionScenario(
+  public SkewedPartitionScenario() {
+    this(Utils.randomString(), 10, (short) 1, 0.5);
+  }
+
+  public SkewedPartitionScenario(Configuration configuration) {
+    this(
+        configuration.requireString("topicName"),
+        configuration.string("partitions").map(Integer::parseInt).orElse(10),
+        configuration.string("replicas").map(Short::parseShort).orElse((short) 1),
+        configuration.string("binomialProbability").map(Double::parseDouble).orElse(0.5));
+  }
+
+  private SkewedPartitionScenario(
       String topicName, int partitions, short replicas, double binomialProbability) {
     super(SkewedPartitionScenario.class.getName());
     this.topicName = topicName;

--- a/app/src/main/java/org/astraea/app/scenario/impl/SkewedPartitionScenario.java
+++ b/app/src/main/java/org/astraea/app/scenario/impl/SkewedPartitionScenario.java
@@ -44,16 +44,12 @@ public class SkewedPartitionScenario extends Scenario<SkewedPartitionScenario.Re
   final short replicas;
   final double binomialProbability;
 
-  public SkewedPartitionScenario() {
-    this(Utils.randomString(), 10, (short) 1, 0.5);
-  }
-
   public SkewedPartitionScenario(Configuration configuration) {
     this(
-        configuration.requireString("topicName"),
-        configuration.string("partitions").map(Integer::parseInt).orElseThrow(),
+        configuration.string("topicName").orElse(Utils.randomString()),
+        configuration.string("partitions").map(Integer::parseInt).orElse(10),
         configuration.string("replicas").map(Short::parseShort).orElse((short) 1),
-        configuration.string("binomialProbability").map(Double::parseDouble).orElseThrow());
+        configuration.string("binomialProbability").map(Double::parseDouble).orElse(0.5));
   }
 
   private SkewedPartitionScenario(

--- a/app/src/main/java/org/astraea/app/scenario/impl/SkewedPartitionScenario.java
+++ b/app/src/main/java/org/astraea/app/scenario/impl/SkewedPartitionScenario.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.app.scenario.impl;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.commons.math3.distribution.BinomialDistribution;
+import org.apache.commons.math3.distribution.EnumeratedDistribution;
+import org.apache.commons.math3.distribution.IntegerDistribution;
+import org.apache.commons.math3.util.Pair;
+import org.astraea.app.scenario.Scenario;
+import org.astraea.common.Utils;
+import org.astraea.common.admin.Admin;
+import org.astraea.common.admin.ReplicaInfo;
+import org.astraea.common.admin.TopicPartition;
+import org.astraea.common.admin.TopicPartitionReplica;
+
+public class SkewedPartitionScenario extends Scenario<SkewedPartitionScenario.Result> {
+
+  final String topicName;
+  final int partitions;
+  final short replicas;
+  final double binomialProbability;
+
+  public SkewedPartitionScenario(
+      String topicName, int partitions, short replicas, double binomialProbability) {
+    super(SkewedPartitionScenario.class.getName());
+    this.topicName = topicName;
+    this.partitions = partitions;
+    this.replicas = replicas;
+    this.binomialProbability = binomialProbability;
+  }
+
+  @Override
+  public Result apply(Admin admin) {
+    // retrieve online brokers
+    var brokers = admin.brokerIds().stream().sorted().collect(Collectors.toUnmodifiableList());
+
+    // create topic
+    admin
+        .creator()
+        .topic(topicName)
+        .numberOfPartitions(partitions)
+        .numberOfReplicas(replicas)
+        .create();
+    Utils.sleep(Duration.ofSeconds(1));
+
+    var topicPartitions =
+        IntStream.range(0, partitions)
+            .mapToObj(p -> TopicPartition.of(topicName, p))
+            .collect(Collectors.toUnmodifiableSet());
+
+    // randomize the replica list by a specific distribution
+    var distribution = new BinomialDistribution(brokers.size() - 1, binomialProbability);
+    topicPartitions.forEach(
+        tp ->
+            admin
+                .migrator()
+                .partition(tp.topic(), tp.partition())
+                .moveTo(sampledReplicaList(brokers, replicas, distribution)));
+    Utils.sleep(Duration.ofSeconds(1));
+
+    // elect leader
+    topicPartitions.forEach(admin::preferredLeaderElection);
+    Utils.sleep(Duration.ofSeconds(1));
+
+    return packResult(admin);
+  }
+
+  private Result packResult(Admin admin) {
+    var currentReplica = admin.replicas(Set.of(topicName));
+    var leaderSum =
+        currentReplica.values().stream()
+            .flatMap(Collection::stream)
+            .filter(ReplicaInfo::isLeader)
+            .map(ReplicaInfo::topicPartitionReplica)
+            .collect(Collectors.groupingBy(TopicPartitionReplica::brokerId, Collectors.counting()));
+    var logSum =
+        currentReplica.values().stream()
+            .flatMap(Collection::stream)
+            .map(ReplicaInfo::topicPartitionReplica)
+            .collect(Collectors.groupingBy(TopicPartitionReplica::brokerId, Collectors.counting()));
+    return new Result(topicName, partitions, replicas, binomialProbability, leaderSum, logSum);
+  }
+
+  /** Sample a random replica list from the given probability distribution. */
+  private List<Integer> sampledReplicaList(
+      List<Integer> brokerIds, int listSize, IntegerDistribution distribution) {
+    if (brokerIds.size() < listSize)
+      throw new IllegalStateException(
+          "Not enough live brokers to meet the desired replica list size");
+
+    var brokerProbability =
+        IntStream.range(0, brokerIds.size())
+            .mapToObj(index -> Pair.create(brokerIds.get(index), distribution.probability(index)))
+            .collect(Collectors.toList());
+
+    var result = new ArrayList<Integer>();
+    while (result.size() < listSize) {
+      if (brokerProbability.size() == 1) {
+        var remove = brokerProbability.remove(0);
+        result.add(remove.getKey());
+      } else {
+        var enumeratedDistribution = new EnumeratedDistribution<>(brokerProbability);
+        var broker = enumeratedDistribution.sample();
+        result.add(broker);
+        brokerProbability.removeIf(x -> Objects.equals(x.getKey(), broker));
+      }
+    }
+    return result;
+  }
+
+  public static class Result {
+
+    public final String topicName;
+    public final int partitions;
+    public final short replicas;
+    public final double binomialProbability;
+    public final Map<Integer, Long> leaderSum;
+    public final Map<Integer, Long> logSum;
+
+    public Result(
+        String topicName,
+        int partitions,
+        short replicas,
+        double binomialProbability,
+        Map<Integer, Long> leaderSum,
+        Map<Integer, Long> logSum) {
+      this.topicName = topicName;
+      this.partitions = partitions;
+      this.replicas = replicas;
+      this.binomialProbability = binomialProbability;
+      this.leaderSum = leaderSum;
+      this.logSum = logSum;
+    }
+  }
+}

--- a/app/src/main/java/org/astraea/app/scenario/impl/SkewedPartitionScenario.java
+++ b/app/src/main/java/org/astraea/app/scenario/impl/SkewedPartitionScenario.java
@@ -113,7 +113,7 @@ public class SkewedPartitionScenario implements Scenario<SkewedPartitionScenario
   }
 
   /** Sample a random replica list from the given probability distribution. */
-  private List<Integer> sampledReplicaList(
+  static List<Integer> sampledReplicaList(
       List<Integer> brokerIds, int listSize, IntegerDistribution distribution) {
     if (brokerIds.size() < listSize)
       throw new IllegalStateException(

--- a/app/src/test/java/org/astraea/app/scenario/impl/SkewedPartitionScenarioTest.java
+++ b/app/src/test/java/org/astraea/app/scenario/impl/SkewedPartitionScenarioTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.app.scenario.impl;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.math3.distribution.BinomialDistribution;
+import org.astraea.common.Utils;
+import org.astraea.common.admin.Admin;
+import org.astraea.common.cost.Configuration;
+import org.astraea.it.RequireBrokerCluster;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class SkewedPartitionScenarioTest extends RequireBrokerCluster {
+
+  @CsvSource(
+      value = {
+        // partitions, replicas
+        "           1,        1",
+        "           1,        2",
+        "           1,        3",
+        "           2,        1",
+        "           2,        2",
+        "           3,        2",
+        "           3,        3",
+        "           5,        3",
+        "          10,        3",
+        "         100,        1",
+        "         100,        2",
+        "         100,        3",
+      })
+  @ParameterizedTest
+  void test(int partitions, short replicas) {
+    var topicName = Utils.randomString();
+    var scenario =
+        new SkewedPartitionScenario(
+            Configuration.of(
+                Map.of(
+                    "topicName", topicName,
+                    "partitions", String.valueOf(partitions),
+                    "replicas", String.valueOf(replicas),
+                    "binomialProbability", String.valueOf(0.5))));
+    try (Admin admin = Admin.of(bootstrapServers())) {
+      var result = scenario.apply(admin);
+      Assertions.assertEquals(topicName, result.topicName);
+      Assertions.assertEquals(partitions, result.partitions);
+      Assertions.assertEquals(replicas, result.replicas);
+      Assertions.assertEquals(0.5, result.binomialProbability);
+      Assertions.assertEquals(
+          partitions, result.leaderSum.values().stream().mapToLong(x -> x).sum());
+      Assertions.assertEquals(
+          (long) partitions * replicas, result.logSum.values().stream().mapToLong(x -> x).sum());
+    }
+  }
+
+  @ValueSource(ints = {0, 1, 2, 3, 4, 5})
+  @ParameterizedTest
+  void testSampledReplicaList(int selection) {
+    for (int i = 0; i < 100; i++) {
+      var brokerIds = List.of(0, 1, 2, 3, 4, 5);
+      var distribution = new BinomialDistribution(brokerIds.size() - 1, 0.5);
+      var selections =
+          SkewedPartitionScenario.sampledReplicaList(brokerIds, selection, distribution);
+      Assertions.assertTrue(brokerIds.containsAll(selections), "Valid candidates");
+      Assertions.assertEquals(selection, Set.copyOf(selections).size(), "No duplicate items");
+    }
+  }
+}

--- a/common/src/main/java/org/astraea/common/Utils.java
+++ b/common/src/main/java/org/astraea/common/Utils.java
@@ -30,6 +30,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
+import org.astraea.common.cost.Configuration;
 
 public final class Utils {
 
@@ -78,6 +79,17 @@ public final class Utils {
       runner.run();
     } catch (Exception ex) {
       ex.printStackTrace();
+    }
+  }
+
+  public static <T> T construct(Class<T> target, Configuration configuration) {
+    try {
+      // case 0: create cost function by configuration
+      var constructor = target.getConstructor(Configuration.class);
+      return packException(() -> constructor.newInstance(configuration));
+    } catch (NoSuchMethodException e) {
+      // case 1: create cost function by empty constructor
+      return packException(() -> target.getConstructor().newInstance());
     }
   }
 

--- a/common/src/main/java/org/astraea/common/Utils.java
+++ b/common/src/main/java/org/astraea/common/Utils.java
@@ -84,11 +84,11 @@ public final class Utils {
 
   public static <T> T construct(Class<T> target, Configuration configuration) {
     try {
-      // case 0: create cost function by configuration
+      // case 0: create the class by the given configuration
       var constructor = target.getConstructor(Configuration.class);
       return packException(() -> constructor.newInstance(configuration));
     } catch (NoSuchMethodException e) {
-      // case 1: create cost function by empty constructor
+      // case 1: create the class by empty constructor
       return packException(() -> target.getConstructor().newInstance());
     }
   }

--- a/common/src/main/java/org/astraea/common/partitioner/StrictCostDispatcher.java
+++ b/common/src/main/java/org/astraea/common/partitioner/StrictCostDispatcher.java
@@ -270,23 +270,13 @@ public class StrictCostDispatcher implements Dispatcher {
         .filter(e -> HasBrokerCost.class.isAssignableFrom(e.getKey()))
         .collect(
             Collectors.toMap(
-                e -> construct((Class<HasBrokerCost>) e.getKey(), config), Map.Entry::getValue));
+                e -> Utils.construct((Class<HasBrokerCost>) e.getKey(), config),
+                Map.Entry::getValue));
   }
 
   @Override
   public void close() {
     receivers.values().forEach(r -> Utils.swallowException(r::close));
     receivers.clear();
-  }
-
-  static <T> T construct(Class<T> target, Configuration configuration) {
-    try {
-      // case 0: create cost function by configuration
-      var constructor = target.getConstructor(Configuration.class);
-      return Utils.packException(() -> constructor.newInstance(configuration));
-    } catch (NoSuchMethodException e) {
-      // case 1: create cost function by empty constructor
-      return Utils.packException(() -> target.getConstructor().newInstance());
-    }
   }
 }

--- a/common/src/test/java/org/astraea/common/UtilsTest.java
+++ b/common/src/test/java/org/astraea/common/UtilsTest.java
@@ -24,8 +24,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.astraea.common.cost.Configuration;
+import org.astraea.common.cost.CostFunction;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class UtilsTest {
 
@@ -121,5 +125,41 @@ public class UtilsTest {
     public int value() {
       return value;
     }
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {TestCostFunction.class, TestConfigCostFunction.class})
+  void testConstruct(Class<? extends CostFunction> aClass) {
+    // arrange
+    var config = Configuration.of(Map.of());
+
+    // act
+    var costFunction = Utils.construct(aClass, config);
+
+    // assert
+    Assertions.assertInstanceOf(CostFunction.class, costFunction);
+    Assertions.assertInstanceOf(aClass, costFunction);
+  }
+
+  @Test
+  void testConstructException() {
+    // arrange
+    var aClass = TestBadCostFunction.class;
+    var config = Configuration.of(Map.of());
+
+    // act, assert
+    Assertions.assertThrows(RuntimeException.class, () -> Utils.construct(aClass, config));
+  }
+
+  private static class TestConfigCostFunction implements CostFunction {
+    public TestConfigCostFunction(Configuration configuration) {}
+  }
+
+  private static class TestCostFunction implements CostFunction {
+    public TestCostFunction() {}
+  }
+
+  private static class TestBadCostFunction implements CostFunction {
+    public TestBadCostFunction(int value) {}
   }
 }

--- a/common/src/test/java/org/astraea/common/partitioner/StrictCostDispatcherTest.java
+++ b/common/src/test/java/org/astraea/common/partitioner/StrictCostDispatcherTest.java
@@ -32,7 +32,6 @@ import org.astraea.common.admin.ReplicaInfo;
 import org.astraea.common.cost.BrokerCost;
 import org.astraea.common.cost.BrokerInputCost;
 import org.astraea.common.cost.Configuration;
-import org.astraea.common.cost.CostFunction;
 import org.astraea.common.cost.HasBrokerCost;
 import org.astraea.common.cost.NodeThroughputCost;
 import org.astraea.common.cost.ReplicaLeaderCost;
@@ -40,8 +39,6 @@ import org.astraea.common.metrics.collector.Fetcher;
 import org.astraea.common.metrics.collector.Receiver;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 public class StrictCostDispatcherTest {
@@ -348,42 +345,5 @@ public class StrictCostDispatcherTest {
       Assertions.assertEquals(1, dispatcher.receivers.size());
       Assertions.assertEquals(1, receiverCount.get());
     }
-  }
-
-  @ParameterizedTest
-  @ValueSource(classes = {TestCostFunction.class, TestConfigCostFunction.class})
-  void testConstruct(Class<? extends CostFunction> aClass) {
-    // arrange
-    var config = Configuration.of(Map.of());
-
-    // act
-    var costFunction = StrictCostDispatcher.construct(aClass, config);
-
-    // assert
-    Assertions.assertInstanceOf(CostFunction.class, costFunction);
-    Assertions.assertInstanceOf(aClass, costFunction);
-  }
-
-  @Test
-  void testConstructException() {
-    // arrange
-    var aClass = TestBadCostFunction.class;
-    var config = Configuration.of(Map.of());
-
-    // act, assert
-    Assertions.assertThrows(
-        RuntimeException.class, () -> StrictCostDispatcher.construct(aClass, config));
-  }
-
-  private static class TestConfigCostFunction implements CostFunction {
-    public TestConfigCostFunction(Configuration configuration) {}
-  }
-
-  private static class TestCostFunction implements CostFunction {
-    public TestCostFunction() {}
-  }
-
-  private static class TestBadCostFunction implements CostFunction {
-    public TestBadCostFunction(int value) {}
   }
 }


### PR DESCRIPTION
resolve #684

這個 PR 實作一個 `Scenario` 界面，其描述一個 Kafka 使用情境的 log allocation 建立邏輯。

目前提供一個 `SkewedPartitionScenario`，其透過 Binomial Distribution 來決定每個 Partition 的 Replica List 長相。由於 Binomial Distribution 可以說是離散情境下的常態分佈，因此我們可以預期他所產生出來的 partition 分佈是集中在特定幾個節點的。我們可以透過這個特性來製造一些負載不平衡的情境。

## Demo

#### cmd

```
./gradlew run --args="scenario --bootstrap.servers 192.168.0.4:19128 --scenario.file /home/garyparrot/Ignore.txt"
```

#### scenario.file

```json
{
  "topicName": "b5f6871ed8864de69998052b77ef8021",
  "partitions": 100,
  "replicas": 1,
  "binomialProbability": 0.5,
  "scenarioName": "org.astraea.app.scenario.impl.SkewedPartitionScenario"
}
```

#### output

```
Accept scenario: org.astraea.app.scenario.impl.SkewedPartitionScenario
{
  "topicName": "b5f6871ed8864de69998052b77ef8021",
  "partitions": 100,
  "replicas": 1,
  "binomialProbability": 0.5,
  "leaderSum": {
    "1001": 27,
    "1002": 45,
    "1003": 28
  },
  "logSum": {
    "1001": 27,
    "1002": 45,
    "1003": 28
  }
}
```

leaderSum 指出每個節點有幾個 leader，從輸出可以看出 1002 承受比較多的 leader