### PR TITLE
Revise `ClusterLogAllocation`

### DIFF
--- a/app/src/main/java/org/astraea/app/balancer/BalancerUtils.java
+++ b/app/src/main/java/org/astraea/app/balancer/BalancerUtils.java
@@ -68,7 +68,7 @@ public class BalancerUtils {
                             return Replica.of(
                                 previous.topic(),
                                 previous.partition(),
-                                clusterInfo.node(lp.broker()),
+                                clusterInfo.node(lp.nodeInfo().id()),
                                 previous.lag(),
                                 previous.size(),
                                 index == 0,
@@ -119,7 +119,7 @@ public class BalancerUtils {
                                 Replica.of(
                                     tp.topic(),
                                     tp.partition(),
-                                    nodeIdMap.get(logs.get(i).broker()),
+                                    nodeIdMap.get(logs.get(i).nodeInfo().id()),
                                     0,
                                     -1,
                                     i == 0,

--- a/app/src/main/java/org/astraea/app/balancer/executor/StraightPlanExecutor.java
+++ b/app/src/main/java/org/astraea/app/balancer/executor/StraightPlanExecutor.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.astraea.app.balancer.log.ClusterLogAllocation;
+import org.astraea.app.balancer.log.LogPlacement;
 import org.astraea.common.admin.TopicPartition;
 
 /** Execute every possible migration immediately. */
@@ -40,7 +41,12 @@ public class StraightPlanExecutor implements RebalancePlanExecutor {
         (Function<TopicPartition, List<ReplicaMigrationTask>>)
             (topicPartition) ->
                 rebalanceAdmin.alterReplicaPlacements(
-                    topicPartition, logAllocation.logPlacements(topicPartition));
+                    topicPartition,
+                    logAllocation.logPlacements(topicPartition).stream()
+                        .map(
+                            replica ->
+                                LogPlacement.of(replica.nodeInfo().id(), replica.dataFolder()))
+                        .collect(Collectors.toUnmodifiableList()));
 
     // do log migration
     migrationTargets.stream()

--- a/app/src/main/java/org/astraea/app/balancer/log/ClusterLogAllocation.java
+++ b/app/src/main/java/org/astraea/app/balancer/log/ClusterLogAllocation.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.Replica;
 import org.astraea.common.admin.ReplicaInfo;
 import org.astraea.common.admin.TopicPartition;
@@ -61,39 +62,33 @@ public interface ClusterLogAllocation {
                     })));
   }
 
-  static ClusterLogAllocation of(Map<TopicPartition, List<LogPlacement>> allocation) {
+  static ClusterLogAllocation of(Map<TopicPartition, List<Replica>> allocation) {
     return new ClusterLogAllocationImpl(allocation);
   }
   /**
    * let specific broker leave the replica set and let another broker join the replica set. Which
    * data directory the migrated replica will be is up to the Kafka broker implementation to decide.
    *
-   * @param topicPartition the topic/partition to perform replica migration
-   * @param atBroker the id of the broker about to remove
+   * @param replica the replica to perform replica migration
    * @param toBroker the id of the broker about to replace the removed broker
    */
-  default ClusterLogAllocation migrateReplica(
-      TopicPartition topicPartition, int atBroker, int toBroker) {
-    return migrateReplica(topicPartition, atBroker, toBroker, null);
+  default ClusterLogAllocation migrateReplica(Replica replica, int toBroker) {
+    return migrateReplica(replica, toBroker, null);
   }
-  // TODO: Revise the log argument by TopicPartitionReplica, once #411 is merged
 
   /**
    * let specific broker leave the replica set and let another broker join the replica set.
    *
-   * @param topicPartition the topic/partition to perform replica migration
-   * @param atBroker the id of the broker about to remove
+   * @param replica the replica to perform replica migration
    * @param toBroker the id of the broker about to replace the removed broker
    * @param toDir the absolute path of the data directory this migrated replica is supposed to be on
    *     the destination broker, if {@code null} is specified then the data directory choice is left
    *     up to the Kafka broker implementation.
    */
-  ClusterLogAllocation migrateReplica(
-      TopicPartition topicPartition, int atBroker, int toBroker, String toDir);
-  // TODO: Revise the log argument by TopicPartitionReplica, once #411 is merged
+  ClusterLogAllocation migrateReplica(Replica replica, int toBroker, String toDir);
 
   /** let specific follower log become the leader log of this topic/partition. */
-  ClusterLogAllocation letReplicaBecomeLeader(TopicPartition topicPartition, int followerReplica);
+  ClusterLogAllocation letReplicaBecomeLeader(Replica replica);
 
   /**
    * Retrieve the log placements of specific {@link TopicPartition}.
@@ -101,7 +96,11 @@ public interface ClusterLogAllocation {
    * @param topicPartition to query
    * @return log placements or empty collection if there is no log placements
    */
-  List<LogPlacement> logPlacements(TopicPartition topicPartition);
+  List<Replica> logPlacements(TopicPartition topicPartition);
+
+  default List<Replica> logPlacements(Replica replica) {
+    return logPlacements(replica.topicPartition());
+  }
 
   /** Retrieve the stream of all topic/partition pairs in allocation. */
   Set<TopicPartition> topicPartitions();
@@ -128,8 +127,21 @@ public interface ClusterLogAllocation {
               + unknownTopicPartitions);
 
     return targetTopicPartition.stream()
-        .filter(tp -> !LogPlacement.isMatch(source.logPlacements(tp), target.logPlacements(tp)))
+        .filter(tp -> !replicaListEqual(source.logPlacements(tp), target.logPlacements(tp)))
         .collect(Collectors.toUnmodifiableSet());
+  }
+
+  static boolean replicaListEqual(List<Replica> sourceReplicas, List<Replica> targetReplicas) {
+    if (sourceReplicas.size() != targetReplicas.size()) return false;
+    return IntStream.range(0, sourceReplicas.size())
+        .allMatch(
+            index ->
+                sourceReplicas.get(index).nodeInfo().id()
+                        == targetReplicas.get(index).nodeInfo().id()
+                    && sourceReplicas
+                        .get(index)
+                        .dataFolder()
+                        .equals(targetReplicas.get(index).dataFolder()));
   }
 
   static String toString(ClusterLogAllocation allocation) {
@@ -146,7 +158,7 @@ public interface ClusterLogAllocation {
                   .forEach(
                       log ->
                           stringBuilder.append(
-                              String.format("(%s, %s) ", log.broker(), log.dataFolder())));
+                              String.format("(%s, %s) ", log.nodeInfo().id(), log.dataFolder())));
 
               stringBuilder.append(System.lineSeparator());
             });
@@ -156,9 +168,9 @@ public interface ClusterLogAllocation {
 
   class ClusterLogAllocationImpl implements ClusterLogAllocation {
 
-    private final Map<TopicPartition, List<LogPlacement>> allocation;
+    private final Map<TopicPartition, List<Replica>> allocation;
 
-    private ClusterLogAllocationImpl(Map<TopicPartition, List<LogPlacement>> allocation) {
+    private ClusterLogAllocationImpl(Map<TopicPartition, List<Replica>> allocation) {
       this.allocation = Collections.unmodifiableMap(allocation);
 
       this.allocation.keySet().stream()
@@ -174,7 +186,8 @@ public interface ClusterLogAllocation {
 
       this.allocation.forEach(
           (tp, logs) -> {
-            long uniqueBrokers = logs.stream().map(LogPlacement::broker).distinct().count();
+            long uniqueBrokers =
+                logs.stream().map(ReplicaInfo::nodeInfo).mapToInt(NodeInfo::id).distinct().count();
             if (uniqueBrokers != logs.size() || logs.size() == 0)
               throw new IllegalArgumentException(
                   "The topic "
@@ -187,53 +200,55 @@ public interface ClusterLogAllocation {
     }
 
     @Override
-    public ClusterLogAllocation migrateReplica(
-        TopicPartition topicPartition, int atBroker, int toBroker, String toDir) {
-      var sourceLogPlacements = this.logPlacements(topicPartition);
+    public ClusterLogAllocation migrateReplica(Replica replica, int toBroker, String toDir) {
+      var sourceLogPlacements = this.logPlacements(replica);
       if (sourceLogPlacements.isEmpty())
         throw new IllegalMigrationException(
-            topicPartition.topic() + "-" + topicPartition.partition() + " no such topic/partition");
+            replica.topic() + "-" + replica.partition() + " no such topic/partition");
 
-      int sourceLogIndex = indexOfBroker(sourceLogPlacements, atBroker).orElse(-1);
+      int sourceLogIndex = indexOfBroker(sourceLogPlacements, replica.nodeInfo().id()).orElse(-1);
       if (sourceLogIndex == -1)
         throw new IllegalMigrationException(
-            atBroker + " is not part of the replica set for " + topicPartition);
+            replica.nodeInfo().id()
+                + " is not part of the replica set for "
+                + replica.topicPartition());
 
       var newAllocations = new HashMap<>(allocation);
       newAllocations.put(
-          topicPartition,
+          replica.topicPartition(),
           IntStream.range(0, sourceLogPlacements.size())
               .mapToObj(
                   index ->
                       index == sourceLogIndex
-                          ? LogPlacement.of(toBroker, toDir)
+                          ? update(replica, toBroker, toDir)
                           : sourceLogPlacements.get(index))
               .collect(Collectors.toUnmodifiableList()));
       return new ClusterLogAllocationImpl(newAllocations);
     }
 
     @Override
-    public ClusterLogAllocation letReplicaBecomeLeader(
-        TopicPartition topicPartition, int followerReplica) {
-      final List<LogPlacement> sourceLogPlacements = this.logPlacements(topicPartition);
+    public ClusterLogAllocation letReplicaBecomeLeader(Replica replica) {
+      final var sourceLogPlacements = this.logPlacements(replica);
       if (sourceLogPlacements.isEmpty())
         throw new IllegalMigrationException(
-            topicPartition.topic() + "-" + topicPartition.partition() + " no such topic/partition");
+            replica.topic() + "-" + replica.partition() + " no such topic/partition");
 
       int leaderLogIndex = 0;
-      int followerLogIndex = indexOfBroker(sourceLogPlacements, followerReplica).orElse(-1);
+      int followerLogIndex = indexOfBroker(sourceLogPlacements, replica.nodeInfo().id()).orElse(-1);
       if (followerLogIndex == -1)
         throw new IllegalArgumentException(
-            followerReplica + " is not part of the replica set for " + topicPartition);
+            replica.nodeInfo().id()
+                + " is not part of the replica set for "
+                + replica.topicPartition());
 
       if (leaderLogIndex == followerLogIndex) return this; // nothing to do
 
-      final var leaderLog = this.logPlacements(topicPartition).get(leaderLogIndex);
-      final var followerLog = this.logPlacements(topicPartition).get(followerLogIndex);
+      final var leaderLog = this.logPlacements(replica).get(leaderLogIndex);
+      final var followerLog = this.logPlacements(replica).get(followerLogIndex);
 
       var newAllocations = new HashMap<>(allocation);
       newAllocations.put(
-          topicPartition,
+          replica.topicPartition(),
           IntStream.range(0, sourceLogPlacements.size())
               .mapToObj(
                   index ->
@@ -246,7 +261,7 @@ public interface ClusterLogAllocation {
     }
 
     @Override
-    public List<LogPlacement> logPlacements(TopicPartition topicPartition) {
+    public List<Replica> logPlacements(TopicPartition topicPartition) {
       return allocation.getOrDefault(topicPartition, List.of());
     }
 
@@ -255,10 +270,25 @@ public interface ClusterLogAllocation {
       return allocation.keySet();
     }
 
-    private static OptionalInt indexOfBroker(List<LogPlacement> logPlacements, int targetBroker) {
+    private static OptionalInt indexOfBroker(List<Replica> logPlacements, int targetBroker) {
       return IntStream.range(0, logPlacements.size())
-          .filter(index -> logPlacements.get(index).broker() == targetBroker)
+          .filter(index -> logPlacements.get(index).nodeInfo().id() == targetBroker)
           .findFirst();
+    }
+
+    private static Replica update(Replica source, int newBroker, String newDir) {
+      return Replica.of(
+          source.topic(),
+          source.partition(),
+          NodeInfo.of(newBroker, null, -1),
+          source.lag(),
+          source.size(),
+          source.isLeader(),
+          source.inSync(),
+          source.isFuture(),
+          source.isOffline(),
+          source.isPreferredLeader(),
+          newDir);
     }
   }
 }

--- a/app/src/main/java/org/astraea/app/balancer/log/ClusterLogAllocation.java
+++ b/app/src/main/java/org/astraea/app/balancer/log/ClusterLogAllocation.java
@@ -55,9 +55,6 @@ public interface ClusterLogAllocation {
                             "The " + entry.getKey() + " leader count mismatch 1.");
                       return entry.getValue().stream()
                           .sorted(Comparator.comparingInt(replica -> replica.isLeader() ? 0 : 1))
-                          .map(
-                              replica ->
-                                  LogPlacement.of(replica.nodeInfo().id(), replica.dataFolder()))
                           .collect(Collectors.toList());
                     })));
   }
@@ -275,20 +272,20 @@ public interface ClusterLogAllocation {
           .filter(index -> logPlacements.get(index).nodeInfo().id() == targetBroker)
           .findFirst();
     }
+  }
 
-    private static Replica update(Replica source, int newBroker, String newDir) {
-      return Replica.of(
-          source.topic(),
-          source.partition(),
-          NodeInfo.of(newBroker, null, -1),
-          source.lag(),
-          source.size(),
-          source.isLeader(),
-          source.inSync(),
-          source.isFuture(),
-          source.isOffline(),
-          source.isPreferredLeader(),
-          newDir);
-    }
+  static Replica update(Replica source, int newBroker, String newDir) {
+    return Replica.of(
+        source.topic(),
+        source.partition(),
+        NodeInfo.of(newBroker, "", -1),
+        source.lag(),
+        source.size(),
+        source.isLeader(),
+        source.inSync(),
+        source.isFuture(),
+        source.isOffline(),
+        source.isPreferredLeader(),
+        newDir);
   }
 }

--- a/app/src/test/java/org/astraea/app/balancer/BalancerUtilsIntegratedTest.java
+++ b/app/src/test/java/org/astraea/app/balancer/BalancerUtilsIntegratedTest.java
@@ -22,9 +22,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.IntStream;
 import org.astraea.app.balancer.log.ClusterLogAllocation;
-import org.astraea.app.balancer.log.LogPlacement;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
+import org.astraea.common.admin.NodeInfo;
+import org.astraea.common.admin.Replica;
 import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.producer.Producer;
 import org.astraea.it.RequireBrokerCluster;
@@ -59,7 +60,19 @@ public class BalancerUtilsIntegratedTest extends RequireBrokerCluster {
                   Map.of(
                       TopicPartition.of(topicName, 0),
                       // change the broker
-                      List.of(LogPlacement.of(newBrokerId, replica.dataFolder())))));
+                      List.of(
+                          Replica.of(
+                              topicName,
+                              0,
+                              NodeInfo.of(newBrokerId, null, -1),
+                              0,
+                              0,
+                              true,
+                              true,
+                              false,
+                              false,
+                              true,
+                              replica.dataFolder())))));
 
       Assertions.assertEquals(clusterInfo.replicas().size(), merged.replicas().size());
       Assertions.assertEquals(clusterInfo.topics().size(), merged.topics().size());

--- a/app/src/test/java/org/astraea/app/balancer/BalancerUtilsTest.java
+++ b/app/src/test/java/org/astraea/app/balancer/BalancerUtilsTest.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import org.astraea.app.balancer.log.ClusterLogAllocation;
-import org.astraea.app.balancer.log.LogPlacement;
 import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.Replica;
@@ -64,8 +63,58 @@ class BalancerUtilsTest {
   void testMockClusterInfoAllocation() {
     var tp1 = TopicPartition.of("testMockCluster", 1);
     var tp2 = TopicPartition.of("testMockCluster", 0);
-    var logPlacement1 = List.of(LogPlacement.of(0, "/data"), LogPlacement.of(1, "/data"));
-    var logPlacement2 = List.of(LogPlacement.of(1, "/data1"), LogPlacement.of(2, "/data1"));
+    var logPlacement1 =
+        List.of(
+            Replica.of(
+                tp1.topic(),
+                tp1.partition(),
+                NodeInfo.of(0, null, -1),
+                0,
+                0,
+                true,
+                true,
+                false,
+                false,
+                false,
+                "/data"),
+            Replica.of(
+                tp1.topic(),
+                tp1.partition(),
+                NodeInfo.of(1, null, -1),
+                0,
+                0,
+                true,
+                true,
+                false,
+                false,
+                false,
+                "/data"));
+    var logPlacement2 =
+        List.of(
+            Replica.of(
+                tp1.topic(),
+                tp1.partition(),
+                NodeInfo.of(1, null, -1),
+                0,
+                0,
+                true,
+                true,
+                false,
+                false,
+                false,
+                "/data1"),
+            Replica.of(
+                tp1.topic(),
+                tp1.partition(),
+                NodeInfo.of(2, null, -1),
+                0,
+                0,
+                true,
+                true,
+                false,
+                false,
+                false,
+                "/data1"));
     var clusterInfo =
         ClusterInfo.of(
             List.of(

--- a/app/src/test/java/org/astraea/app/web/TopicHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/TopicHandlerTest.java
@@ -134,10 +134,13 @@ public class TopicHandlerTest extends RequireBrokerCluster {
                       topicName0, topicName1)));
       var topics = handler.post(request);
       Assertions.assertEquals(2, topics.topics.size());
-      var t0 = topics.topics.stream().filter(t -> t.name.equals(topicName0)).findFirst().get();
-      Assertions.assertEquals(1, t0.partitions.size());
-      var t1 = topics.topics.stream().filter(t -> t.name.equals(topicName1)).findFirst().get();
-      Assertions.assertEquals(2, t1.partitions.size());
+      // the topic creation is not synced, so we have to wait the creation.
+      Utils.sleep(Duration.ofSeconds(2));
+      var actualTopPartitions = admin.offsets(Set.of(topicName0, topicName1)).keySet();
+      Assertions.assertEquals(
+          1, actualTopPartitions.stream().filter(tp -> tp.topic().equals(topicName0)).count());
+      Assertions.assertEquals(
+          2, actualTopPartitions.stream().filter(tp -> tp.topic().equals(topicName1)).count());
     }
   }
 


### PR DESCRIPTION
resolve #433 

這個 PR 在修正 `ClusterLogAllocation`，讓大多的 method signatures 使用 `Replica` 來指定要操作的對象