### PR TITLE
update replicas

### DIFF
--- a/common/src/main/java/org/astraea/common/admin/Admin.java
+++ b/common/src/main/java/org/astraea/common/admin/Admin.java
@@ -115,9 +115,11 @@ public interface Admin extends Closeable {
 
   /**
    * @param topics topic names
-   * @return the replicas of partition
+   * @return all replica in topics
    */
   Map<TopicPartition, List<Replica>> replicas(Set<String> topics);
+
+  List<Replica> newReplicas(Set<String> topics);
 
   /** @return all broker id and their configuration */
   default Map<Integer, Config> brokers() {

--- a/common/src/test/java/org/astraea/common/admin/AdminTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AdminTest.java
@@ -502,6 +502,28 @@ public class AdminTest extends RequireBrokerCluster {
   }
 
   @Test
+  void testNewReplicas() {
+    try (var admin = Admin.of(bootstrapServers())) {
+      var topics = Set.of("abc", "def", "ghi");
+      topics.forEach(t -> admin.creator().topic(t).numberOfPartitions(2).create());
+
+      Utils.sleep(Duration.ofSeconds(2));
+      topics.forEach(t -> Assertions.assertEquals(2, admin.replicas(Set.of(t)).size()));
+      Assertions.assertEquals(6, admin.replicas(topics).size());
+      Assertions.assertEquals(6, admin.newReplicas(topics).size());
+
+      var count = admin.topicNames().stream().mapToInt(t -> admin.replicas(Set.of(t)).size()).sum();
+      Assertions.assertEquals(count, admin.replicas().size());
+
+      var replicas =
+          admin.replicas(Set.of("abc")).values().stream()
+              .flatMap(Collection::stream)
+              .collect(Collectors.toList());
+      Assertions.assertTrue(replicas.containsAll(admin.newReplicas(Set.of("abc"))));
+    }
+  }
+
+  @Test
   void testReplicasPreferredLeaderFlag() {
     // arrange
     try (Admin admin = Admin.of(bootstrapServers())) {


### PR DESCRIPTION
因為大部分呼叫 `Admin#replicas` 的使用者都不會使用Map的索引功能，且會重新去結構化，此pr將的回傳型態改成 List<Replica>，然後呼叫端自己組合Map，此PR合併後會另開一支來取代舊的方法