### PR TITLE
[GUI] BrokerTab show the orphan partitions

### DIFF
--- a/gui/src/main/java/org/astraea/gui/BrokerTab.java
+++ b/gui/src/main/java/org/astraea/gui/BrokerTab.java
@@ -59,6 +59,20 @@ public class BrokerTab {
                         broker.folders().stream()
                             .mapToLong(
                                 d -> d.partitionSizes().values().stream().mapToLong(v -> v).sum())
+                            .sum()),
+                    "orphan partitions",
+                    broker.folders().stream()
+                        .flatMap(d -> d.orphanPartitionSizes().keySet().stream())
+                        .distinct()
+                        .count(),
+                    "orphan size",
+                    DataSize.Byte.of(
+                        broker.folders().stream()
+                            .mapToLong(
+                                d ->
+                                    d.orphanPartitionSizes().values().stream()
+                                        .mapToLong(v -> v)
+                                        .sum())
                             .sum())))
         .collect(Collectors.toList());
   }


### PR DESCRIPTION
Broker 頁面現在會顯示保存在本地但不屬於任何 topic 的partitions，這有幾種可能：
1. 該些partitions是正在搬移中，而該些metadata尚未更新到每個節點
2. 該節點曾經下線，然後partitions配置已經被更新，該節點上線後會導致該些partition不是follower/leader