### PR TITLE
Add AsyncAdmin to fetch topic, partition and broker

### DIFF
--- a/common/src/main/java/org/astraea/common/Utils.java
+++ b/common/src/main/java/org/astraea/common/Utils.java
@@ -24,8 +24,10 @@ import java.util.Objects;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
@@ -153,6 +155,12 @@ public final class Utils {
     return value;
   }
 
+  public static short requirePositive(short value) {
+    if (value <= 0)
+      throw new IllegalArgumentException("the value: " + value + " must be bigger than zero");
+    return value;
+  }
+
   public static boolean notNegative(int value) {
     return value >= 0;
   }
@@ -210,6 +218,13 @@ public final class Utils {
   public static <T> CompletableFuture<List<T>> sequence(Collection<CompletableFuture<T>> futures) {
     return CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[0]))
         .thenApply(f -> futures.stream().map(CompletableFuture::join).collect(Collectors.toList()));
+  }
+
+  public static <T, U, V> CompletionStage<V> thenCombine(
+      CompletionStage<? extends T> from,
+      CompletionStage<? extends U> other,
+      BiFunction<? super T, ? super U, ? extends CompletionStage<V>> fn) {
+    return from.thenCompose(l -> other.thenCompose(r -> fn.apply(l, r)));
   }
 
   public static Object staticMember(Class<?> clz, String attribute) {

--- a/common/src/main/java/org/astraea/common/admin/Admin.java
+++ b/common/src/main/java/org/astraea/common/admin/Admin.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.astraea.common.Utils;
 
+@Deprecated
 public interface Admin extends Closeable {
 
   static Builder builder() {

--- a/common/src/main/java/org/astraea/common/admin/AsyncAdmin.java
+++ b/common/src/main/java/org/astraea/common/admin/AsyncAdmin.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.admin;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.KafkaAdminClient;
+
+public interface AsyncAdmin extends AutoCloseable {
+
+  static AsyncAdmin of(String bootstrap) {
+    return of(Map.of(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrap));
+  }
+
+  static AsyncAdmin of(Map<String, Object> configs) {
+    return of(KafkaAdminClient.create(configs));
+  }
+
+  static AsyncAdmin of(org.apache.kafka.clients.admin.Admin kafkaAdmin) {
+    return new AsyncAdminImpl(kafkaAdmin);
+  }
+
+  // ---------------------------------[readonly]---------------------------------//
+
+  /**
+   * @param listInternal should list internal topics or not
+   * @return names of topics
+   */
+  CompletionStage<Set<String>> topicNames(boolean listInternal);
+
+  CompletionStage<List<Topic>> topics(Set<String> topics);
+
+  /** delete topics by topic names */
+  CompletionStage<Void> deleteTopics(Set<String> topics);
+
+  /**
+   * @param topics target
+   * @return the partitions belong to input topics
+   */
+  CompletionStage<Set<TopicPartition>> topicPartitions(Set<String> topics);
+
+  /**
+   * list all partitions belongs to input brokers
+   *
+   * @param brokerId to search
+   * @return all partition belongs to brokers
+   */
+  CompletionStage<Set<TopicPartition>> topicPartitions(int brokerId);
+
+  CompletionStage<List<Partition>> partitions(Set<String> topics);
+
+  CompletionStage<Set<NodeInfo>> nodeInfos();
+
+  CompletionStage<List<Broker>> brokers();
+
+  // ---------------------------------[write]---------------------------------//
+
+  /** @return a topic creator to set all topic configs and then run the procedure. */
+  TopicCreator creator();
+}

--- a/common/src/main/java/org/astraea/common/admin/AsyncAdminImpl.java
+++ b/common/src/main/java/org/astraea/common/admin/AsyncAdminImpl.java
@@ -1,0 +1,352 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.admin;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.admin.ListTopicsOptions;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.config.ConfigResource;
+import org.astraea.common.Utils;
+
+class AsyncAdminImpl implements AsyncAdmin {
+
+  private final org.apache.kafka.clients.admin.Admin kafkaAdmin;
+
+  AsyncAdminImpl(org.apache.kafka.clients.admin.Admin kafkaAdmin) {
+    this.kafkaAdmin = kafkaAdmin;
+  }
+
+  private static <T> CompletionStage<T> to(org.apache.kafka.common.KafkaFuture<T> kafkaFuture) {
+    var f = new CompletableFuture<T>();
+    kafkaFuture.whenComplete(
+        (r, e) -> {
+          if (e != null) f.completeExceptionally(e);
+          else f.complete(r);
+        });
+    return f;
+  }
+
+  @Override
+  public CompletionStage<Set<String>> topicNames(boolean listInternal) {
+    return to(kafkaAdmin
+            .listTopics(new ListTopicsOptions().listInternal(listInternal))
+            .namesToListings())
+        .thenApply(Map::keySet);
+  }
+
+  @Override
+  public CompletionStage<List<Topic>> topics(Set<String> names) {
+    return to(kafkaAdmin
+            .describeConfigs(
+                names.stream()
+                    .map(topic -> new ConfigResource(ConfigResource.Type.TOPIC, topic))
+                    .collect(Collectors.toList()))
+            .all())
+        .thenApply(
+            r ->
+                r.entrySet().stream()
+                    .map(entry -> Topic.of(entry.getKey().name(), entry.getValue()))
+                    .collect(Collectors.toUnmodifiableList()));
+  }
+
+  @Override
+  public CompletionStage<Void> deleteTopics(Set<String> topics) {
+    return to(kafkaAdmin.deleteTopics(topics).all());
+  }
+
+  @Override
+  public CompletionStage<Set<TopicPartition>> topicPartitions(Set<String> topics) {
+    return to(kafkaAdmin.describeTopics(topics).all())
+        .thenApply(
+            r ->
+                r.entrySet().stream()
+                    .flatMap(
+                        entry ->
+                            entry.getValue().partitions().stream()
+                                .map(p -> TopicPartition.of(entry.getKey(), p.partition())))
+                    .collect(Collectors.toSet()));
+  }
+
+  @Override
+  public CompletionStage<Set<TopicPartition>> topicPartitions(int brokerId) {
+    return topicNames(true)
+        .thenCompose(topics -> to(kafkaAdmin.describeTopics(topics).all()))
+        .thenApply(
+            r ->
+                r.entrySet().stream()
+                    .flatMap(
+                        entry ->
+                            entry.getValue().partitions().stream()
+                                .filter(
+                                    p -> p.replicas().stream().anyMatch(n -> n.id() == brokerId))
+                                .map(p -> TopicPartition.of(entry.getKey(), p.partition())))
+                    .collect(Collectors.toSet()));
+  }
+
+  @Override
+  public CompletionStage<List<Partition>> partitions(Set<String> topics) {
+    return to(kafkaAdmin.describeTopics(topics).all())
+        .thenApply(
+            ts ->
+                ts.entrySet().stream()
+                    .flatMap(
+                        e ->
+                            e.getValue().partitions().stream()
+                                .map(
+                                    tp ->
+                                        Map.entry(
+                                            new org.apache.kafka.common.TopicPartition(
+                                                e.getKey(), tp.partition()),
+                                            tp)))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
+        .thenCompose(
+            partitions ->
+                to(kafkaAdmin
+                        .listOffsets(
+                            partitions.keySet().stream()
+                                .collect(
+                                    Collectors.toMap(
+                                        Function.identity(), e -> new OffsetSpec.EarliestSpec())))
+                        .all())
+                    .thenCompose(
+                        earliest ->
+                            to(kafkaAdmin
+                                    .listOffsets(
+                                        partitions.keySet().stream()
+                                            .collect(
+                                                Collectors.toMap(
+                                                    Function.identity(),
+                                                    e -> new OffsetSpec.LatestSpec())))
+                                    .all())
+                                .thenCompose(
+                                    latest ->
+                                        to(kafkaAdmin
+                                                .listOffsets(
+                                                    partitions.keySet().stream()
+                                                        .collect(
+                                                            Collectors.toMap(
+                                                                Function.identity(),
+                                                                e ->
+                                                                    new OffsetSpec
+                                                                        .MaxTimestampSpec())))
+                                                .all())
+                                            .thenApply(
+                                                maxTimestamp ->
+                                                    partitions.entrySet().stream()
+                                                        .map(
+                                                            entry ->
+                                                                Partition.of(
+                                                                    entry.getKey().topic(),
+                                                                    entry.getValue(),
+                                                                    Optional.ofNullable(
+                                                                        earliest.get(
+                                                                            entry.getKey())),
+                                                                    Optional.ofNullable(
+                                                                        latest.get(entry.getKey())),
+                                                                    Optional.ofNullable(
+                                                                        maxTimestamp.get(
+                                                                            entry.getKey()))))
+                                                        .collect(Collectors.toList())))));
+  }
+
+  @Override
+  public CompletionStage<Set<NodeInfo>> nodeInfos() {
+    return to(kafkaAdmin.describeCluster().nodes())
+        .thenApply(
+            nodes -> nodes.stream().map(NodeInfo::of).collect(Collectors.toUnmodifiableSet()));
+  }
+
+  @Override
+  public CompletionStage<List<Broker>> brokers() {
+    var cluster = kafkaAdmin.describeCluster();
+    return to(cluster.controller())
+        .thenCompose(
+            controller ->
+                to(cluster.nodes())
+                    .thenCompose(
+                        nodes ->
+                            to(kafkaAdmin
+                                    .describeLogDirs(
+                                        nodes.stream().map(Node::id).collect(Collectors.toList()))
+                                    .all())
+                                .thenCompose(
+                                    logDirs ->
+                                        to(kafkaAdmin
+                                                .describeConfigs(
+                                                    nodes.stream()
+                                                        .map(
+                                                            n ->
+                                                                new ConfigResource(
+                                                                    ConfigResource.Type.BROKER,
+                                                                    String.valueOf(n.id())))
+                                                        .collect(Collectors.toList()))
+                                                .all())
+                                            .thenApply(
+                                                configs ->
+                                                    configs.entrySet().stream()
+                                                        .collect(
+                                                            Collectors.toMap(
+                                                                e ->
+                                                                    Integer.valueOf(
+                                                                        e.getKey().name()),
+                                                                Map.Entry::getValue)))
+                                            .thenCompose(
+                                                configs ->
+                                                    topicNames(true)
+                                                        .thenCompose(
+                                                            names ->
+                                                                to(
+                                                                    kafkaAdmin
+                                                                        .describeTopics(names)
+                                                                        .all()))
+                                                        .thenApply(
+                                                            topics ->
+                                                                nodes.stream()
+                                                                    .map(
+                                                                        node ->
+                                                                            Broker.of(
+                                                                                node.id()
+                                                                                    == controller
+                                                                                        .id(),
+                                                                                node,
+                                                                                configs.get(
+                                                                                    node.id()),
+                                                                                logDirs.get(
+                                                                                    node.id()),
+                                                                                topics.values()))
+                                                                    .collect(
+                                                                        Collectors.toList()))))));
+  }
+
+  @Override
+  public TopicCreator creator() {
+    return new TopicCreator() {
+      private String topic;
+      private int numberOfPartitions = 1;
+      private short numberOfReplicas = 1;
+      private Map<String, String> configs = Map.of();
+
+      @Override
+      public TopicCreator topic(String topic) {
+        this.topic = topic;
+        return this;
+      }
+
+      @Override
+      public TopicCreator numberOfPartitions(int numberOfPartitions) {
+        this.numberOfPartitions = numberOfPartitions;
+        return this;
+      }
+
+      @Override
+      public TopicCreator numberOfReplicas(short numberOfReplicas) {
+        this.numberOfReplicas = numberOfReplicas;
+        return this;
+      }
+
+      @Override
+      public TopicCreator configs(Map<String, String> configs) {
+        this.configs = configs;
+        return this;
+      }
+
+      @Override
+      public CompletionStage<Boolean> run() {
+        Utils.requireNonEmpty(topic);
+        Utils.requirePositive(numberOfPartitions);
+        Utils.requirePositive(numberOfReplicas);
+        Objects.requireNonNull(configs);
+
+        return topicNames(true)
+            .thenCompose(
+                names -> {
+                  if (!names.contains(topic))
+                    return to(kafkaAdmin
+                            .createTopics(
+                                List.of(
+                                    new NewTopic(topic, numberOfPartitions, numberOfReplicas)
+                                        .configs(configs)))
+                            .all())
+                        .thenApply(r -> true);
+                  return topics(Set.of(topic))
+                      .thenCombine(
+                          partitions(Set.of(topic)),
+                          (ts, partitions) -> {
+                            if (partitions.size() != numberOfPartitions)
+                              throw new IllegalArgumentException(
+                                  topic
+                                      + " is existent but its partitions: "
+                                      + partitions.size()
+                                      + " is not equal to expected: "
+                                      + numberOfPartitions);
+                            partitions.forEach(
+                                p -> {
+                                  if (p.replicas().size() != numberOfReplicas)
+                                    throw new IllegalArgumentException(
+                                        topic
+                                            + " is existent but its replicas: "
+                                            + p.replicas().size()
+                                            + " is not equal to expected: "
+                                            + numberOfReplicas);
+                                });
+
+                            ts.stream()
+                                .filter(t -> t.name().equals(topic))
+                                .map(Topic::config)
+                                .forEach(
+                                    existentConfigs ->
+                                        configs.forEach(
+                                            (k, v) -> {
+                                              if (existentConfigs
+                                                  .value(k)
+                                                  .filter(actual -> actual.equals(v))
+                                                  .isEmpty())
+                                                throw new IllegalArgumentException(
+                                                    topic
+                                                        + " is existent but its config: <"
+                                                        + k
+                                                        + ", "
+                                                        + existentConfigs.value(k)
+                                                        + "> is not equal to expected: "
+                                                        + k
+                                                        + ", "
+                                                        + v);
+                                            }));
+
+                            // there is equal topic
+                            return false;
+                          });
+                });
+      }
+    };
+  }
+
+  @Override
+  public void close() {
+    kafkaAdmin.close();
+  }
+}

--- a/common/src/main/java/org/astraea/common/admin/Broker.java
+++ b/common/src/main/java/org/astraea/common/admin/Broker.java
@@ -21,14 +21,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.kafka.common.requests.DescribeLogDirsResponse;
 
 public interface Broker extends NodeInfo {
 
   static Broker of(
       boolean isController,
-      org.astraea.common.admin.NodeInfo nodeInfo,
+      org.apache.kafka.common.Node nodeInfo,
       org.apache.kafka.clients.admin.Config kafkaConfig,
-      Map<String, org.apache.kafka.clients.admin.LogDirDescription> dirs,
+      Map<String, DescribeLogDirsResponse.LogDirInfo> dirs,
       Collection<org.apache.kafka.clients.admin.TopicDescription> topics) {
     var config = Config.of(kafkaConfig);
     var folders =
@@ -37,10 +38,10 @@ public interface Broker extends NodeInfo {
                 entry -> {
                   var path = entry.getKey();
                   var tpAndSize =
-                      entry.getValue().replicaInfos().entrySet().stream()
+                      entry.getValue().replicaInfos.entrySet().stream()
                           .collect(
                               Collectors.toUnmodifiableMap(
-                                  e -> TopicPartition.from(e.getKey()), e -> e.getValue().size()));
+                                  e -> TopicPartition.from(e.getKey()), e -> e.getValue().size));
                   return (DataFolder)
                       new DataFolder() {
 

--- a/common/src/main/java/org/astraea/common/admin/TopicCreator.java
+++ b/common/src/main/java/org/astraea/common/admin/TopicCreator.java
@@ -49,6 +49,7 @@ public interface TopicCreator {
   TopicCreator configs(Map<String, String> configs);
 
   /** start to create topic. */
+  @Deprecated
   default void create() {
     Utils.packException(() -> run().toCompletableFuture().get());
   }

--- a/common/src/main/java/org/astraea/common/admin/TopicCreator.java
+++ b/common/src/main/java/org/astraea/common/admin/TopicCreator.java
@@ -16,42 +16,31 @@
  */
 package org.astraea.common.admin;
 
-import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.CompletionStage;
 import org.apache.kafka.common.config.TopicConfig;
+import org.astraea.common.Utils;
 
 public interface TopicCreator {
+
+  // ---------------------------------[keys]---------------------------------//
+
+  String CLEANUP_POLICY_CONFIG = TopicConfig.CLEANUP_POLICY_CONFIG;
+  String MAX_COMPACTION_LAG_MS_CONFIG = TopicConfig.MAX_COMPACTION_LAG_MS_CONFIG;
+  String COMPRESSION_TYPE_CONFIG = TopicConfig.COMPRESSION_TYPE_CONFIG;
+
+  // ---------------------------------[values]---------------------------------//
+
+  String CLEANUP_POLICY_COMPACT = TopicConfig.CLEANUP_POLICY_COMPACT;
+  String CLEANUP_POLICY_DELETE = TopicConfig.CLEANUP_POLICY_DELETE;
+
+  // ---------------------------------[methods]---------------------------------//
+
   TopicCreator topic(String topic);
 
   TopicCreator numberOfPartitions(int numberOfPartitions);
 
   TopicCreator numberOfReplicas(short numberOfReplicas);
-
-  /**
-   * set the cleanup policy to compact. By default, the policy is `delete`/
-   *
-   * @return this creator
-   */
-  default TopicCreator compacted() {
-    return config(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT);
-  }
-
-  /**
-   * the max time to make segments be eligible for compaction.
-   *
-   * @param value the max lag
-   * @return this creator
-   */
-  default TopicCreator compactionMaxLag(Duration value) {
-    return compacted()
-        .config(TopicConfig.MAX_COMPACTION_LAG_MS_CONFIG, String.valueOf(value.toMillis()));
-  }
-
-  default TopicCreator compression(Compression compression) {
-    return config(TopicConfig.COMPRESSION_TYPE_CONFIG, compression.nameOfKafka());
-  }
-
-  TopicCreator config(String key, String value);
 
   /**
    * @param configs used to create new topic
@@ -60,5 +49,9 @@ public interface TopicCreator {
   TopicCreator configs(Map<String, String> configs);
 
   /** start to create topic. */
-  void create();
+  default void create() {
+    Utils.packException(() -> run().toCompletableFuture().get());
+  }
+
+  CompletionStage<Boolean> run();
 }


### PR DESCRIPTION
原先封裝的`Admin`為了方便將所有 async 都封裝成 sync，這在大量操作下會有大量執行緒彼此等待的問題，因此我們新增一個`AsyncAdmin`，它保持非同步的操作，並且將物件重新封裝回 astraea object 