### PR TITLE
Fix flaky testCreateTopics

### DIFF
--- a/app/src/test/java/org/astraea/app/web/TopicHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/TopicHandlerTest.java
@@ -134,10 +134,13 @@ public class TopicHandlerTest extends RequireBrokerCluster {
                       topicName0, topicName1)));
       var topics = handler.post(request);
       Assertions.assertEquals(2, topics.topics.size());
-      var t0 = topics.topics.stream().filter(t -> t.name.equals(topicName0)).findFirst().get();
-      Assertions.assertEquals(1, t0.partitions.size());
-      var t1 = topics.topics.stream().filter(t -> t.name.equals(topicName1)).findFirst().get();
-      Assertions.assertEquals(2, t1.partitions.size());
+      // the topic creation is not synced, so we have to wait the creation.
+      Utils.sleep(Duration.ofSeconds(2));
+      var actualTopPartitions = admin.offsets(Set.of(topicName0, topicName1)).keySet();
+      Assertions.assertEquals(
+          1, actualTopPartitions.stream().filter(tp -> tp.topic().equals(topicName0)).count());
+      Assertions.assertEquals(
+          2, actualTopPartitions.stream().filter(tp -> tp.topic().equals(topicName1)).count());
     }
   }
 


### PR DESCRIPTION
resolve https://github.com/skiptests/astraea/issues/722

類似的解法已經有在 testCreateTopicWithReplicas 提供
https://github.com/skiptests/astraea/blob/7596f590ae0f0ec370a6e257c10cc2aeb5fb5bf4/app/src/test/java/org/astraea/app/web/TopicHandlerTest.java#L244-L254