### PR TITLE
Fix flaky `BalancerHandlerTest#testRebalanceDetectOngoing`

### DIFF
--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -457,8 +457,17 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
 
   @Test
   void testRebalanceDetectOngoing() {
-    final String theTopic = createAndProduceTopic(1).get(0);
     try (var admin = Admin.of(bootstrapServers())) {
+      var theTopic = Utils.randomString();
+      admin.creator().topic(theTopic).numberOfPartitions(1).run().toCompletableFuture().join();
+      try (var producer = Producer.of(bootstrapServers())) {
+        var dummy = new byte[1024];
+        IntStream.range(0, 100000)
+            .mapToObj(i -> producer.sender().topic(theTopic).value(dummy).run())
+            .collect(Collectors.toUnmodifiableSet())
+            .forEach(i -> i.toCompletableFuture().join());
+      }
+
       var handler =
           new BalancerHandler(
               admin,
@@ -474,7 +483,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
 
       // create an ongoing reassignment
       admin.migrator().partition(theTopic, 0).moveTo(List.of(0, 1, 2));
-      Utils.sleep(Duration.ofMillis(500));
+      Utils.sleep(Duration.ofMillis(50));
 
       Assertions.assertThrows(
           IllegalStateException.class,

--- a/common/src/main/java/org/astraea/common/Utils.java
+++ b/common/src/main/java/org/astraea/common/Utils.java
@@ -129,23 +129,29 @@ public final class Utils {
     waitForNonNull(() -> done.get() ? "good" : null, timeout);
   }
 
+  public static <T> T waitForNonNull(Supplier<T> supplier, Duration timeout) {
+    return waitForNonNull(supplier, timeout, Duration.ofSeconds(1));
+  }
+
   /**
    * loop the supplier until it returns non-null value. The exception arisen in the waiting get
    * ignored if the supplier offers the non-null value in the end.
    *
    * @param supplier to loop
    * @param timeout to break the loop
+   * @param retryInterval the time interval between each supplier call
    * @param <T> returned type
    * @return value from supplier
    */
-  public static <T> T waitForNonNull(Supplier<T> supplier, Duration timeout) {
+  public static <T> T waitForNonNull(
+      Supplier<T> supplier, Duration timeout, Duration retryInterval) {
     var endTime = System.currentTimeMillis() + timeout.toMillis();
     Exception lastError = null;
     while (System.currentTimeMillis() <= endTime)
       try {
         var r = supplier.get();
         if (r != null) return r;
-        Utils.sleep(Duration.ofSeconds(1));
+        Utils.sleep(retryInterval);
       } catch (Exception e) {
         lastError = e;
       }


### PR DESCRIPTION
resolve #857 

觸發錯誤的源頭應該是 reassignment 在 assertion 之前結束

修正：建立足夠大的 Partition, 確保搬移持續一段時間，減少 reassignment 發生到 assertion 觸發之間的 sleep interval。