### PR TITLE
Remove earliest/latest timestamp

### DIFF
--- a/common/src/main/java/org/astraea/common/admin/Builder.java
+++ b/common/src/main/java/org/astraea/common/admin/Builder.java
@@ -227,6 +227,18 @@ public class Builder {
 
     @Override
     public List<Topic> topics(Set<String> names) {
+      var maxTimestamp =
+          Utils.packException(
+              () ->
+                  admin
+                      .listOffsets(
+                          topicPartitions(names).stream()
+                              .map(TopicPartition::to)
+                              .collect(
+                                  Collectors.toMap(
+                                      Function.identity(), e -> new OffsetSpec.MaxTimestampSpec())))
+                      .all()
+                      .get());
       return Utils.packException(
               () ->
                   admin
@@ -238,7 +250,16 @@ public class Builder {
                       .get())
           .entrySet()
           .stream()
-          .map(entry -> Topic.of(entry.getKey().name(), entry.getValue()))
+          .map(
+              entry ->
+                  Topic.of(
+                      entry.getKey().name(),
+                      entry.getValue(),
+                      maxTimestamp.entrySet().stream()
+                          .filter(offset -> offset.getKey().topic().equals(entry.getKey().name()))
+                          .mapToLong(offset -> offset.getValue().timestamp())
+                          .filter(v -> v > 0)
+                          .max()))
           .collect(Collectors.toUnmodifiableList());
     }
 

--- a/common/src/main/java/org/astraea/common/admin/Builder.java
+++ b/common/src/main/java/org/astraea/common/admin/Builder.java
@@ -337,6 +337,18 @@ public class Builder {
                       .all()
                       .get());
 
+      var maxTimestamp =
+          Utils.packException(
+              () ->
+                  admin
+                      .listOffsets(
+                          partitions.keySet().stream()
+                              .collect(
+                                  Collectors.toMap(
+                                      Function.identity(), e -> new OffsetSpec.MaxTimestampSpec())))
+                      .all()
+                      .get());
+
       return partitions.entrySet().stream()
           .map(
               entry ->
@@ -344,7 +356,8 @@ public class Builder {
                       entry.getKey().topic(),
                       entry.getValue(),
                       Optional.ofNullable(earliest.get(entry.getKey())),
-                      Optional.ofNullable(latest.get(entry.getKey()))))
+                      Optional.ofNullable(latest.get(entry.getKey())),
+                      Optional.ofNullable(maxTimestamp.get(entry.getKey()))))
           .collect(Collectors.toList());
     }
 

--- a/common/src/main/java/org/astraea/common/admin/Builder.java
+++ b/common/src/main/java/org/astraea/common/admin/Builder.java
@@ -227,18 +227,6 @@ public class Builder {
 
     @Override
     public List<Topic> topics(Set<String> names) {
-      var maxTimestamp =
-          Utils.packException(
-              () ->
-                  admin
-                      .listOffsets(
-                          topicPartitions(names).stream()
-                              .map(TopicPartition::to)
-                              .collect(
-                                  Collectors.toMap(
-                                      Function.identity(), e -> new OffsetSpec.MaxTimestampSpec())))
-                      .all()
-                      .get());
       return Utils.packException(
               () ->
                   admin
@@ -250,16 +238,7 @@ public class Builder {
                       .get())
           .entrySet()
           .stream()
-          .map(
-              entry ->
-                  Topic.of(
-                      entry.getKey().name(),
-                      entry.getValue(),
-                      maxTimestamp.entrySet().stream()
-                          .filter(offset -> offset.getKey().topic().equals(entry.getKey().name()))
-                          .mapToLong(offset -> offset.getValue().timestamp())
-                          .filter(v -> v > 0)
-                          .max()))
+          .map(entry -> Topic.of(entry.getKey().name(), entry.getValue()))
           .collect(Collectors.toUnmodifiableList());
     }
 

--- a/common/src/main/java/org/astraea/common/admin/Partition.java
+++ b/common/src/main/java/org/astraea/common/admin/Partition.java
@@ -27,7 +27,9 @@ public interface Partition {
       String topic,
       org.apache.kafka.common.TopicPartitionInfo tpi,
       Optional<org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo> earliest,
-      Optional<org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo> latest) {
+      Optional<org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo> latest,
+      Optional<org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo>
+          maxTimestamp) {
     return of(
         topic,
         tpi.partition(),
@@ -35,9 +37,8 @@ public interface Partition {
         tpi.replicas().stream().map(NodeInfo::of).collect(Collectors.toList()),
         tpi.isr().stream().map(NodeInfo::of).collect(Collectors.toList()),
         earliest.map(ListOffsetsResult.ListOffsetsResultInfo::offset).orElse(-1L),
-        earliest.map(ListOffsetsResult.ListOffsetsResultInfo::timestamp).orElse(-1L),
         latest.map(ListOffsetsResult.ListOffsetsResultInfo::offset).orElse(-1L),
-        latest.map(ListOffsetsResult.ListOffsetsResultInfo::timestamp).orElse(-1L));
+        maxTimestamp.map(ListOffsetsResult.ListOffsetsResultInfo::timestamp).orElse(-1L));
   }
 
   static Partition of(
@@ -47,9 +48,8 @@ public interface Partition {
       List<NodeInfo> replicas,
       List<NodeInfo> isr,
       long earliestOffset,
-      long earliestOffsetTimestamp,
       long latestOffset,
-      long latestOffsetTimestamp) {
+      long maxTimestamp) {
     return new Partition() {
 
       @Override
@@ -68,18 +68,13 @@ public interface Partition {
       }
 
       @Override
-      public long earliestOffsetTimestamp() {
-        return earliestOffsetTimestamp;
-      }
-
-      @Override
       public long latestOffset() {
         return latestOffset;
       }
 
       @Override
-      public long latestOffsetTimestamp() {
-        return latestOffsetTimestamp;
+      public long maxTimestamp() {
+        return maxTimestamp;
       }
 
       @Override
@@ -110,14 +105,11 @@ public interface Partition {
   /** @return existent earliest offset */
   long earliestOffset();
 
-  /** @return timestamp of the earliest offset */
-  long earliestOffsetTimestamp();
-
   /** @return existent latest offset */
   long latestOffset();
 
-  /** @return timestamp of the latest offset */
-  long latestOffsetTimestamp();
+  /** @return max timestamp of existent records */
+  long maxTimestamp();
 
   NodeInfo leader();
 

--- a/common/src/main/java/org/astraea/common/admin/Topic.java
+++ b/common/src/main/java/org/astraea/common/admin/Topic.java
@@ -16,9 +16,12 @@
  */
 package org.astraea.common.admin;
 
+import java.util.OptionalLong;
+
 public interface Topic {
 
-  static Topic of(String name, org.apache.kafka.clients.admin.Config kafkaConfig) {
+  static Topic of(
+      String name, org.apache.kafka.clients.admin.Config kafkaConfig, OptionalLong maxTimestamp) {
 
     var config = Config.of(kafkaConfig);
     return new Topic() {
@@ -31,6 +34,11 @@ public interface Topic {
       public Config config() {
         return config;
       }
+
+      @Override
+      public long maxTimestamp() {
+        return maxTimestamp.orElse(-1L);
+      }
     };
   }
 
@@ -39,4 +47,7 @@ public interface Topic {
 
   /** @return config used by this topic */
   Config config();
+
+  /** @return max timestamp of existent record */
+  long maxTimestamp();
 }

--- a/common/src/main/java/org/astraea/common/admin/Topic.java
+++ b/common/src/main/java/org/astraea/common/admin/Topic.java
@@ -16,12 +16,9 @@
  */
 package org.astraea.common.admin;
 
-import java.util.OptionalLong;
-
 public interface Topic {
 
-  static Topic of(
-      String name, org.apache.kafka.clients.admin.Config kafkaConfig, OptionalLong maxTimestamp) {
+  static Topic of(String name, org.apache.kafka.clients.admin.Config kafkaConfig) {
 
     var config = Config.of(kafkaConfig);
     return new Topic() {
@@ -34,11 +31,6 @@ public interface Topic {
       public Config config() {
         return config;
       }
-
-      @Override
-      public long maxTimestamp() {
-        return maxTimestamp.orElse(-1L);
-      }
     };
   }
 
@@ -47,7 +39,4 @@ public interface Topic {
 
   /** @return config used by this topic */
   Config config();
-
-  /** @return max timestamp of existent record */
-  long maxTimestamp();
 }

--- a/common/src/test/java/org/astraea/common/admin/AdminTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AdminTest.java
@@ -184,6 +184,8 @@ public class AdminTest extends RequireBrokerCluster {
       admin
           .partitions(Set.of(topicName))
           .forEach(p -> Assertions.assertNotEquals(-1, p.maxTimestamp()));
+
+      Assertions.assertNotEquals(-1, admin.topics(Set.of(topicName)).get(0).maxTimestamp());
     }
   }
 

--- a/common/src/test/java/org/astraea/common/admin/AdminTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AdminTest.java
@@ -184,8 +184,6 @@ public class AdminTest extends RequireBrokerCluster {
       admin
           .partitions(Set.of(topicName))
           .forEach(p -> Assertions.assertNotEquals(-1, p.maxTimestamp()));
-
-      Assertions.assertNotEquals(-1, admin.topics(Set.of(topicName)).get(0).maxTimestamp());
     }
   }
 


### PR DESCRIPTION
重新審視了一下 kafka 原始碼，發現 `List offset`並不會順便搜尋 timestamp，因此這邊改成有紀錄的 max timestamp