### PR TITLE
Fix flaky BalancerHandlerTest#testReport

### DIFF
--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -46,12 +46,14 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
 
   @Test
   void testReport() {
+    var topicNames = createAndProduceTopic(1);
     try (var admin = Admin.of(bootstrapServers())) {
       var handler = new BalancerHandler(admin, new DegradeCost(), new ReplicaSizeCost());
       var report =
           Assertions.assertInstanceOf(
               BalancerHandler.Report.class,
-              handler.get(Channel.ofQueries(Map.of(BalancerHandler.LIMIT_KEY, "3000"))));
+              handler.get(Channel.ofQueries(Map.of(BalancerHandler.LIMIT_KEY, "3000",
+                      BalancerHandler.TOPICS_KEY, topicNames.get(0)))));
       Assertions.assertEquals(3000, report.limit);
       Assertions.assertNotEquals(0, report.changes.size());
       Assertions.assertTrue(report.cost >= report.newCost);

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -46,19 +46,13 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
 
   @Test
   void testReport() {
-    var topicNames = createAndProduceTopic(1);
+    createAndProduceTopic(3);
     try (var admin = Admin.of(bootstrapServers())) {
       var handler = new BalancerHandler(admin, new DegradeCost(), new ReplicaSizeCost());
       var report =
           Assertions.assertInstanceOf(
               BalancerHandler.Report.class,
-              handler.get(
-                  Channel.ofQueries(
-                      Map.of(
-                          BalancerHandler.LIMIT_KEY,
-                          "3000",
-                          BalancerHandler.TOPICS_KEY,
-                          topicNames.get(0)))));
+              handler.get(Channel.ofQueries(Map.of(BalancerHandler.LIMIT_KEY, "3000"))));
       Assertions.assertEquals(3000, report.limit);
       Assertions.assertNotEquals(0, report.changes.size());
       Assertions.assertTrue(report.cost >= report.newCost);

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -52,8 +52,13 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
       var report =
           Assertions.assertInstanceOf(
               BalancerHandler.Report.class,
-              handler.get(Channel.ofQueries(Map.of(BalancerHandler.LIMIT_KEY, "3000",
-                      BalancerHandler.TOPICS_KEY, topicNames.get(0)))));
+              handler.get(
+                  Channel.ofQueries(
+                      Map.of(
+                          BalancerHandler.LIMIT_KEY,
+                          "3000",
+                          BalancerHandler.TOPICS_KEY,
+                          topicNames.get(0)))));
       Assertions.assertEquals(3000, report.limit);
       Assertions.assertNotEquals(0, report.changes.size());
       Assertions.assertTrue(report.cost >= report.newCost);


### PR DESCRIPTION
#653 
BalancerHandler.get() 因為 queries 缺少 topics，導致 targetAllocations 的 size ＝ 0。