### PR TITLE
Revise `GET /balancer`

### DIFF
--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -49,11 +49,13 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
   void testReport() {
     createAndProduceTopic(3);
     try (var admin = Admin.of(bootstrapServers())) {
-      var handler = new BalancerHandler(admin, new DegradeCost(), new ReplicaSizeCost());
+      var handler =
+          new BalancerHandler(admin, MultiplicationCost.decreasing(), new ReplicaSizeCost());
       var report =
           Assertions.assertInstanceOf(
               BalancerHandler.Report.class,
               handler.get(Channel.ofQueries(Map.of(BalancerHandler.LIMIT_KEY, "3000"))));
+      Assertions.assertNotNull(report.id);
       Assertions.assertEquals(3000, report.limit);
       Assertions.assertNotEquals(0, report.changes.size());
       Assertions.assertTrue(report.cost >= report.newCost);
@@ -80,7 +82,8 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
   void testTopic() {
     var topicNames = createAndProduceTopic(3);
     try (var admin = Admin.of(bootstrapServers())) {
-      var handler = new BalancerHandler(admin, new DegradeCost(), new ReplicaSizeCost());
+      var handler =
+          new BalancerHandler(admin, MultiplicationCost.decreasing(), new ReplicaSizeCost());
       var report =
           Assertions.assertInstanceOf(
               BalancerHandler.Report.class,
@@ -105,15 +108,29 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
   }
 
   /** The score will getter better after each call, pretend we find a better plan */
-  private static class DegradeCost implements HasClusterCost {
+  private static class MultiplicationCost implements HasClusterCost {
 
     private double value0 = 1.0;
+    private final double mul;
+
+    static MultiplicationCost decreasing() {
+      return new MultiplicationCost(0.998);
+    }
+
+    static MultiplicationCost increasing() {
+      return new MultiplicationCost(1.02);
+    }
+
+    private MultiplicationCost(double mul) {
+      this.mul = mul;
+    }
 
     @Override
     public synchronized ClusterCost clusterCost(
         ClusterInfo<Replica> clusterInfo, ClusterBean clusterBean) {
-      value0 = value0 * 0.998;
-      return () -> value0;
+      double theCost = value0;
+      value0 = value0 * mul;
+      return () -> theCost;
     }
   }
 
@@ -121,7 +138,8 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
   void testTopics() {
     var topicNames = createAndProduceTopic(3);
     try (var admin = Admin.of(bootstrapServers())) {
-      var handler = new BalancerHandler(admin, new DegradeCost(), new ReplicaSizeCost());
+      var handler =
+          new BalancerHandler(admin, MultiplicationCost.decreasing(), new ReplicaSizeCost());
       var report =
           Assertions.assertInstanceOf(
               BalancerHandler.Report.class,
@@ -219,7 +237,8 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
           (originClusterInfo, newClusterInfo, clusterBean) ->
               MoveCost.builder().totalCost(100).build();
 
-      var balancerHandler = new BalancerHandler(admin, new DegradeCost(), new ReplicaSizeCost());
+      var balancerHandler =
+          new BalancerHandler(admin, MultiplicationCost.decreasing(), new ReplicaSizeCost());
       var Best =
           Balancer.builder()
               .planGenerator(RebalancePlanGenerator.random(30))
@@ -265,6 +284,23 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
               .movementConstraint(moveCost -> false)
               .build()
               .offer(admin.clusterInfo(), ignore -> true, admin.brokerFolders()));
+    }
+  }
+
+  @Test
+  void testNoReport() {
+    try (var admin = Admin.of(bootstrapServers())) {
+      admin.creator().topic(Utils.randomString()).numberOfPartitions(30).create();
+      Utils.sleep(Duration.ofSeconds(1));
+      var handler =
+          new BalancerHandler(admin, MultiplicationCost.increasing(), new ReplicaSizeCost());
+      var report =
+          Assertions.assertInstanceOf(
+              BalancerHandler.Report.class,
+              handler.get(Channel.ofQueries(Map.of(BalancerHandler.LIMIT_KEY, "10"))));
+
+      Assertions.assertTrue(report.changes.isEmpty());
+      Assertions.assertNull(report.id);
     }
   }
 }


### PR DESCRIPTION
Related issue: https://github.com/skiptests/astraea/issues/743
Related PR: https://github.com/skiptests/astraea/pull/767
* 給每個產生的計劃添加一個 Version 4 UUID
* BalancerHandler 內部會儲存產生過的計劃，且用他們的 `id` 來索引他們。
