### PR TITLE
Enable to trace subscribed partitions when running perf tool

### DIFF
--- a/app/src/main/java/org/astraea/app/performance/ConsumerThread.java
+++ b/app/src/main/java/org/astraea/app/performance/ConsumerThread.java
@@ -87,6 +87,7 @@ public interface ConsumerThread extends AbstractThread {
                       Utils.swallowException(consumer::close);
                       closeLatch.countDown();
                       closed.set(true);
+                      CLIENT_ID_PARTITIONS.remove(clientId);
                     }
                   });
               return new ConsumerThread() {

--- a/app/src/main/java/org/astraea/app/performance/Performance.java
+++ b/app/src/main/java/org/astraea/app/performance/Performance.java
@@ -95,7 +95,7 @@ public class Performance {
     var consumerThreads =
         ConsumerThread.create(
             param.consumers,
-            listener ->
+            (clientId, listener) ->
                 Consumer.forTopics(new HashSet<>(param.topics))
                     .bootstrapServers(param.bootstrapServers())
                     .groupId(param.groupId)
@@ -103,6 +103,7 @@ public class Performance {
                     .isolation(param.isolation())
                     .seek(latestOffsets)
                     .consumerRebalanceListener(listener)
+                    .clientId(clientId)
                     .build());
 
     System.out.println("creating tracker");


### PR DESCRIPTION
由於 kafka metrics 無法得知明確的 subscribed partitions，因此新增一個變數保存目前運作中的 client 各自處理哪些 partitions