### PR TITLE
fix no configuration constructor for SkewedPartitionScenario

### DIFF
--- a/app/src/main/java/org/astraea/app/scenario/SkewedPartitionScenario.java
+++ b/app/src/main/java/org/astraea/app/scenario/SkewedPartitionScenario.java
@@ -30,6 +30,7 @@ import org.apache.commons.math3.util.Pair;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.admin.TopicPartition;
+import org.astraea.common.cost.Configuration;
 
 public class SkewedPartitionScenario implements Scenario {
 
@@ -37,6 +38,14 @@ public class SkewedPartitionScenario implements Scenario {
   final int partitions;
   final short replicas;
   final double binomialProbability;
+
+  public SkewedPartitionScenario(Configuration configuration) {
+    this(
+        configuration.string("topicName").orElse(Utils.randomString()),
+        configuration.string("partitions").map(Integer::parseInt).orElse(10),
+        configuration.string("replicas").map(Short::parseShort).orElse((short) 1),
+        configuration.string("binomialProbability").map(Double::parseDouble).orElse(0.5));
+  }
 
   SkewedPartitionScenario(
       String topicName, int partitions, short replicas, double binomialProbability) {

--- a/app/src/test/java/org/astraea/app/scenario/SkewedPartitionScenarioTest.java
+++ b/app/src/test/java/org/astraea/app/scenario/SkewedPartitionScenarioTest.java
@@ -17,17 +17,26 @@
 package org.astraea.app.scenario;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.commons.math3.distribution.BinomialDistribution;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
+import org.astraea.common.cost.Configuration;
 import org.astraea.it.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class SkewedPartitionScenarioTest extends RequireBrokerCluster {
+
+  @Test
+  void testConstruct() {
+    var c = Utils.construct(SkewedPartitionScenario.class, Configuration.of(Map.of()));
+    Assertions.assertInstanceOf(SkewedPartitionScenario.class, c);
+  }
 
   @CsvSource(
       value = {


### PR DESCRIPTION
執行 scenario 時發生錯誤，因為找不到 `Configuration` 的 constructor。一開始這個 configuration 是存在的，不過好像有次被刪除了。

```
./gradlew run --args="scenario --bootstrap.servers 192.168.103.177:25655,192.168.103.178:25655,192.168.103.179:25655,192.168.103.180:25655,192.168.103.181:25655 --scenario.class org.astraea.app.scenario.SkewedPar
titionScenario"
```

```
> Task :app:run FAILED
Exception in thread "main" java.lang.RuntimeException: java.lang.NoSuchMethodException: org.astraea.app.scenario.SkewedPartitionScenario.<init>()
        at org.astraea.common.Utils.packException(Utils.java:54)
        at org.astraea.common.Utils.construct(Utils.java:92)
        at org.astraea.app.scenario.ScenarioMain.execute(ScenarioMain.java:41)
        at org.astraea.app.scenario.ScenarioMain.main(ScenarioMain.java:55)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.astraea.app.App.execute(App.java:65)
        at org.astraea.app.App.main(App.java:77)
Caused by: java.lang.NoSuchMethodException: org.astraea.app.scenario.SkewedPartitionScenario.<init>()
        at java.base/java.lang.Class.getConstructor0(Class.java:3349)
        at java.base/java.lang.Class.getConstructor(Class.java:2151)
        at org.astraea.common.Utils.lambda$construct$2(Utils.java:92)
        at org.astraea.common.Utils.packException(Utils.java:48)
        ... 9 more
```