### PR TITLE
Enable to trace leaders from Admin#brokers

### DIFF
--- a/common/src/main/java/org/astraea/common/admin/Builder.java
+++ b/common/src/main/java/org/astraea/common/admin/Builder.java
@@ -293,10 +293,18 @@ public class Builder {
               .collect(
                   Collectors.toMap(e -> Integer.valueOf(e.getKey().name()), Map.Entry::getValue));
 
+      var tableDesc =
+          Utils.packException(() -> admin.describeTopics(this.topicNames()).all().get()).values();
+
       return nodes.stream()
           .map(
               n ->
-                  Broker.of(n.id() == controller.id(), n, configs.get(n.id()), logDirs.get(n.id())))
+                  Broker.of(
+                      n.id() == controller.id(),
+                      n,
+                      configs.get(n.id()),
+                      logDirs.get(n.id()),
+                      tableDesc))
           .collect(Collectors.toList());
     }
 

--- a/common/src/test/java/org/astraea/common/admin/AdminTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AdminTest.java
@@ -492,10 +492,14 @@ public class AdminTest extends RequireBrokerCluster {
   @Test
   void testBrokers() {
     try (var admin = Admin.of(bootstrapServers())) {
-      var nodes = admin.brokers();
-      Assertions.assertEquals(3, nodes.size());
-      nodes.forEach(c -> Assertions.assertNotEquals(0, c.config().raw().size()));
-      Assertions.assertEquals(1, nodes.stream().filter(Broker::isController).count());
+      admin.creator().topic(Utils.randomString()).numberOfPartitions(6).create();
+      Utils.sleep(Duration.ofSeconds(2));
+      var brokers = admin.brokers();
+      Assertions.assertEquals(3, brokers.size());
+      brokers.forEach(broker -> Assertions.assertNotEquals(0, broker.config().raw().size()));
+      Assertions.assertEquals(1, brokers.stream().filter(Broker::isController).count());
+      brokers.forEach(
+          broker -> Assertions.assertNotEquals(0, broker.topicPartitionLeaders().size()));
     }
   }
 


### PR DESCRIPTION
Admin#brokers 可以取得 partitions，但無法辨別是否為 leaders，因此這隻 PR 新增一個方法回傳 leader partitions