### PR TITLE
Remove null directory usage in `ClusterLogAllocation`

### DIFF
--- a/app/src/main/java/org/astraea/app/balancer/executor/RebalanceAdminImpl.java
+++ b/app/src/main/java/org/astraea/app/balancer/executor/RebalanceAdminImpl.java
@@ -74,6 +74,8 @@ class RebalanceAdminImpl implements RebalanceAdmin {
     // of time to actually trigger it (race condition).
     final var declareMap =
         preferredPlacements.entrySet().stream()
+            // filter out offline replicas
+            .filter(entry -> entry.getValue() != null)
             .filter(entry -> !currentBrokerAllocation.contains(entry.getKey()))
             .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
 

--- a/app/src/test/java/org/astraea/app/balancer/executor/RebalanceAdminTest.java
+++ b/app/src/test/java/org/astraea/app/balancer/executor/RebalanceAdminTest.java
@@ -41,6 +41,7 @@ import org.astraea.common.admin.TopicPartitionReplica;
 import org.astraea.common.producer.Producer;
 import org.astraea.it.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
@@ -76,6 +77,23 @@ class RebalanceAdminTest extends RequireBrokerCluster {
       Assertions.assertEquals(logFolder0, replicas.get(0).dataFolder());
       Assertions.assertEquals(logFolder1, replicas.get(1).dataFolder());
       Assertions.assertEquals(logFolder2, replicas.get(2).dataFolder());
+    }
+  }
+
+  @Test
+  @DisplayName("Offline directory will not raise an exception")
+  void testOfflineReplicaWorks() {
+    // arrange
+    try (Admin admin = Admin.of(bootstrapServers())) {
+      var topic = prepareTopic(admin, 1, (short) 1);
+      var topicPartition = TopicPartition.of(topic, 0);
+      var rebalanceAdmin = prepareRebalanceAdmin(admin);
+      var newPlacement = new LinkedHashMap<Integer, String>();
+      newPlacement.put(1, null);
+
+      // act, assert
+      Assertions.assertDoesNotThrow(
+          () -> rebalanceAdmin.alterReplicaPlacements(topicPartition, newPlacement));
     }
   }
 


### PR DESCRIPTION
Context: https://github.com/skiptests/astraea/pull/764#discussion_r981445170

* `ClusterLogAllocation#migrateReplica` 一定要指定 destination data directory 位置
* 修正 `RebalanceAdmin#declarePreferredDataDirectories` 在遇到 null directory(caused by offline replica) 時會噴錯的問題