### PR TITLE
Fix AsyncAdmin can't get partitions when there is offline node

### DIFF
--- a/common/src/main/java/org/astraea/common/admin/AsyncAdmin.java
+++ b/common/src/main/java/org/astraea/common/admin/AsyncAdmin.java
@@ -68,8 +68,10 @@ public interface AsyncAdmin extends AutoCloseable {
 
   CompletionStage<List<Partition>> partitions(Set<String> topics);
 
+  /** @return online node information */
   CompletionStage<Set<NodeInfo>> nodeInfos();
 
+  /** @return online broker information */
   CompletionStage<List<Broker>> brokers();
 
   default CompletionStage<Map<Integer, Set<String>>> brokerFolders() {

--- a/common/src/main/java/org/astraea/common/admin/NodeInfo.java
+++ b/common/src/main/java/org/astraea/common/admin/NodeInfo.java
@@ -26,6 +26,11 @@ public interface NodeInfo {
 
   static NodeInfo of(int id, String host, int port) {
     return new NodeInfo() {
+      @Override
+      public String toString() {
+        return "NodeInfo{" + "host=" + host + ", id=" + id + ", port=" + port + '}';
+      }
+
       // NodeInfo is used to be key of Map commonly, so creating hash can reduce the memory pressure
       private final int hashCode = Objects.hash(id, host, port);
 
@@ -68,4 +73,9 @@ public interface NodeInfo {
 
   /** @return id of broker node. it must be unique. */
   int id();
+
+  /** @return true if the node is offline. An offline node can't offer host or port information. */
+  default boolean offline() {
+    return host() == null || host().isEmpty() || port() < 0;
+  }
 }

--- a/common/src/main/java/org/astraea/common/admin/Partition.java
+++ b/common/src/main/java/org/astraea/common/admin/Partition.java
@@ -33,7 +33,7 @@ public interface Partition {
     return of(
         topic,
         tpi.partition(),
-        NodeInfo.of(tpi.leader()),
+        tpi.leader() == null ? null : NodeInfo.of(tpi.leader()),
         tpi.replicas().stream().map(NodeInfo::of).collect(Collectors.toList()),
         tpi.isr().stream().map(NodeInfo::of).collect(Collectors.toList()),
         earliest.map(ListOffsetsResult.ListOffsetsResultInfo::offset).orElse(-1L),
@@ -78,8 +78,8 @@ public interface Partition {
       }
 
       @Override
-      public NodeInfo leader() {
-        return leader;
+      public Optional<NodeInfo> leader() {
+        return Optional.ofNullable(leader);
       }
 
       @Override
@@ -111,7 +111,8 @@ public interface Partition {
   /** @return max timestamp of existent records */
   long maxTimestamp();
 
-  NodeInfo leader();
+  /** @return null if the node gets offline. otherwise, it returns node info. */
+  Optional<NodeInfo> leader();
 
   List<NodeInfo> replicas();
 

--- a/common/src/test/java/org/astraea/common/admin/AsyncAdminTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AsyncAdminTest.java
@@ -43,7 +43,7 @@ public class AsyncAdminTest extends RequireBrokerCluster {
 
       var ids =
           brokerIds().stream()
-              .filter(i -> i != partition.leader().id())
+              .filter(i -> i != partition.leader().get().id())
               .collect(Collectors.toList());
       admin.migrator().topic(topic).moveTo(ids).toCompletableFuture().get();
       Utils.sleep(Duration.ofSeconds(2));
@@ -53,7 +53,7 @@ public class AsyncAdminTest extends RequireBrokerCluster {
       var newPartition = newPartitions.get(0);
       Assertions.assertEquals(ids.size(), newPartition.replicas().size());
       Assertions.assertEquals(ids.size(), newPartition.isr().size());
-      Assertions.assertEquals(ids.get(0), newPartition.leader().id());
+      Assertions.assertEquals(ids.get(0), newPartition.leader().get().id());
     }
   }
 
@@ -70,8 +70,11 @@ public class AsyncAdminTest extends RequireBrokerCluster {
       Assertions.assertEquals(1, partition.replicas().size());
       var ids =
           List.of(
-              brokerIds().stream().filter(i -> i != partition.leader().id()).findFirst().get(),
-              partition.leader().id());
+              brokerIds().stream()
+                  .filter(i -> i != partition.leader().get().id())
+                  .findFirst()
+                  .get(),
+              partition.leader().get().id());
       admin.migrator().topic(topic).moveTo(ids).toCompletableFuture().get();
       Utils.sleep(Duration.ofSeconds(2));
 
@@ -80,7 +83,7 @@ public class AsyncAdminTest extends RequireBrokerCluster {
       var newPartition = newPartitions.get(0);
       Assertions.assertEquals(ids.size(), newPartition.replicas().size());
       Assertions.assertEquals(ids.size(), newPartition.isr().size());
-      Assertions.assertNotEquals(ids.get(0), newPartition.leader().id());
+      Assertions.assertNotEquals(ids.get(0), newPartition.leader().get().id());
 
       admin
           .preferredLeaderElection(TopicPartition.of(partition.topic(), partition.partition()))
@@ -88,7 +91,7 @@ public class AsyncAdminTest extends RequireBrokerCluster {
           .get();
       Assertions.assertEquals(
           ids.get(0),
-          admin.partitions(Set.of(topic)).toCompletableFuture().get().get(0).leader().id());
+          admin.partitions(Set.of(topic)).toCompletableFuture().get().get(0).leader().get().id());
     }
   }
 

--- a/common/src/test/java/org/astraea/common/admin/AsyncAdminWithOfflineBrokerTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AsyncAdminWithOfflineBrokerTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.admin;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import org.astraea.common.Utils;
+import org.astraea.it.RequireBrokerCluster;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+public class AsyncAdminWithOfflineBrokerTest extends RequireBrokerCluster {
+
+  private static final String TOPIC_NAME = Utils.randomString();
+  private static final int CLOSED_BROKER_ID = brokerIds().iterator().next();
+
+  @BeforeAll
+  static void closeOneBroker() throws ExecutionException, InterruptedException {
+    try (var admin = AsyncAdmin.of(bootstrapServers())) {
+      admin.creator().topic(TOPIC_NAME).numberOfPartitions(10).run().toCompletableFuture().get();
+      var allPs = admin.partitions(Set.of(TOPIC_NAME)).toCompletableFuture().get();
+      Assertions.assertEquals(10, allPs.size());
+      Utils.sleep(Duration.ofSeconds(2));
+    }
+    closeBroker(CLOSED_BROKER_ID);
+  }
+
+  @Timeout(10)
+  @Test
+  void testNodeInfos() throws ExecutionException, InterruptedException {
+    try (var admin = AsyncAdmin.of(bootstrapServers())) {
+      var nodeInfos = admin.nodeInfos().toCompletableFuture().get();
+      Assertions.assertEquals(2, nodeInfos.size());
+      var offlineNodeInfos =
+          nodeInfos.stream().filter(NodeInfo::offline).collect(Collectors.toList());
+      Assertions.assertEquals(0, offlineNodeInfos.size());
+    }
+  }
+
+  @Timeout(10)
+  @Test
+  void testBrokers() throws ExecutionException, InterruptedException {
+    try (var admin = AsyncAdmin.of(bootstrapServers())) {
+      var brokers = admin.brokers().toCompletableFuture().get();
+      Assertions.assertEquals(2, brokers.size());
+      brokers.forEach(
+          b ->
+              b.folders()
+                  .forEach(d -> Assertions.assertEquals(0, d.orphanPartitionSizes().size())));
+      var offlineBrokers = brokers.stream().filter(NodeInfo::offline).collect(Collectors.toList());
+      Assertions.assertEquals(0, offlineBrokers.size());
+    }
+  }
+
+  @Timeout(10)
+  @Test
+  void testPartitions() throws ExecutionException, InterruptedException {
+    try (var admin = AsyncAdmin.of(bootstrapServers())) {
+      var partitions = admin.partitions(Set.of(TOPIC_NAME)).toCompletableFuture().get();
+      Assertions.assertEquals(10, partitions.size());
+      var offlinePartitions =
+          partitions.stream().filter(p -> p.leader().isEmpty()).collect(Collectors.toList());
+      offlinePartitions.forEach(
+          p -> {
+            Assertions.assertEquals(1, p.replicas().size());
+            p.replicas().forEach(n -> Assertions.assertTrue(n.offline()));
+            // there is no more data, so all replicas are in-sync
+            Assertions.assertEquals(1, p.isr().size());
+            p.isr().forEach(n -> Assertions.assertTrue(n.offline()));
+          });
+      Assertions.assertNotEquals(0, offlinePartitions.size());
+    }
+  }
+
+  @Timeout(10)
+  @Test
+  void testReplicas() throws ExecutionException, InterruptedException {
+    try (var admin = AsyncAdmin.of(bootstrapServers())) {
+      var replicas = admin.replicas(Set.of(TOPIC_NAME)).toCompletableFuture().get();
+      Assertions.assertEquals(10, replicas.size());
+      var offlineReplicas =
+          replicas.stream().filter(ReplicaInfo::isOffline).collect(Collectors.toList());
+      offlineReplicas.forEach(r -> Assertions.assertTrue(r.nodeInfo().offline()));
+      Assertions.assertNotEquals(0, offlineReplicas.size());
+    }
+  }
+
+  @Timeout(10)
+  @Test
+  void testTopicPartitions() throws ExecutionException, InterruptedException {
+    try (var admin = AsyncAdmin.of(bootstrapServers())) {
+      Assertions.assertNotEquals(
+          0, admin.topicPartitions(CLOSED_BROKER_ID).toCompletableFuture().get().size());
+      Assertions.assertNotEquals(
+          0, admin.topicPartitions(Set.of(TOPIC_NAME)).toCompletableFuture().get().size());
+    }
+  }
+
+  @Timeout(10)
+  @Test
+  void testTopicNames() throws ExecutionException, InterruptedException {
+    try (var admin = AsyncAdmin.of(bootstrapServers())) {
+      Assertions.assertEquals(1, admin.topicNames(false).toCompletableFuture().get().size());
+    }
+  }
+
+  @Timeout(10)
+  @Test
+  void testTopics() throws ExecutionException, InterruptedException {
+    try (var admin = AsyncAdmin.of(bootstrapServers())) {
+      Assertions.assertEquals(
+          1, admin.topics(Set.of(TOPIC_NAME)).toCompletableFuture().get().size());
+    }
+  }
+}

--- a/common/src/test/java/org/astraea/common/admin/ClusterInfoWithOfflineNodeTest.java
+++ b/common/src/test/java/org/astraea/common/admin/ClusterInfoWithOfflineNodeTest.java
@@ -19,6 +19,7 @@ package org.astraea.common.admin;
 import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 import org.astraea.common.Utils;
 import org.astraea.it.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
@@ -70,6 +71,12 @@ public class ClusterInfoWithOfflineNodeTest extends RequireBrokerCluster {
       Assertions.assertTrue(
           after.replicaLeaders(topicName).stream()
               .allMatch(x -> x.nodeInfo().id() != brokerToClose));
+      System.out.println(
+          "[CHIA] "
+              + after.replicas(topicName).stream()
+                  .filter(ReplicaInfo::isOffline)
+                  .map(r -> r.nodeInfo().id())
+                  .collect(Collectors.toList()));
       Assertions.assertTrue(
           after.replicas(topicName).stream()
               .filter(ReplicaInfo::isOffline)

--- a/gui/src/main/java/org/astraea/gui/PartitionTab.java
+++ b/gui/src/main/java/org/astraea/gui/PartitionTab.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javafx.scene.control.Tab;
 import org.astraea.common.LinkedHashMap;
+import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.Partition;
 
 public class PartitionTab {
@@ -36,7 +37,7 @@ public class PartitionTab {
                     "partition",
                     p.partition(),
                     "leader",
-                    p.leader().id(),
+                    p.leader().map(NodeInfo::id).orElse(-1),
                     "replicas",
                     p.replicas().stream()
                         .map(n -> String.valueOf(n.id()))


### PR DESCRIPTION
Kafka admin 更新 metadata 的時候是以 topic 為單位，因此如果有些操作需要更新 metadata (例如 listOffsets)時就可能因為 offline node 並且只有一個 replica 時而卡住