### PR TITLE
Add leaders to BrokerTab

### DIFF
--- a/gui/src/main/java/org/astraea/gui/BrokerTab.java
+++ b/gui/src/main/java/org/astraea/gui/BrokerTab.java
@@ -44,43 +44,42 @@ public class BrokerTab {
                                 .map(
                                     node ->
                                         LinkedHashMap.of(
-                                            "hostname", node.host(),
-                                            "id", String.valueOf(node.id()),
-                                            "port", String.valueOf(node.port()),
-                                            "controller", String.valueOf(node.isController()),
+                                            "hostname",
+                                            node.host(),
+                                            "id",
+                                            String.valueOf(node.id()),
+                                            "port",
+                                            String.valueOf(node.port()),
+                                            "controller",
+                                            String.valueOf(node.isController()),
                                             "topics",
-                                                String.valueOf(
-                                                    node.folders().stream()
-                                                        .flatMap(
-                                                            d ->
-                                                                d.partitionSizes().keySet().stream()
-                                                                    .map(TopicPartition::topic))
-                                                        .distinct()
-                                                        .count()),
+                                            String.valueOf(
+                                                node.folders().stream()
+                                                    .flatMap(
+                                                        d ->
+                                                            d.partitionSizes().keySet().stream()
+                                                                .map(TopicPartition::topic))
+                                                    .distinct()
+                                                    .count()),
                                             "partitions",
-                                                String.valueOf(
-                                                    node.folders().stream()
-                                                        .flatMap(
-                                                            d ->
-                                                                d
-                                                                    .partitionSizes()
-                                                                    .keySet()
-                                                                    .stream())
-                                                        .distinct()
-                                                        .count()),
+                                            String.valueOf(
+                                                node.folders().stream()
+                                                    .flatMap(
+                                                        d -> d.partitionSizes().keySet().stream())
+                                                    .distinct()
+                                                    .count()),
+                                            "leaders",
+                                            String.valueOf(node.topicPartitionLeaders().size()),
                                             "size",
-                                                DataSize.Byte.of(
-                                                        node.folders().stream()
-                                                            .mapToLong(
-                                                                d ->
-                                                                    d
-                                                                        .partitionSizes()
-                                                                        .values()
-                                                                        .stream()
-                                                                        .mapToLong(v -> v)
-                                                                        .sum())
-                                                            .sum())
-                                                    .toString()))
+                                            DataSize.Byte.of(
+                                                    node.folders().stream()
+                                                        .mapToLong(
+                                                            d ->
+                                                                d.partitionSizes().values().stream()
+                                                                    .mapToLong(v -> v)
+                                                                    .sum())
+                                                        .sum())
+                                                .toString()))
                                 .collect(Collectors.toList()))
                     .orElse(List.of()));
     var tab = new Tab("broker");


### PR DESCRIPTION
<img width="591" alt="截圖 2022-10-02 下午4 20 46" src="https://user-images.githubusercontent.com/6234750/193444936-45278ffc-e529-45cd-bb1b-1b860435287a.png">

如上圖，會統計每個節點所負責的leaders數量