### PR TITLE
Add our LinkedHashMap

### DIFF
--- a/app/src/test/java/org/astraea/app/balancer/executor/RebalanceAdminTest.java
+++ b/app/src/test/java/org/astraea/app/balancer/executor/RebalanceAdminTest.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.astraea.common.DataSize;
 import org.astraea.common.DataUnit;
+import org.astraea.common.LinkedHashMap;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.admin.NodeInfo;
@@ -61,11 +62,7 @@ class RebalanceAdminTest extends RequireBrokerCluster {
       var tasks =
           rebalanceAdmin.alterReplicaPlacements(
               TopicPartition.of(topic, 0),
-              Utils.toLinkedHashMap(
-                  List.of(
-                      Map.entry(0, logFolder0),
-                      Map.entry(1, logFolder1),
-                      Map.entry(2, logFolder2))));
+              LinkedHashMap.of(0, logFolder0, 1, logFolder1, 2, logFolder2));
       tasks.forEach(
           task -> Utils.packException(() -> task.completableFuture().get(5, TimeUnit.SECONDS)));
 
@@ -104,9 +101,7 @@ class RebalanceAdminTest extends RequireBrokerCluster {
       var task =
           rebalanceAdmin
               .alterReplicaPlacements(
-                  topicPartition,
-                  Utils.toLinkedHashMap(
-                      List.of(Map.entry(originalReplica.nodeInfo().id(), nextDir))))
+                  topicPartition, LinkedHashMap.of(originalReplica.nodeInfo().id(), nextDir))
               .get(0);
 
       // assert

--- a/common/src/main/java/org/astraea/common/LinkedHashMap.java
+++ b/common/src/main/java/org/astraea/common/LinkedHashMap.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class LinkedHashMap<K, V> extends java.util.LinkedHashMap<K, V> {
+
+  public static <K, V> LinkedHashMap<K, V> of(K k1, V v1) {
+    return create(k1, v1);
+  }
+
+  public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2) {
+    return create(k1, v1, k2, v2);
+  }
+
+  public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3) {
+    return create(k1, v1, k2, v2, k3, v3);
+  }
+
+  public static <K, V> LinkedHashMap<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
+    return create(k1, v1, k2, v2, k3, v3, k4, v4);
+  }
+
+  public static <K, V> LinkedHashMap<K, V> of(
+      K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5) {
+    return create(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5);
+  }
+
+  public static <K, V> LinkedHashMap<K, V> of(
+      K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6) {
+    return create(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6);
+  }
+
+  public static <K, V> LinkedHashMap<K, V> of(
+      K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5, K k6, V v6, K k7, V v7) {
+    return create(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7);
+  }
+
+  public static <K, V> LinkedHashMap<K, V> of(
+      K k1,
+      V v1,
+      K k2,
+      V v2,
+      K k3,
+      V v3,
+      K k4,
+      V v4,
+      K k5,
+      V v5,
+      K k6,
+      V v6,
+      K k7,
+      V v7,
+      K k8,
+      V v8) {
+    return create(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8);
+  }
+
+  public static <K, V> LinkedHashMap<K, V> of(
+      K k1,
+      V v1,
+      K k2,
+      V v2,
+      K k3,
+      V v3,
+      K k4,
+      V v4,
+      K k5,
+      V v5,
+      K k6,
+      V v6,
+      K k7,
+      V v7,
+      K k8,
+      V v8,
+      K k9,
+      V v9) {
+    return create(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8, k9, v9);
+  }
+
+  public static <K, V> LinkedHashMap<K, V> of(
+      K k1,
+      V v1,
+      K k2,
+      V v2,
+      K k3,
+      V v3,
+      K k4,
+      V v4,
+      K k5,
+      V v5,
+      K k6,
+      V v6,
+      K k7,
+      V v7,
+      K k8,
+      V v8,
+      K k9,
+      V v9,
+      K k10,
+      V v10) {
+    return create(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7, k8, v8, k9, v9, k10, v10);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <K, V> LinkedHashMap<K, V> create(Object... objs) {
+    if (objs.length % 2 != 0) throw new IllegalArgumentException("the length must be even");
+    var map = new LinkedHashMap<K, V>(objs.length / 2);
+    for (var i = 0; i != objs.length; i += 2)
+      map.put((K) Objects.requireNonNull(objs[i]), (V) Objects.requireNonNull(objs[i + 1]));
+    return map;
+  }
+
+  public LinkedHashMap(int initialCapacity, float loadFactor) {
+    super(initialCapacity, loadFactor);
+  }
+
+  public LinkedHashMap(int initialCapacity) {
+    super(initialCapacity);
+  }
+
+  /**
+   * Constructs an empty insertion-ordered {@code LinkedHashMap} instance with the default initial
+   * capacity (16) and load factor (0.75).
+   */
+  public LinkedHashMap() {
+    super();
+  }
+
+  public LinkedHashMap(Map<? extends K, ? extends V> m) {
+    super(m);
+  }
+}

--- a/common/src/main/java/org/astraea/common/Utils.java
+++ b/common/src/main/java/org/astraea/common/Utils.java
@@ -19,9 +19,7 @@ package org.astraea.common;
 import java.net.InetAddress;
 import java.time.Duration;
 import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -254,12 +252,6 @@ public final class Utils {
           throw new IllegalStateException("Duplicate key");
         },
         TreeMap::new);
-  }
-
-  public static <K, V> LinkedHashMap<K, V> toLinkedHashMap(List<Map.Entry<K, V>> entries) {
-    var result = new LinkedHashMap<K, V>();
-    entries.forEach(e -> result.put(e.getKey(), e.getValue()));
-    return result;
   }
 
   private Utils() {}

--- a/common/src/test/java/org/astraea/common/LinkedHashMapTest.java
+++ b/common/src/test/java/org/astraea/common/LinkedHashMapTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class LinkedHashMapTest {
+
+  @Test
+  void testOf1() {
+    var map = LinkedHashMap.of("a", 0);
+    Assertions.assertEquals(1, map.size());
+    Assertions.assertEquals(0, map.get("a"));
+  }
+
+  @Test
+  void testOf2() {
+    var map = LinkedHashMap.of("a", 0, "b", 1);
+    Assertions.assertEquals(2, map.size());
+    Assertions.assertEquals(0, map.get("a"));
+    Assertions.assertEquals(1, map.get("b"));
+  }
+
+  @Test
+  void testOf3() {
+    var map = LinkedHashMap.of("a", 0, "b", 1, "c", 2);
+    Assertions.assertEquals(3, map.size());
+    Assertions.assertEquals(0, map.get("a"));
+    Assertions.assertEquals(1, map.get("b"));
+    Assertions.assertEquals(2, map.get("c"));
+  }
+
+  @Test
+  void testOf4() {
+    var map = LinkedHashMap.of("a", 0, "b", 1, "c", 2, "d", 3);
+    Assertions.assertEquals(4, map.size());
+    Assertions.assertEquals(0, map.get("a"));
+    Assertions.assertEquals(1, map.get("b"));
+    Assertions.assertEquals(2, map.get("c"));
+    Assertions.assertEquals(3, map.get("d"));
+  }
+
+  @Test
+  void testOf5() {
+    var map = LinkedHashMap.of("a", 0, "b", 1, "c", 2, "d", 3, "e", 4);
+    Assertions.assertEquals(5, map.size());
+    Assertions.assertEquals(0, map.get("a"));
+    Assertions.assertEquals(1, map.get("b"));
+    Assertions.assertEquals(2, map.get("c"));
+    Assertions.assertEquals(3, map.get("d"));
+    Assertions.assertEquals(4, map.get("e"));
+  }
+
+  @Test
+  void testOf6() {
+    var map = LinkedHashMap.of("a", 0, "b", 1, "c", 2, "d", 3, "e", 4, "f", 5);
+    Assertions.assertEquals(6, map.size());
+    Assertions.assertEquals(0, map.get("a"));
+    Assertions.assertEquals(1, map.get("b"));
+    Assertions.assertEquals(2, map.get("c"));
+    Assertions.assertEquals(3, map.get("d"));
+    Assertions.assertEquals(4, map.get("e"));
+    Assertions.assertEquals(5, map.get("f"));
+  }
+
+  @Test
+  void testOf7() {
+    var map = LinkedHashMap.of("a", 0, "b", 1, "c", 2, "d", 3, "e", 4, "f", 5, "g", 6);
+    Assertions.assertEquals(7, map.size());
+    Assertions.assertEquals(0, map.get("a"));
+    Assertions.assertEquals(1, map.get("b"));
+    Assertions.assertEquals(2, map.get("c"));
+    Assertions.assertEquals(3, map.get("d"));
+    Assertions.assertEquals(4, map.get("e"));
+    Assertions.assertEquals(5, map.get("f"));
+    Assertions.assertEquals(6, map.get("g"));
+  }
+
+  @Test
+  void testOf8() {
+    var map = LinkedHashMap.of("a", 0, "b", 1, "c", 2, "d", 3, "e", 4, "f", 5, "g", 6, "h", 7);
+    Assertions.assertEquals(8, map.size());
+    Assertions.assertEquals(0, map.get("a"));
+    Assertions.assertEquals(1, map.get("b"));
+    Assertions.assertEquals(2, map.get("c"));
+    Assertions.assertEquals(3, map.get("d"));
+    Assertions.assertEquals(4, map.get("e"));
+    Assertions.assertEquals(5, map.get("f"));
+    Assertions.assertEquals(6, map.get("g"));
+    Assertions.assertEquals(7, map.get("h"));
+  }
+
+  @Test
+  void testOf9() {
+    var map =
+        LinkedHashMap.of("a", 0, "b", 1, "c", 2, "d", 3, "e", 4, "f", 5, "g", 6, "h", 7, "i", 8);
+    Assertions.assertEquals(9, map.size());
+    Assertions.assertEquals(0, map.get("a"));
+    Assertions.assertEquals(1, map.get("b"));
+    Assertions.assertEquals(2, map.get("c"));
+    Assertions.assertEquals(3, map.get("d"));
+    Assertions.assertEquals(4, map.get("e"));
+    Assertions.assertEquals(5, map.get("f"));
+    Assertions.assertEquals(6, map.get("g"));
+    Assertions.assertEquals(7, map.get("h"));
+    Assertions.assertEquals(8, map.get("i"));
+  }
+
+  @Test
+  void testOf10() {
+    var map =
+        LinkedHashMap.of(
+            "a", 0, "b", 1, "c", 2, "d", 3, "e", 4, "f", 5, "g", 6, "h", 7, "i", 8, "j", 9);
+    Assertions.assertEquals(10, map.size());
+    Assertions.assertEquals(0, map.get("a"));
+    Assertions.assertEquals(1, map.get("b"));
+    Assertions.assertEquals(2, map.get("c"));
+    Assertions.assertEquals(3, map.get("d"));
+    Assertions.assertEquals(4, map.get("e"));
+    Assertions.assertEquals(5, map.get("f"));
+    Assertions.assertEquals(6, map.get("g"));
+    Assertions.assertEquals(7, map.get("h"));
+    Assertions.assertEquals(8, map.get("i"));
+    Assertions.assertEquals(9, map.get("j"));
+  }
+}


### PR DESCRIPTION
在實作新的元件時發現`Utils.toLinkedHashMap`真他x的有夠醜 :(

所以新增一個 astraea LinkedHashMap，這個有兩個好處：

1. 它繼承自java `LinkedHashMap`，所以可以相容
2. 提供各種helper，類似`Map.of`，之後要建立有順序的物件可以呼叫`LinkedHashMap.of`