### PR TITLE
Apply greedy algorithm to balancer

### DIFF
--- a/common/src/main/java/org/astraea/common/balancer/BalancerBuilder.java
+++ b/common/src/main/java/org/astraea/common/balancer/BalancerBuilder.java
@@ -19,10 +19,15 @@ package org.astraea.common.balancer;
 import java.time.Duration;
 import java.util.Comparator;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import org.astraea.common.admin.ClusterBean;
 import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.admin.Replica;
 import org.astraea.common.balancer.generator.RebalancePlanGenerator;
 import org.astraea.common.balancer.log.ClusterLogAllocation;
 import org.astraea.common.cost.ClusterCost;
@@ -36,10 +41,12 @@ public class BalancerBuilder {
   private HasClusterCost clusterCostFunction;
   private HasMoveCost moveCostFunction = HasMoveCost.EMPTY;
   private BiPredicate<ClusterCost, ClusterCost> clusterConstraint =
-      (before, after) -> after.value() <= before.value();
+      (before, after) -> after.value() < before.value();
   private Predicate<MoveCost> movementConstraint = ignore -> true;
   private int searchLimit = Integer.MAX_VALUE;
   private Duration executionTime = Duration.ofSeconds(3);
+
+  private boolean greedy = true;
 
   /**
    * Specify the {@link RebalancePlanGenerator} for potential rebalance plan generation.
@@ -127,6 +134,11 @@ public class BalancerBuilder {
     return this;
   }
 
+  public BalancerBuilder greedy(boolean greedy) {
+    this.greedy = greedy;
+    return this;
+  }
+
   /**
    * @return a {@link Balancer} that will offer rebalance plan based on the implementation detail
    *     you specified.
@@ -138,6 +150,7 @@ public class BalancerBuilder {
     Objects.requireNonNull(this.moveCostFunction);
     Objects.requireNonNull(this.movementConstraint);
 
+    if (greedy) return buildGreedy();
     return (currentClusterInfo, topicFilter, brokerFolders) -> {
       final var currentClusterBean = ClusterBean.EMPTY;
       final var currentCost =
@@ -163,6 +176,50 @@ public class BalancerBuilder {
           .filter(plan -> clusterConstraint.test(currentCost, plan.clusterCost))
           .filter(plan -> movementConstraint.test(plan.moveCost))
           .min(Comparator.comparing(plan -> plan.clusterCost.value()));
+    };
+  }
+
+  private Balancer buildGreedy() {
+    return (originClusterInfo, topicFilter, brokerFolders) -> {
+      final var loop = new AtomicInteger(searchLimit);
+      final var start = System.currentTimeMillis();
+      Supplier<Boolean> isDone =
+          () ->
+              System.currentTimeMillis() - start >= executionTime.toMillis()
+                  || loop.getAndDecrement() <= 0;
+      BiFunction<ClusterInfo<Replica>, ClusterCost, Optional<Balancer.Plan>> next =
+          (currentClusterInfo, currentCost) ->
+              planGenerator
+                  .generate(brokerFolders, ClusterLogAllocation.of(currentClusterInfo))
+                  .takeWhile(ignored -> !isDone.get())
+                  .map(
+                      proposal -> {
+                        var newClusterInfo =
+                            BalancerUtils.update(currentClusterInfo, proposal.rebalancePlan());
+                        return new Balancer.Plan(
+                            proposal,
+                            clusterCostFunction.clusterCost(newClusterInfo, ClusterBean.EMPTY),
+                            moveCostFunction.moveCost(
+                                currentClusterInfo, newClusterInfo, ClusterBean.EMPTY));
+                      })
+                  .filter(plan -> clusterConstraint.test(currentCost, plan.clusterCost))
+                  .filter(plan -> movementConstraint.test(plan.moveCost))
+                  .findFirst();
+      var currentCost = clusterCostFunction.clusterCost(originClusterInfo, ClusterBean.EMPTY);
+      var currentClusterInfo = ClusterInfo.masked(originClusterInfo, topicFilter);
+      var currentPlan = Optional.<Balancer.Plan>empty();
+      while (true) {
+        var newPlan = next.apply(currentClusterInfo, currentCost);
+        if (newPlan.isEmpty()) break;
+        currentPlan = newPlan;
+        currentCost = currentPlan.get().clusterCost;
+        currentClusterInfo =
+            ClusterInfo.masked(
+                BalancerUtils.update(
+                    originClusterInfo, currentPlan.get().proposal().rebalancePlan()),
+                topicFilter);
+      }
+      return currentPlan;
     };
   }
 }

--- a/common/src/main/java/org/astraea/common/balancer/BalancerBuilder.java
+++ b/common/src/main/java/org/astraea/common/balancer/BalancerBuilder.java
@@ -151,6 +151,10 @@ public class BalancerBuilder {
     Objects.requireNonNull(this.movementConstraint);
 
     if (greedy) return buildGreedy();
+    return buildNormal();
+  }
+
+  private Balancer buildNormal() {
     return (currentClusterInfo, topicFilter, brokerFolders) -> {
       final var currentClusterBean = ClusterBean.EMPTY;
       final var currentCost =

--- a/common/src/main/java/org/astraea/common/cost/ReplicaLeaderCost.java
+++ b/common/src/main/java/org/astraea/common/cost/ReplicaLeaderCost.java
@@ -53,6 +53,7 @@ public class ReplicaLeaderCost implements HasBrokerCost, HasClusterCost, HasMove
 
   private static Map<Integer, Integer> leaderCount(
       ClusterInfo<? extends ReplicaInfo> clusterInfo, ClusterBean clusterBean) {
+    if (clusterBean == ClusterBean.EMPTY) return leaderCount(clusterInfo);
     var leaderCount = leaderCount(clusterBean);
     // if there is no available metrics, we re-count the leaders based on cluster information
     if (leaderCount.values().stream().mapToInt(i -> i).sum() == 0) return leaderCount(clusterInfo);

--- a/common/src/test/java/org/astraea/common/balancer/BalancerAlgorithmTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerAlgorithmTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.balancer;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.astraea.common.Utils;
+import org.astraea.common.admin.Admin;
+import org.astraea.common.balancer.generator.ShufflePlanGenerator;
+import org.astraea.common.cost.HasClusterCost;
+import org.astraea.it.RequireBrokerCluster;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
+
+public class BalancerAlgorithmTest extends RequireBrokerCluster {
+
+  @RepeatedTest(5)
+  void test() {
+    try (Admin admin = Admin.of(bootstrapServers())) {
+      IntStream.range(0, 5)
+          .forEach(
+              ignored ->
+                  admin.creator().topic(Utils.randomString()).numberOfPartitions(10).create());
+      admin
+          .topicNames()
+          .forEach(tp -> admin.migrator().topic(tp).moveTo(List.of(brokerIds().iterator().next())));
+      Utils.sleep(Duration.ofSeconds(2));
+
+      HasClusterCost cost =
+          (clusterInfo, ignored) -> {
+            var group =
+                clusterInfo.replicas().stream()
+                    .collect(Collectors.groupingBy(r -> r.nodeInfo().id()));
+
+            var max = group.values().stream().mapToLong(List::size).max().orElse(0);
+            var min = group.values().stream().mapToLong(List::size).min().orElse(0);
+            var c = group.size() == 1 ? Long.MAX_VALUE : max - min;
+            System.out.println(
+                "cost="
+                    + c
+                    + " allocations:"
+                    + group.entrySet().stream()
+                        .map(e -> e.getKey() + ":" + e.getValue().size())
+                        .collect(Collectors.joining(",")));
+            return () -> c;
+          };
+
+      var planOfGreedy =
+          Balancer.builder()
+              .planGenerator(new ShufflePlanGenerator(0, 30))
+              .clusterCost(cost)
+              .limit(Duration.ofSeconds(5))
+              .greedy(true)
+              .build()
+              .offer(admin.clusterInfo(), admin.brokerFolders())
+              .get();
+
+      System.out.println("greedy done");
+
+      var plan =
+          Balancer.builder()
+              .planGenerator(new ShufflePlanGenerator(0, 30))
+              .clusterCost(cost)
+              .limit(Duration.ofSeconds(5))
+              .greedy(false)
+              .build()
+              .offer(admin.clusterInfo(), admin.brokerFolders())
+              .get();
+      System.out.println("normal done");
+
+      Assertions.assertNotEquals(plan.clusterCost.value(), planOfGreedy.clusterCost.value());
+      Assertions.assertTrue(plan.clusterCost.value() > planOfGreedy.clusterCost.value());
+    }
+  }
+}


### PR DESCRIPTION
這是一隻討論用的PR

原本 balancer 是在同一個基礎上產生多種隨機組合，必且從中選擇一個最佳解，這隻PR則改為採用 greedy 的方式先找到一個相對好的組合後，再以該組合為基礎繼續往下找

greedy 的好處在於能較穩地的找尋更低成本的組合，但副作用是如果第一步踩錯，會導致後續基於不好的基礎往下嘗試，使得很快掉進區域最佳解裡面