### PR TITLE
Add consumer constants

### DIFF
--- a/common/src/main/java/org/astraea/common/consumer/Builder.java
+++ b/common/src/main/java/org/astraea/common/consumer/Builder.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.astraea.common.EnumInfo;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.TopicPartition;
@@ -47,7 +46,7 @@ public abstract class Builder<Key, Value> {
    * @return this builder
    */
   public Builder<Key, Value> fromBeginning() {
-    this.configs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    this.configs.put(Consumer.AUTO_OFFSET_RESET_CONFIG, "earliest");
     return this;
   }
 
@@ -57,7 +56,7 @@ public abstract class Builder<Key, Value> {
    * @return this builder
    */
   public Builder<Key, Value> fromLatest() {
-    this.configs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+    this.configs.put(Consumer.AUTO_OFFSET_RESET_CONFIG, "latest");
     return this;
   }
 
@@ -106,17 +105,17 @@ public abstract class Builder<Key, Value> {
   }
 
   public Builder<Key, Value> bootstrapServers(String bootstrapServers) {
-    this.configs.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, requireNonNull(bootstrapServers));
+    this.configs.put(Consumer.BOOTSTRAP_SERVERS_CONFIG, requireNonNull(bootstrapServers));
     return this;
   }
 
   public Builder<Key, Value> isolation(Isolation isolation) {
-    this.configs.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, isolation.nameOfKafka());
+    this.configs.put(Consumer.ISOLATION_LEVEL_CONFIG, isolation.nameOfKafka());
     return this;
   }
 
   public Builder<Key, Value> clientId(String clientId) {
-    this.configs.put(ConsumerConfig.CLIENT_ID_CONFIG, clientId);
+    this.configs.put(Consumer.CLIENT_ID_CONFIG, clientId);
     return this;
   }
 

--- a/common/src/main/java/org/astraea/common/consumer/Consumer.java
+++ b/common/src/main/java/org/astraea/common/consumer/Consumer.java
@@ -24,6 +24,47 @@ import org.astraea.common.admin.TopicPartition;
 /** An interface for polling records. */
 public interface Consumer<Key, Value> extends AutoCloseable {
 
+  String GROUP_ID_CONFIG = "group.id";
+  String GROUP_INSTANCE_ID_CONFIG = "group.instance.id";
+  String MAX_POLL_RECORDS_CONFIG = "max.poll.records";
+  String MAX_POLL_INTERVAL_MS_CONFIG = "max.poll.interval.ms";
+  String SESSION_TIMEOUT_MS_CONFIG = "session.timeout.ms";
+  String HEARTBEAT_INTERVAL_MS_CONFIG = "heartbeat.interval.ms";
+  String BOOTSTRAP_SERVERS_CONFIG = "bootstrap.servers";
+  String CLIENT_DNS_LOOKUP_CONFIG = "client.dns.lookup";
+  String ENABLE_AUTO_COMMIT_CONFIG = "enable.auto.commit";
+  String AUTO_COMMIT_INTERVAL_MS_CONFIG = "auto.commit.interval.ms";
+  String PARTITION_ASSIGNMENT_STRATEGY_CONFIG = "partition.assignment.strategy";
+  String AUTO_OFFSET_RESET_CONFIG = "auto.offset.reset";
+  String FETCH_MIN_BYTES_CONFIG = "fetch.min.bytes";
+  String FETCH_MAX_BYTES_CONFIG = "fetch.max.bytes";
+  String FETCH_MAX_WAIT_MS_CONFIG = "fetch.max.wait.ms";
+  String METADATA_MAX_AGE_CONFIG = "metadata.max.age.ms";
+  String MAX_PARTITION_FETCH_BYTES_CONFIG = "max.partition.fetch.bytes";
+  String SEND_BUFFER_CONFIG = "send.buffer.bytes";
+  String RECEIVE_BUFFER_CONFIG = "receive.buffer.bytes";
+  String CLIENT_ID_CONFIG = "client.id";
+  String CLIENT_RACK_CONFIG = "client.rack";
+  String RECONNECT_BACKOFF_MS_CONFIG = "reconnect.backoff.ms";
+  String RECONNECT_BACKOFF_MAX_MS_CONFIG = "reconnect.backoff.max.ms";
+  String RETRY_BACKOFF_MS_CONFIG = "retry.backoff.ms";
+  String METRICS_SAMPLE_WINDOW_MS_CONFIG = "metrics.sample.window.ms";
+  String METRICS_NUM_SAMPLES_CONFIG = "metrics.num.samples";
+  String METRICS_RECORDING_LEVEL_CONFIG = "metrics.recording.level";
+  String METRIC_REPORTER_CLASSES_CONFIG = "metric.reporters";
+  String CHECK_CRCS_CONFIG = "check.crcs";
+  String KEY_DESERIALIZER_CLASS_CONFIG = "key.deserializer";
+  String VALUE_DESERIALIZER_CLASS_CONFIG = "value.deserializer";
+  String SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG = "socket.connection.setup.timeout.ms";
+  String SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG = "socket.connection.setup.timeout.max.ms";
+  String CONNECTIONS_MAX_IDLE_MS_CONFIG = "connections.max.idle.ms";
+  String REQUEST_TIMEOUT_MS_CONFIG = "request.timeout.ms";
+  String DEFAULT_API_TIMEOUT_MS_CONFIG = "default.api.timeout.ms";
+  String INTERCEPTOR_CLASSES_CONFIG = "interceptor.classes";
+  String EXCLUDE_INTERNAL_TOPICS_CONFIG = "exclude.internal.topics";
+  String ISOLATION_LEVEL_CONFIG = "isolation.level";
+  String ALLOW_AUTO_CREATE_TOPICS_CONFIG = "allow.auto.create.topics";
+
   default Collection<Record<Key, Value>> poll(Duration timeout) {
     return poll(1, timeout);
   }

--- a/common/src/main/java/org/astraea/common/consumer/TopicsBuilder.java
+++ b/common/src/main/java/org/astraea/common/consumer/TopicsBuilder.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.TopicPartition;
@@ -40,11 +39,11 @@ public class TopicsBuilder<Key, Value> extends Builder<Key, Value> {
   }
 
   public TopicsBuilder<Key, Value> groupId(String groupId) {
-    return config(ConsumerConfig.GROUP_ID_CONFIG, requireNonNull(groupId));
+    return config(Consumer.GROUP_ID_CONFIG, requireNonNull(groupId));
   }
 
   public TopicsBuilder<Key, Value> groupInstanceId(String groupInstanceId) {
-    return config(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, requireNonNull(groupInstanceId));
+    return config(Consumer.GROUP_INSTANCE_ID_CONFIG, requireNonNull(groupInstanceId));
   }
 
   public TopicsBuilder<Key, Value> consumerRebalanceListener(ConsumerRebalanceListener listener) {
@@ -121,7 +120,7 @@ public class TopicsBuilder<Key, Value> extends Builder<Key, Value> {
   }
 
   public TopicsBuilder<Key, Value> disableAutoCommitOffsets() {
-    return config(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+    return config(Consumer.ENABLE_AUTO_COMMIT_CONFIG, "false");
   }
 
   @Override
@@ -134,7 +133,7 @@ public class TopicsBuilder<Key, Value> extends Builder<Key, Value> {
   @Override
   public SubscribedConsumer<Key, Value> build() {
     // generate group id if it is empty
-    configs.putIfAbsent(ConsumerConfig.GROUP_ID_CONFIG, "groupId-" + System.currentTimeMillis());
+    configs.putIfAbsent(Consumer.GROUP_ID_CONFIG, "groupId-" + System.currentTimeMillis());
 
     var kafkaConsumer =
         new KafkaConsumer<>(


### PR DESCRIPTION
把一些可用的 consumer 參數字串添加到 consuemr，這樣會方便日後取用，也能避免直接引入 kafka config