### PR TITLE
Add VersionUtils to display the build information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ spark.dockerfile
 deps.dockerfile
 # we don't put binary file to git repo
 gradle-wrapper.jar
+VersionUtils.java

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -76,3 +76,87 @@ publishing {
         }
     }
 }
+
+private String exec(String[] args) {
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine args
+        standardOutput = stdout
+    }
+    // If the shell is wrapped by cygwin, the line separator is changed to \n...
+    // Hence, checking the separator manually is more suitable in this case
+    def s = stdout.toString()
+    if (s.contains("\r\n")) return s.replaceAll("\r\n", "")
+    return s.replaceAll("\n", "")
+}
+
+import org.apache.tools.ant.taskdefs.condition.Os
+private String whoami() {
+    try {
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            def fullName = exec("whoami")
+            def backslash = fullName.lastIndexOf("\\")
+            if (backslash == -1) return fullName
+            else fullName.substring(backslash + 1)
+        }
+        else return exec("whoami")
+    } catch (Throwable ignored) {
+        return "Unknown"
+    }
+}
+
+private String user() {
+    try {
+        return exec("git", "config", "user.name")
+    } catch (Throwable ignored) {
+        // if git's user is not set, git will return exit code 1
+        return whoami()
+    }
+}
+
+private String revision() {
+    try {
+        return exec("git", "log", "-1", "--pretty=format:%H")
+    } catch (Throwable ignored) {
+        // if git's user is not set, git will return exit code 1
+        return "Unknown"
+    }
+}
+
+private static String date() {
+    return new Date().format('yyyy-MM-dd HH:mm:ss')
+}
+
+private String version() {
+    return project.version.toString();
+}
+
+task initializer {
+    doLast {
+        def file = new File("$projectDir" + "/src/main/java/org/astraea/common/VersionUtils.java")
+        if (file.exists()) file.delete()
+        String code = """package org.astraea.common;
+// DON'T touch this file!!! It is generated dynamically. see common/build.gradle
+public final class VersionUtils {
+  public static final String VERSION = \"${version()}\";
+  public static final String BUILDER = \"${user()}\";
+  public static final String REVISION = \"${revision()}\";
+  public static final String DATE = \"${date()}\";
+  private VersionUtils() {}
+}
+"""
+        def writer = new FileWriter(file)
+        try {
+            writer.write(code.replaceAll("\n", System.lineSeparator()))
+        } finally {
+            writer.close()
+        }
+    }
+}
+
+/**
+ * Generating VersionUtils must run before compileJava.
+ */
+tasks.matching { it.name != 'initializer' && it.name == "compileJava"}.all { Task task ->
+    task.dependsOn initializer
+}

--- a/common/src/test/java/org/astraea/common/VersionUtilsTest.java
+++ b/common/src/test/java/org/astraea/common/VersionUtilsTest.java
@@ -14,27 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-plugins {
-    id "com.diffplug.spotless" version "5.14.3"
-}
+package org.astraea.common;
 
-spotless {
-    java {
-        licenseHeaderFile(file("$rootDir/checkstyle/apache.header"))
-        importOrder()
-        removeUnusedImports()
-        targetExclude "**/VersionUtils.java"
-        target '**/java/**/*.java'
-        googleJavaFormat()
-        custom 'refuse wildcard', {
-            if (it.contains('*;\n')) {
-                throw new Error("Wildcard imports is disallowed")
-            }
-        }
-    }
-    scala {
-        licenseHeaderFile(file("$rootDir/checkstyle/apache.header"), "package ")
-        target '**/scala/**/*.scala'
-        scalafmt()
-    }
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class VersionUtilsTest {
+
+  @Test
+  void test() {
+    Assertions.assertNotNull(VersionUtils.VERSION);
+    Assertions.assertNotNull(VersionUtils.REVISION);
+    Assertions.assertNotNull(VersionUtils.DATE);
+    Assertions.assertNotNull(VersionUtils.BUILDER);
+  }
 }


### PR DESCRIPTION
我們在接下來釋出的二進位檔案中，需要提供一個方式讓使用者知道目前的二進制是何時何版所建置，因此這隻PR新增一個功能，在建置專案時會即時產生一個`VersionUtils`，該檔案會提供`version`, `revision`, `builder` and `date`等等資訊