### PR TITLE
Revise `ClusterLogAllocation#findNonFulfilledAllocation`

### DIFF
--- a/app/src/main/java/org/astraea/app/balancer/log/ClusterLogAllocation.java
+++ b/app/src/main/java/org/astraea/app/balancer/log/ClusterLogAllocation.java
@@ -117,12 +117,17 @@ public interface ClusterLogAllocation {
 
     final var sourceTopicPartition = source.topicPartitions();
     final var targetTopicPartition = target.topicPartitions();
+    final var unknownTopicPartitions =
+        targetTopicPartition.stream()
+            .filter(tp -> !sourceTopicPartition.contains(tp))
+            .collect(Collectors.toUnmodifiableSet());
 
-    if (!sourceTopicPartition.equals(targetTopicPartition))
+    if (!unknownTopicPartitions.isEmpty())
       throw new IllegalArgumentException(
-          "source allocation and target allocation has different topic/partition set");
+          "target topic/partition should be a subset of source topic/partition: "
+              + unknownTopicPartitions);
 
-    return sourceTopicPartition.stream()
+    return targetTopicPartition.stream()
         .filter(tp -> !LogPlacement.isMatch(source.logPlacements(tp), target.logPlacements(tp)))
         .collect(Collectors.toUnmodifiableSet());
   }

--- a/app/src/test/java/org/astraea/app/balancer/log/ClusterLogAllocationTest.java
+++ b/app/src/test/java/org/astraea/app/balancer/log/ClusterLogAllocationTest.java
@@ -198,5 +198,17 @@ class ClusterLogAllocationTest {
     Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> ClusterLogAllocation.findNonFulfilledAllocation(source, target4));
+
+    final var allocation0 =
+        ClusterLogAllocation.of(
+            Map.of(
+                TopicPartition.of("topicA", 0), List.of(LogPlacement.of(0, "no-change")),
+                TopicPartition.of("topicB", 0), List.of(LogPlacement.of(0, "no-change"))));
+    final var allocation1 =
+        ClusterLogAllocation.of(
+            Map.of(TopicPartition.of("topicB", 0), List.of(LogPlacement.of(0, "do-change"))));
+    Assertions.assertEquals(
+        Set.of(TopicPartition.of("topicB", 0)),
+        ClusterLogAllocation.findNonFulfilledAllocation(allocation0, allocation1));
   }
 }


### PR DESCRIPTION
原先的 `ClusterLogAllocation#findNonFulfilledAllocation` 假設輸入的兩個 allocation 有着相同的 topic/partition set。

由於現在 Generator 產生的計劃可能是基於叢集的子集合，現在需要修正這個規則。

* 原本：source 和 target 必須要有相同的 topic/partition set。
* 現在：target topic/partitions 必須是 source 的 topic/partitions 的 subset。

目前沒有修正的版本會在有套 topic filter 時發生錯誤。