### PR TITLE
Fix failed tests in MetadataTest

### DIFF
--- a/etl/src/test/scala/org/astraea/etl/MetadataTest.scala
+++ b/etl/src/test/scala/org/astraea/etl/MetadataTest.scala
@@ -55,7 +55,7 @@ class MetadataTest {
     assert(config.primaryKeys equals Map("ID" -> StringType))
     assert(config.kafkaBootstrapServers.equals("0.0.0.0"))
     assert(config.numPartitions.equals(15))
-    assert(config.numReplicas.equals(1))
+    assert(config.numReplicas.equals(1.toShort))
     assert(config.topicName.nonEmpty)
     assert(config.topicConfig.isEmpty)
   }
@@ -84,7 +84,7 @@ class MetadataTest {
     assert(config.primaryKeys equals Map("ID" -> StringType))
     assert(config.kafkaBootstrapServers.equals("0.0.0.0"))
     assert(config.numPartitions.equals(30))
-    assert(config.numReplicas.equals(3))
+    assert(config.numReplicas.equals(3.toShort))
     assert(config.topicName.equals("spark-1"))
     assert(config.topicConfig.equals(Map("KA" -> "VA", "KB" -> "VB")))
   }


### PR DESCRIPTION
修正錯誤測試，目前 ci 會因為 `defaultTest`, `configuredTest` 這兩個測試報錯