### PR TITLE
Fix flaky BalancerTest#testLeaderCountRebalance

### DIFF
--- a/app/src/test/java/org/astraea/app/balancer/BalancerTest.java
+++ b/app/src/test/java/org/astraea/app/balancer/BalancerTest.java
@@ -38,12 +38,11 @@ import org.astraea.common.cost.HasClusterCost;
 import org.astraea.common.cost.ReplicaLeaderCost;
 import org.astraea.it.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 class BalancerTest extends RequireBrokerCluster {
 
-  @RepeatedTest(value = 3000)
+  @Test
   void testLeaderCountRebalance() {
     try (Admin admin = Admin.of(bootstrapServers())) {
       var topicName = Utils.randomString();


### PR DESCRIPTION
resolve #750 

出錯的原因是 `SkewedPartitionScenario` 在把 log 分佈套用到叢集時，只等待一秒鐘當作工作完成，但是實際上這個過程可能會花上不少時間。太快呼叫的結果導致後面重新選舉 leader 時觸發 `PreferredLeaderNotAvailableException` 錯誤。

修正的方式是用 `RebalanceAdmin` 裏面的等待功能等特定 log 達到 sync 狀態，而非單純等 1 秒鐘。