### PR TITLE
Replace String by DataSize

### DIFF
--- a/gui/src/main/java/org/astraea/gui/BrokerTab.java
+++ b/gui/src/main/java/org/astraea/gui/BrokerTab.java
@@ -55,14 +55,10 @@ public class BrokerTab {
                     broker.topicPartitionLeaders().size(),
                     "size",
                     DataSize.Byte.of(
-                            broker.folders().stream()
-                                .mapToLong(
-                                    d ->
-                                        d.partitionSizes().values().stream()
-                                            .mapToLong(v -> v)
-                                            .sum())
-                                .sum())
-                        .toString()))
+                        broker.folders().stream()
+                            .mapToLong(
+                                d -> d.partitionSizes().values().stream().mapToLong(v -> v).sum())
+                            .sum())))
         .collect(Collectors.toList());
   }
 

--- a/gui/src/main/java/org/astraea/gui/TopicTab.java
+++ b/gui/src/main/java/org/astraea/gui/TopicTab.java
@@ -67,8 +67,8 @@ public class TopicTab {
                     "replicas", tps.get(topic).stream().mapToInt(p -> p.replicas().size()).sum(),
                     "size",
                         Optional.ofNullable(topicSize.get(topic))
-                            .map(s -> DataSize.Byte.of(s).toString())
-                            .orElse("unknown"),
+                            .map(DataSize.Byte::of)
+                            .orElse(DataSize.Byte.of(0)),
                     "broker ids",
                         tps.get(topic).stream()
                             .flatMap(p -> p.replicas().stream().map(NodeInfo::id))

--- a/gui/src/main/java/org/astraea/gui/Utils.java
+++ b/gui/src/main/java/org/astraea/gui/Utils.java
@@ -188,9 +188,9 @@ class Utils {
               console.append("there is no result!!!");
               return;
             }
-            console.append("Applying result ... ");
+            console.append("result is applying");
             CompletableFuture.runAsync(() -> resultConsumer.accept(result, console))
-                .whenComplete((r, e) -> console.append(e));
+                .whenComplete((r, e) -> console.append("result is applied", e));
           });
 
     return vbox(


### PR DESCRIPTION
`DataSize` offers great `toString` and `Comparable` (thanks to @garyparrot), so we can replace `String` type by `DataSize` directly. The benefit is that we can not only sort the `DataSize` but also have human-readable content.