### PR TITLE
Remove ConsumerGroup#activeMembers

### DIFF
--- a/app/src/main/java/org/astraea/app/web/GroupHandler.java
+++ b/app/src/main/java/org/astraea/app/web/GroupHandler.java
@@ -56,7 +56,7 @@ public class GroupHandler implements Handler {
     if (shouldDeleteInstance) {
       var groupInstanceId = channel.queries().get(INSTANCE_KEY);
       var instanceExisted =
-          admin.consumerGroups(Set.of(groupId)).get(groupId).activeMembers().stream()
+          admin.consumerGroups(Set.of(groupId)).get(groupId).assignment().keySet().stream()
               .anyMatch(x -> x.groupInstanceId().filter(groupInstanceId::equals).isPresent());
       if (instanceExisted) admin.removeStaticMembers(groupId, Set.of(groupInstanceId));
     } else {

--- a/app/src/test/java/org/astraea/app/web/GroupHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/GroupHandlerTest.java
@@ -166,7 +166,7 @@ public class GroupHandlerTest extends RequireBrokerCluster {
             admin
                 .consumerGroups(Set.of(consumer.groupId()))
                 .get(consumer.groupId())
-                .activeMembers()
+                .assignment()
                 .size());
 
         handler.delete(Channel.ofTarget(consumer.groupId()));
@@ -175,7 +175,7 @@ public class GroupHandlerTest extends RequireBrokerCluster {
             admin
                 .consumerGroups(Set.of(consumer.groupId()))
                 .get(consumer.groupId())
-                .activeMembers()
+                .assignment()
                 .size());
 
         // idempotent test
@@ -194,7 +194,7 @@ public class GroupHandlerTest extends RequireBrokerCluster {
             admin
                 .consumerGroups(Set.of(consumer.groupId()))
                 .get(consumer.groupId())
-                .activeMembers()
+                .assignment()
                 .size());
 
         handler.delete(
@@ -206,7 +206,7 @@ public class GroupHandlerTest extends RequireBrokerCluster {
             admin
                 .consumerGroups(Set.of(consumer.groupId()))
                 .get(consumer.groupId())
-                .activeMembers()
+                .assignment()
                 .size());
 
         // idempotent test
@@ -253,7 +253,7 @@ public class GroupHandlerTest extends RequireBrokerCluster {
       Assertions.assertFalse(admin.consumerGroupIds().contains(groupIds.get(2)));
 
       var group1Members =
-          admin.consumerGroups(Set.of(groupIds.get(1))).get(groupIds.get(1)).activeMembers();
+          admin.consumerGroups(Set.of(groupIds.get(1))).get(groupIds.get(1)).assignment().keySet();
       handler.delete(
           Channel.ofQueries(
               groupIds.get(1),
@@ -261,7 +261,7 @@ public class GroupHandlerTest extends RequireBrokerCluster {
                   GroupHandler.GROUP_KEY,
                   "true",
                   GroupHandler.INSTANCE_KEY,
-                  group1Members.get(0).groupInstanceId().get())));
+                  group1Members.iterator().next().groupInstanceId().get())));
       Assertions.assertFalse(admin.consumerGroupIds().contains(groupIds.get(1)));
     }
   }

--- a/common/src/main/java/org/astraea/common/admin/ConsumerGroup.java
+++ b/common/src/main/java/org/astraea/common/admin/ConsumerGroup.java
@@ -16,24 +16,20 @@
  */
 package org.astraea.common.admin;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
 public class ConsumerGroup {
   private final String groupId;
-  private final List<Member> activeMembers;
   private final Map<TopicPartition, Long> consumeProgress;
   private final Map<Member, Set<TopicPartition>> assignment;
 
   public ConsumerGroup(
       String groupId,
-      List<Member> activeMembers,
       Map<TopicPartition, Long> consumeProgress,
       Map<Member, Set<TopicPartition>> assignment) {
     this.groupId = Objects.requireNonNull(groupId);
-    this.activeMembers = List.copyOf(activeMembers);
     this.consumeProgress = Map.copyOf(consumeProgress);
     this.assignment = Map.copyOf(assignment);
   }
@@ -50,18 +46,12 @@ public class ConsumerGroup {
     return consumeProgress;
   }
 
-  public List<Member> activeMembers() {
-    return activeMembers;
-  }
-
   @Override
   public String toString() {
     return "ConsumerGroup{"
         + "groupId='"
         + groupId
         + '\''
-        + ", activeMembers="
-        + activeMembers
         + ", consumeProgress="
         + consumeProgress
         + ", assignment="

--- a/common/src/test/java/org/astraea/common/admin/AdminTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AdminTest.java
@@ -915,7 +915,7 @@ public class AdminTest extends RequireBrokerCluster {
           admin
               .consumerGroups(Set.of(consumer.groupId()))
               .get(consumer.groupId())
-              .activeMembers()
+              .assignment()
               .size());
     }
   }
@@ -934,10 +934,10 @@ public class AdminTest extends RequireBrokerCluster {
         Assertions.assertEquals(0, consumer.poll(Duration.ofSeconds(3)).size());
       }
       Assertions.assertEquals(
-          1, admin.consumerGroups(Set.of(groupId)).get(groupId).activeMembers().size());
+          1, admin.consumerGroups(Set.of(groupId)).get(groupId).assignment().size());
       admin.removeAllMembers(groupId);
       Assertions.assertEquals(
-          0, admin.consumerGroups(Set.of(groupId)).get(groupId).activeMembers().size());
+          0, admin.consumerGroups(Set.of(groupId)).get(groupId).assignment().size());
       admin.removeAllMembers(groupId);
     }
   }
@@ -966,7 +966,7 @@ public class AdminTest extends RequireBrokerCluster {
           admin
               .consumerGroups(Set.of(consumer.groupId()))
               .get(consumer.groupId())
-              .activeMembers()
+              .assignment()
               .size());
     }
   }


### PR DESCRIPTION
`activeMembers` 是 `assignments` 的子資訊，因此可以拿掉，另外也簡化了一些程式碼