### PR TITLE
ETL:downgrade scala version to 2.12

### DIFF
--- a/etl/build.gradle
+++ b/etl/build.gradle
@@ -25,7 +25,7 @@ repositories {
 }
 
 def versions = [
-        scala: project.properties['scala.version'] ?: "2.13.7",
+        scala: project.properties['scala.version'] ?: "2.12.15",
         spark_sql: project.properties['spark_sql.version'] ?: "3.3.0",
         spark_kafka: project.properties['spark_kafka.version'] ?: "3.3.0",
         junit: project.properties['junit.version'] ?: "5.8.2",
@@ -34,8 +34,8 @@ def versions = [
 
 dependencies {
     implementation "org.scala-lang:scala-library:${versions["scala"]}"
-    implementation "org.apache.spark:spark-sql_2.13:${versions["spark_sql"]}"
-    implementation "org.apache.spark:spark-sql-kafka-0-10_2.13:${versions["spark_kafka"]}"
+    implementation "org.apache.spark:spark-sql_2.12:${versions["spark_sql"]}"
+    implementation "org.apache.spark:spark-sql-kafka-0-10_2.12:${versions["spark_kafka"]}"
 
     testImplementation "org.junit.jupiter:junit-jupiter:${versions["junit"]}"
     testImplementation "com.opencsv:opencsv:${versions["opencsv"]}"

--- a/etl/src/main/scala/org/astraea/etl/DeployModePattern.scala
+++ b/etl/src/main/scala/org/astraea/etl/DeployModePattern.scala
@@ -33,7 +33,7 @@ object DeployModePattern {
       extends DeployModePattern("spark://(.+):(\\d+)".r)
 
   def of(str: String): Boolean = {
-    all().exists(_.r matches str)
+    all().exists(_.r.findAllIn(str).hasNext)
   }
 
   def all() = {

--- a/etl/src/main/scala/org/astraea/etl/Metadata.scala
+++ b/etl/src/main/scala/org/astraea/etl/Metadata.scala
@@ -152,7 +152,7 @@ object Metadata {
 
   private[this] def readProp(path: File): Properties = {
     val properties = new Properties()
-    Utils.withResources(scala.io.Source.fromFile(path)) { bufferedSource =>
+    Utils.Using(scala.io.Source.fromFile(path)) { bufferedSource =>
       properties.load(bufferedSource.reader())
     }
     properties
@@ -222,7 +222,7 @@ object Metadata {
 
   //spark://host:port or local[*]
   def requireDeployMode(str: String, prop: Map[String, String]): String = {
-    if (!DeployModePattern.of(prop(str))) {
+    if (!DeployMode.deployMatch(prop(str))) {
       throw new IllegalArgumentException(
         s"${prop { str }} not a supported deployment model. Please check $str."
       )

--- a/etl/src/main/scala/org/astraea/etl/Metadata.scala
+++ b/etl/src/main/scala/org/astraea/etl/Metadata.scala
@@ -18,9 +18,7 @@ package org.astraea.etl
 
 import java.io.File
 import java.util.Properties
-import scala.jdk.CollectionConverters._
-import scala.util.Using
-import scala.util.matching.Regex
+import scala.collection.JavaConverters._
 
 /** Parameters required for Astraea ETL.
   *
@@ -154,7 +152,7 @@ object Metadata {
 
   private[this] def readProp(path: File): Properties = {
     val properties = new Properties()
-    Using(scala.io.Source.fromFile(path)) { bufferedSource =>
+    Utils.withResources(scala.io.Source.fromFile(path)) { bufferedSource =>
       properties.load(bufferedSource.reader())
     }
     properties
@@ -164,8 +162,9 @@ object Metadata {
       prop: Map[String, String],
       columnName: Map[String, DataType]
   ): Map[String, DataType] = {
+    val cols = columnName.keys.toArray
     val primaryKeys = requireNonidentical(PRIMARY_KEYS, prop)
-    val combine = primaryKeys.keys.toArray ++ columnName.keys.toArray
+    val combine = primaryKeys.keys.toArray ++ cols
     if (combine.distinct.length != columnName.size) {
       val column = columnName.keys.toArray
       throw new IllegalArgumentException(

--- a/etl/src/main/scala/org/astraea/etl/Utils.scala
+++ b/etl/src/main/scala/org/astraea/etl/Utils.scala
@@ -18,6 +18,7 @@ package org.astraea.etl
 
 import java.awt.geom.IllegalPathStateException
 import java.io.File
+import scala.util.control.NonFatal
 
 object Utils {
   def requireFolder(path: String): File = {
@@ -38,5 +39,39 @@ object Utils {
       )
     }
     file
+  }
+
+  /** Lack of means of try with resource in scala 2.12.So replace it with the
+    * following method.
+    */
+  def withResources[T <: AutoCloseable, V](r: => T)(f: T => V): V = {
+    val resource: T = r
+    require(resource != null, "resource is null")
+    var exception: Throwable = null
+    try {
+      f(resource)
+    } catch {
+      case NonFatal(e) =>
+        exception = e
+        throw e
+    } finally {
+      closeAndAddSuppressed(exception, resource)
+    }
+  }
+
+  private def closeAndAddSuppressed(
+      e: Throwable,
+      resource: AutoCloseable
+  ): Unit = {
+    if (e != null) {
+      try {
+        resource.close()
+      } catch {
+        case NonFatal(suppressed) =>
+          e.addSuppressed(suppressed)
+      }
+    } else {
+      resource.close()
+    }
   }
 }

--- a/etl/src/main/scala/org/astraea/etl/Utils.scala
+++ b/etl/src/main/scala/org/astraea/etl/Utils.scala
@@ -44,19 +44,16 @@ object Utils {
   /** Lack of means of try with resource in scala 2.12.So replace it with the
     * following method.
     */
-  def withResources[T <: AutoCloseable, V](r: => T)(f: T => V): V = {
+  def Using[T <: AutoCloseable, V](r: => T)(f: T => V): V = {
     val resource: T = r
     require(resource != null, "resource is null")
     var exception: Throwable = null
-    try {
-      f(resource)
-    } catch {
+    try f(resource)
+    catch {
       case NonFatal(e) =>
         exception = e
         throw e
-    } finally {
-      closeAndAddSuppressed(exception, resource)
-    }
+    } finally closeAndAddSuppressed(exception, resource)
   }
 
   private def closeAndAddSuppressed(

--- a/etl/src/test/scala/org/astraea/etl/CSVReaderTest.scala
+++ b/etl/src/test/scala/org/astraea/etl/CSVReaderTest.scala
@@ -19,15 +19,14 @@ package org.astraea.etl
 import com.opencsv.CSVWriter
 import org.apache.spark.SparkException
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.types.{StructType, TimestampType}
 import org.astraea.etl.DataType.{IntegerType, StringType}
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
 import java.io._
 import java.nio.file.Files
-import scala.jdk.CollectionConverters.IterableHasAsJava
 import scala.util.{Failure, Random, Try}
+import scala.collection.JavaConverters._
 
 class CSVReaderTest {
   @Test def createSchemaNullTest(): Unit = {

--- a/etl/src/test/scala/org/astraea/etl/DeployModeTest.scala
+++ b/etl/src/test/scala/org/astraea/etl/DeployModeTest.scala
@@ -16,27 +16,32 @@
  */
 package org.astraea.etl
 
-import scala.util.matching.Regex
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
 
-sealed abstract class DeployModePattern(pattern: Regex) {
-  def r: Regex = {
-    pattern
-  }
-}
+class DeployModeTest {
+  @Test def deployModePatternTest(): Unit = {
+    assert(!DeployMode.deployMatch(""))
+    assert(!DeployMode.deployMatch("123"))
+    assert(DeployMode.deployMatch("local[2]"))
 
-object DeployModePattern {
-  // Whether it is a local mode string.
-  case object LocalModePattern
-      extends DeployModePattern("local(\\[)[\\d{1}](])".r)
-  // Whether it is a standalone mode string.
-  case object StandAloneModePattern
-      extends DeployModePattern("spark://(.+):(\\d+)".r)
-
-  def of(str: String): Boolean = {
-    all().exists(_.r.findAllIn(str).hasNext)
+    assert(!DeployMode.deployMatch(""))
+    assert(!DeployMode.deployMatch("abc"))
+    assert(!DeployMode.deployMatch("spark://0.0.0.0"))
   }
 
-  def all() = {
-    Seq(LocalModePattern, StandAloneModePattern)
+  @Test def ofTest(): Unit = {
+    assertThrows(
+      classOf[IllegalArgumentException],
+      () => DeployMode.of("123xxx")
+    )
+    assertThrows(
+      classOf[IllegalArgumentException],
+      () => DeployMode.of("local")
+    )
+    assertThrows(
+      classOf[IllegalArgumentException],
+      () => DeployMode.of("spar://0.0.0.0")
+    )
   }
 }

--- a/etl/src/test/scala/org/astraea/etl/MetadataTest.scala
+++ b/etl/src/test/scala/org/astraea/etl/MetadataTest.scala
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.{BeforeEach, Test}
 import java.io.{File, FileOutputStream}
 import java.nio.file.Files.createTempFile
 import java.util.Properties
-import scala.util.{Try, Using}
+import scala.util.Try
 
 class MetadataTest {
   var file = new File("")
@@ -62,7 +62,7 @@ class MetadataTest {
 
   @Test def configuredTest(): Unit = {
     val prop = new Properties
-    Using(scala.io.Source.fromFile(file)) { bufferedSource =>
+    Utils.withResources(scala.io.Source.fromFile(file)) { bufferedSource =>
       prop.load(bufferedSource.reader())
     }
     prop.setProperty("topic.partitions", "30")

--- a/etl/src/test/scala/org/astraea/etl/MetadataTest.scala
+++ b/etl/src/test/scala/org/astraea/etl/MetadataTest.scala
@@ -62,7 +62,7 @@ class MetadataTest {
 
   @Test def configuredTest(): Unit = {
     val prop = new Properties
-    Utils.withResources(scala.io.Source.fromFile(file)) { bufferedSource =>
+    Utils.Using(scala.io.Source.fromFile(file)) { bufferedSource =>
       prop.load(bufferedSource.reader())
     }
     prop.setProperty("topic.partitions", "30")


### PR DESCRIPTION
因目前專案kafka使用的版本為scala2.12，為了能正常使用專案各功能，因此選擇降級scala版本到2.12。

scala2.12缺少try with resource，故新增該方法。另外還有一些小的scala2.12沒有實現的地方也做了對應修改。

這隻應該也會產生不少conflict，需要儘快meger。再麻煩學長有空的看看。
