### PR TITLE
Refactor pane builder

### DIFF
--- a/common/src/main/java/org/astraea/common/Utils.java
+++ b/common/src/main/java/org/astraea/common/Utils.java
@@ -283,6 +283,17 @@ public final class Utils {
         TreeMap::new);
   }
 
+  public static <T, K, U> Collector<T, ?, LinkedHashMap<K, U>> toLinkedHashMap(
+      Function<? super T, K> keyMapper, Function<? super T, U> valueMapper) {
+    return Collectors.toMap(
+        keyMapper,
+        valueMapper,
+        (x, y) -> {
+          throw new IllegalStateException("Duplicate key");
+        },
+        LinkedHashMap::new);
+  }
+
   public static Set<String> constants(Class<?> clz, Predicate<String> variableNameFilter) {
     return Arrays.stream(clz.getFields())
         .filter(field -> variableNameFilter.test(field.getName()))

--- a/gui/src/main/java/org/astraea/gui/Main.java
+++ b/gui/src/main/java/org/astraea/gui/Main.java
@@ -16,11 +16,11 @@
  */
 package org.astraea.gui;
 
+import java.util.List;
 import javafx.application.Application;
-import javafx.geometry.Side;
 import javafx.scene.Scene;
-import javafx.scene.control.TabPane;
 import javafx.stage.Stage;
+import org.astraea.gui.pane.TabPane;
 import org.astraea.gui.tab.AboutTab;
 import org.astraea.gui.tab.BalancerTab;
 import org.astraea.gui.tab.BrokerTab;
@@ -55,31 +55,31 @@ public class Main {
     @Override
     public void start(Stage stage) {
       var context = new Context();
-      var rootPane =
-          new TabPane(
-              SettingTab.of(context),
-              BrokerTab.of(context),
-              MetricsTab.of(context),
-              TopicTab.of(context),
-              PartitionTab.of(context),
-              ConfigTab.of(context),
-              ConsumerTab.of(context),
-              ProducerTab.of(context),
-              TransactionTab.of(context),
-              MovingReplicaTab.of(context),
-              CreateTopicTab.of(context),
-              UpdateTopicTab.of(context),
-              MoveTopicTab.of(context),
-              UpdateBrokerTab.of(context),
-              BalancerTab.of(context),
-              AboutTab.of(context));
-      rootPane.setSide(Side.BOTTOM);
-      rootPane.setTabClosingPolicy(TabPane.TabClosingPolicy.UNAVAILABLE);
-      var scene = new Scene(rootPane, 300, 300);
       stage.setTitle("Astraea");
       stage.setHeight(1000);
       stage.setWidth(1200);
-      stage.setScene(scene);
+      stage.setScene(
+          new Scene(
+              TabPane.of(
+                  List.of(
+                      SettingTab.of(context),
+                      BrokerTab.of(context),
+                      MetricsTab.of(context),
+                      TopicTab.of(context),
+                      PartitionTab.of(context),
+                      ConfigTab.of(context),
+                      ConsumerTab.of(context),
+                      ProducerTab.of(context),
+                      TransactionTab.of(context),
+                      MovingReplicaTab.of(context),
+                      CreateTopicTab.of(context),
+                      UpdateTopicTab.of(context),
+                      MoveTopicTab.of(context),
+                      UpdateBrokerTab.of(context),
+                      BalancerTab.of(context),
+                      AboutTab.of(context))),
+              300,
+              300));
       stage.show();
     }
 

--- a/gui/src/main/java/org/astraea/gui/box/HBox.java
+++ b/gui/src/main/java/org/astraea/gui/box/HBox.java
@@ -34,19 +34,7 @@ public class HBox extends javafx.scene.layout.HBox {
     return pane;
   }
 
-  public HBox() {
-    super();
-  }
-
-  public HBox(double spacing) {
+  private HBox(double spacing) {
     super(spacing);
-  }
-
-  public HBox(Node... children) {
-    super(children);
-  }
-
-  public HBox(double spacing, Node... children) {
-    super(spacing, children);
   }
 }

--- a/gui/src/main/java/org/astraea/gui/box/VBox.java
+++ b/gui/src/main/java/org/astraea/gui/box/VBox.java
@@ -34,19 +34,7 @@ public class VBox extends javafx.scene.layout.VBox {
     return pane;
   }
 
-  public VBox() {
-    super();
-  }
-
-  public VBox(double spacing) {
+  private VBox(double spacing) {
     super(spacing);
-  }
-
-  public VBox(Node... children) {
-    super(children);
-  }
-
-  public VBox(double spacing, Node... children) {
-    super(spacing, children);
   }
 }

--- a/gui/src/main/java/org/astraea/gui/button/RadioButton.java
+++ b/gui/src/main/java/org/astraea/gui/button/RadioButton.java
@@ -42,7 +42,7 @@ public class RadioButton extends javafx.scene.control.RadioButton {
 
   private final RadioButtonAble obj;
 
-  public RadioButton(RadioButtonAble obj) {
+  private RadioButton(RadioButtonAble obj) {
     super(obj.display());
     this.obj = obj;
   }

--- a/gui/src/main/java/org/astraea/gui/pane/GridPane.java
+++ b/gui/src/main/java/org/astraea/gui/pane/GridPane.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.gui.pane;
+
+import java.util.Map;
+import javafx.geometry.HPos;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+
+public class GridPane extends javafx.scene.layout.GridPane {
+
+  public static GridPane of(Map<? extends Node, ? extends Node> nodePair, int maxPairOneLine) {
+    var pane = new GridPane();
+    pane.setAlignment(Pos.CENTER);
+    var row = 0;
+    var column = 0;
+    var count = 0;
+    for (var pair : nodePair.entrySet()) {
+      if (count >= maxPairOneLine) {
+        count = 0;
+        column = 0;
+        row++;
+      }
+      GridPane.setHalignment(pair.getKey(), HPos.RIGHT);
+      GridPane.setMargin(pair.getKey(), new Insets(10, 5, 10, 15));
+      pane.add(pair.getKey(), column++, row);
+      GridPane.setHalignment(pair.getValue(), HPos.LEFT);
+      GridPane.setMargin(pair.getValue(), new Insets(10, 15, 10, 5));
+      pane.add(pair.getValue(), column++, row);
+      count++;
+    }
+    return pane;
+  }
+
+  public static GridPane singleColumn(
+      Map<? extends Node, ? extends Node> nodePair, int maxPairOneLine) {
+    var pane = new GridPane();
+    pane.setAlignment(Pos.CENTER);
+    var row = 0;
+    var column = 0;
+    var count = 0;
+    for (var pair : nodePair.entrySet()) {
+      GridPane.setHalignment(pair.getKey(), HPos.RIGHT);
+      GridPane.setMargin(pair.getKey(), new Insets(10, 5, 10, 15));
+      pane.add(pair.getKey(), 0, row);
+
+      GridPane.setHalignment(pair.getValue(), HPos.LEFT);
+      GridPane.setMargin(pair.getValue(), new Insets(10, 15, 10, 5));
+      pane.add(pair.getValue(), 1, row);
+      row++;
+    }
+    return pane;
+  }
+
+  private GridPane() {}
+}

--- a/gui/src/main/java/org/astraea/gui/pane/PaneBuilder.java
+++ b/gui/src/main/java/org/astraea/gui/pane/PaneBuilder.java
@@ -25,21 +25,15 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import javafx.geometry.HPos;
-import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
-import javafx.scene.control.Label;
 import javafx.scene.input.KeyCode;
-import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
-import javafx.scene.text.Font;
-import javafx.scene.text.FontWeight;
 import org.astraea.common.LinkedHashMap;
+import org.astraea.common.Utils;
 import org.astraea.gui.Logger;
 import org.astraea.gui.box.HBox;
 import org.astraea.gui.box.VBox;
@@ -47,6 +41,7 @@ import org.astraea.gui.button.Button;
 import org.astraea.gui.button.RadioButton;
 import org.astraea.gui.button.RadioButtonAble;
 import org.astraea.gui.table.TableView;
+import org.astraea.gui.text.Label;
 import org.astraea.gui.text.TextArea;
 import org.astraea.gui.text.TextField;
 
@@ -57,21 +52,19 @@ public class PaneBuilder {
     return new PaneBuilder();
   }
 
-  private static final int MAX_NUMBER_OF_TEXT_FIELD_ONE_LINE = 3;
-
   private List<RadioButton> radioButtons = new ArrayList<>();
 
   private final Set<String> textKeys = new LinkedHashSet<>();
   private final Map<String, Boolean> textPriority = new LinkedHashMap<>();
   private final Map<String, Boolean> textNumberOnly = new LinkedHashMap<>();
   private Label searchLabel = null;
-  private final TextField searchField = new TextField();
+  private final TextField searchField = TextField.of();
 
-  private Button actionButton = new Button("SEARCH");
+  private Button actionButton = Button.of("SEARCH");
 
   private TableView tableView = null;
 
-  private final TextArea console = new TextArea();
+  private final TextArea console = TextArea.of();
 
   private BiFunction<Input, Logger, CompletionStage<List<Map<String, Object>>>> buttonAction = null;
   private BiFunction<Input, Logger, CompletionStage<Void>> buttonListener = null;
@@ -115,12 +108,12 @@ public class PaneBuilder {
   }
 
   public PaneBuilder searchField(String hint) {
-    searchLabel = new Label(hint);
+    searchLabel = Label.of(hint);
     return this;
   }
 
   public PaneBuilder buttonName(String name) {
-    actionButton = new Button(name);
+    actionButton = Button.of(name);
     return this;
   }
 
@@ -140,12 +133,27 @@ public class PaneBuilder {
   public Pane build() {
     var nodes = new ArrayList<Node>();
     if (!radioButtons.isEmpty()) nodes.add(HBox.of(Pos.CENTER, radioButtons.toArray(Node[]::new)));
-    var textFields = new LinkedHashMap<String, Supplier<String>>();
+    Map<String, Supplier<String>> textFields;
     if (!textKeys.isEmpty()) {
-      var paneAndFields = pane(textKeys, textPriority, textNumberOnly);
-      nodes.add(paneAndFields.getKey());
-      textFields.putAll(paneAndFields.getValue());
-    }
+      var pairs =
+          textKeys.stream()
+              .collect(
+                  Utils.toLinkedHashMap(
+                      key ->
+                          textPriority.getOrDefault(key, false)
+                              ? Label.highlight(key)
+                              : Label.of(key),
+                      key ->
+                          textNumberOnly.getOrDefault(key, false)
+                              ? TextField.onlyNumber()
+                              : TextField.of()));
+      var gridPane = pairs.size() <= 3 ? GridPane.singleColumn(pairs, 3) : GridPane.of(pairs, 3);
+      nodes.add(gridPane);
+      textFields =
+          pairs.entrySet().stream()
+              .collect(
+                  Utils.toLinkedHashMap(e -> e.getKey().key(), e -> () -> e.getValue().getText()));
+    } else textFields = Map.of();
     if (searchLabel != null) nodes.add(HBox.of(Pos.CENTER, searchLabel, searchField, actionButton));
     else nodes.add(actionButton);
     if (tableView != null) nodes.add(tableView);
@@ -250,71 +258,6 @@ public class PaneBuilder {
           });
 
     return VBox.of(Pos.CENTER, nodes.toArray(Node[]::new));
-  }
-
-  private static Map.Entry<Pane, LinkedHashMap<String, Supplier<String>>> pane(
-      Set<String> textKeys,
-      Map<String, Boolean> textPriority,
-      Map<String, Boolean> textNumberOnly) {
-    Function<String, Label> labelFunction =
-        (key) -> {
-          if (textPriority.get(key)) {
-            var label = new Label(key + "*");
-            label.setFont(Font.font("Verdana", FontWeight.EXTRA_BOLD, 12));
-            return label;
-          }
-          return new Label(key);
-        };
-
-    Function<String, TextField> textFunction =
-        (key) -> textNumberOnly.get(key) ? TextField.onlyNumber() : new TextField();
-
-    var textFields = new LinkedHashMap<String, Supplier<String>>();
-    if (textKeys.size() <= 3) {
-      var pane = new GridPane();
-      pane.setAlignment(Pos.CENTER);
-      var row = 0;
-      for (var key : textKeys) {
-        var label = labelFunction.apply(key);
-        var textField = textFunction.apply(key);
-        textFields.put(key, textField::getText);
-        GridPane.setHalignment(label, HPos.RIGHT);
-        GridPane.setMargin(label, new Insets(10, 5, 10, 15));
-        pane.add(label, 0, row);
-
-        GridPane.setHalignment(textField, HPos.LEFT);
-        GridPane.setMargin(textField, new Insets(10, 15, 10, 5));
-        pane.add(textField, 1, row);
-        row++;
-      }
-      return Map.entry(pane, textFields);
-    }
-
-    var pane = new GridPane();
-    pane.setAlignment(Pos.CENTER);
-    var row = 0;
-    var column = 0;
-    var count = 0;
-    for (var key : textKeys) {
-      if (count >= MAX_NUMBER_OF_TEXT_FIELD_ONE_LINE) {
-        count = 0;
-        column = 0;
-        row++;
-      }
-
-      var label = labelFunction.apply(key);
-      var textField = textFunction.apply(key);
-      textFields.put(key, textField::getText);
-      GridPane.setHalignment(label, HPos.RIGHT);
-      GridPane.setMargin(label, new Insets(10, 5, 10, 15));
-      pane.add(label, column++, row);
-
-      GridPane.setHalignment(textField, HPos.LEFT);
-      GridPane.setMargin(textField, new Insets(10, 15, 10, 5));
-      pane.add(textField, column++, row);
-      count++;
-    }
-    return Map.entry(pane, textFields);
   }
 
   static Pattern wildcardToPattern(String string) {

--- a/gui/src/main/java/org/astraea/gui/pane/Tab.java
+++ b/gui/src/main/java/org/astraea/gui/pane/Tab.java
@@ -14,27 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.astraea.gui.button;
+package org.astraea.gui.pane;
 
-import javafx.application.Platform;
+import javafx.scene.Node;
 
-public class Button extends javafx.scene.control.Button {
+public class Tab extends javafx.scene.control.Tab {
 
-  public static Button of(String name) {
-    return new Button(name);
+  public static Tab of(String name, Node node) {
+    var t = new Tab(name);
+    t.setContent(node);
+    return t;
   }
 
-  private Button(String topic) {
-    super(topic);
-  }
-
-  public void disable() {
-    if (Platform.isFxApplicationThread()) setDisable(true);
-    else Platform.runLater(() -> setDisable(true));
-  }
-
-  public void enable() {
-    if (Platform.isFxApplicationThread()) setDisable(false);
-    else Platform.runLater(() -> setDisable(false));
+  private Tab(String name) {
+    super(name);
   }
 }

--- a/gui/src/main/java/org/astraea/gui/pane/TabPane.java
+++ b/gui/src/main/java/org/astraea/gui/pane/TabPane.java
@@ -14,27 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.astraea.gui.button;
+package org.astraea.gui.pane;
 
-import javafx.application.Platform;
+import java.util.List;
+import javafx.geometry.Side;
 
-public class Button extends javafx.scene.control.Button {
+public class TabPane extends javafx.scene.control.TabPane {
 
-  public static Button of(String name) {
-    return new Button(name);
+  public static TabPane of(List<Tab> tabs) {
+    var pane = new TabPane();
+    pane.getTabs().setAll(tabs);
+    pane.setSide(Side.BOTTOM);
+    pane.setTabClosingPolicy(javafx.scene.control.TabPane.TabClosingPolicy.UNAVAILABLE);
+    return pane;
   }
 
-  private Button(String topic) {
-    super(topic);
-  }
-
-  public void disable() {
-    if (Platform.isFxApplicationThread()) setDisable(true);
-    else Platform.runLater(() -> setDisable(true));
-  }
-
-  public void enable() {
-    if (Platform.isFxApplicationThread()) setDisable(false);
-    else Platform.runLater(() -> setDisable(false));
+  private TabPane() {
+    super();
   }
 }

--- a/gui/src/main/java/org/astraea/gui/tab/AboutTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/AboutTab.java
@@ -19,12 +19,12 @@ package org.astraea.gui.tab;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import javafx.scene.control.Tab;
 import org.astraea.common.LinkedHashMap;
 import org.astraea.common.VersionUtils;
 import org.astraea.gui.Context;
 import org.astraea.gui.button.RadioButtonAble;
 import org.astraea.gui.pane.PaneBuilder;
+import org.astraea.gui.pane.Tab;
 
 public class AboutTab {
 
@@ -96,8 +96,6 @@ public class AboutTab {
                     CompletableFuture.completedFuture(
                         input.selectedRadio().map(o -> (Info) o).orElse(Info.Version).tables))
             .build();
-    var tab = new Tab("about");
-    tab.setContent(pane);
-    return tab;
+    return Tab.of("about", pane);
   }
 }

--- a/gui/src/main/java/org/astraea/gui/tab/BalancerTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/BalancerTab.java
@@ -24,7 +24,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import javafx.scene.control.Tab;
 import org.astraea.common.LinkedHashMap;
 import org.astraea.common.admin.AsyncAdmin;
 import org.astraea.common.admin.ClusterInfo;
@@ -41,6 +40,7 @@ import org.astraea.gui.Logger;
 import org.astraea.gui.button.RadioButtonAble;
 import org.astraea.gui.pane.Input;
 import org.astraea.gui.pane.PaneBuilder;
+import org.astraea.gui.pane.Tab;
 
 public class BalancerTab {
 
@@ -174,8 +174,6 @@ public class BalancerTab {
                 (input, logger) -> context.submit(admin -> generator(admin, input, logger)))
             .build();
 
-    var tab = new Tab("balance topic");
-    tab.setContent(pane);
-    return tab;
+    return Tab.of("balance topic", pane);
   }
 }

--- a/gui/src/main/java/org/astraea/gui/tab/BrokerTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/BrokerTab.java
@@ -20,13 +20,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javafx.scene.control.Tab;
 import org.astraea.common.DataSize;
 import org.astraea.common.LinkedHashMap;
 import org.astraea.common.admin.Broker;
 import org.astraea.common.admin.TopicPartition;
 import org.astraea.gui.Context;
 import org.astraea.gui.pane.PaneBuilder;
+import org.astraea.gui.pane.Tab;
 
 public class BrokerTab {
 
@@ -98,8 +98,6 @@ public class BrokerTab {
                                                         || input.matchSearch(nodeInfo.host())))
                                 .thenApply(BrokerTab::result)))
             .build();
-    var tab = new Tab("broker");
-    tab.setContent(pane);
-    return tab;
+    return Tab.of("broker", pane);
   }
 }

--- a/gui/src/main/java/org/astraea/gui/tab/ConfigTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/ConfigTab.java
@@ -18,11 +18,11 @@ package org.astraea.gui.tab;
 
 import java.util.Map;
 import java.util.stream.Collectors;
-import javafx.scene.control.Tab;
 import org.astraea.common.LinkedHashMap;
 import org.astraea.gui.Context;
 import org.astraea.gui.button.RadioButtonAble;
 import org.astraea.gui.pane.PaneBuilder;
+import org.astraea.gui.pane.Tab;
 
 public class ConfigTab {
 
@@ -90,8 +90,6 @@ public class ConfigTab {
                                   .collect(Collectors.toList()));
                 })
             .build();
-    var tab = new Tab("config");
-    tab.setContent(pane);
-    return tab;
+    return Tab.of("config", pane);
   }
 }

--- a/gui/src/main/java/org/astraea/gui/tab/ConsumerTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/ConsumerTab.java
@@ -21,12 +21,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javafx.scene.control.Tab;
 import org.astraea.common.LinkedHashMap;
 import org.astraea.common.admin.ConsumerGroup;
 import org.astraea.gui.Context;
 import org.astraea.gui.pane.Input;
 import org.astraea.gui.pane.PaneBuilder;
+import org.astraea.gui.pane.Tab;
 
 public class ConsumerTab {
 
@@ -80,8 +80,6 @@ public class ConsumerTab {
                                 .thenCompose(admin::consumerGroups)
                                 .thenApply(cgs -> result(cgs.stream(), input))))
             .build();
-    var tab = new Tab("consumer");
-    tab.setContent(pane);
-    return tab;
+    return Tab.of("consumer", pane);
   }
 }

--- a/gui/src/main/java/org/astraea/gui/tab/CreateTopicTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/CreateTopicTab.java
@@ -19,10 +19,10 @@ package org.astraea.gui.tab;
 import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import javafx.scene.control.Tab;
 import org.astraea.common.admin.TopicConfigs;
 import org.astraea.gui.Context;
 import org.astraea.gui.pane.PaneBuilder;
+import org.astraea.gui.pane.Tab;
 
 public class CreateTopicTab {
 
@@ -74,8 +74,6 @@ public class CreateTopicTab {
                                   }));
                 })
             .build();
-    var tab = new Tab("create topic");
-    tab.setContent(pane);
-    return tab;
+    return Tab.of("create topic", pane);
   }
 }

--- a/gui/src/main/java/org/astraea/gui/tab/MetricsTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/MetricsTab.java
@@ -24,7 +24,6 @@ import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import javafx.scene.control.Tab;
 import org.astraea.common.DataSize;
 import org.astraea.common.LinkedHashMap;
 import org.astraea.common.metrics.MBeanClient;
@@ -34,6 +33,7 @@ import org.astraea.common.metrics.platform.HostMetrics;
 import org.astraea.gui.Context;
 import org.astraea.gui.button.RadioButtonAble;
 import org.astraea.gui.pane.PaneBuilder;
+import org.astraea.gui.pane.Tab;
 
 public class MetricsTab {
 
@@ -187,8 +187,6 @@ public class MetricsTab {
                                 .collect(Collectors.toList())))
             .build();
 
-    var tab = new Tab("metrics");
-    tab.setContent(pane);
-    return tab;
+    return Tab.of("metrics", pane);
   }
 }

--- a/gui/src/main/java/org/astraea/gui/tab/MoveTopicTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/MoveTopicTab.java
@@ -24,12 +24,12 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
-import javafx.scene.control.Tab;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.Partition;
 import org.astraea.common.admin.TopicPartition;
 import org.astraea.gui.Context;
 import org.astraea.gui.pane.PaneBuilder;
+import org.astraea.gui.pane.Tab;
 
 public class MoveTopicTab {
 
@@ -93,8 +93,6 @@ public class MoveTopicTab {
                 })
             .build();
 
-    var tab = new Tab("move topic");
-    tab.setContent(pane);
-    return tab;
+    return Tab.of("move topic", pane);
   }
 }

--- a/gui/src/main/java/org/astraea/gui/tab/MovingReplicaTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/MovingReplicaTab.java
@@ -20,12 +20,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javafx.scene.control.Tab;
 import org.astraea.common.DataSize;
 import org.astraea.common.LinkedHashMap;
 import org.astraea.common.admin.AddingReplica;
 import org.astraea.gui.Context;
 import org.astraea.gui.pane.PaneBuilder;
+import org.astraea.gui.pane.Tab;
 
 public class MovingReplicaTab {
 
@@ -77,8 +77,6 @@ public class MovingReplicaTab {
                                 .thenApply(MovingReplicaTab::result)))
             .build();
 
-    var tab = new Tab("moving replica");
-    tab.setContent(pane);
-    return tab;
+    return Tab.of("moving replica", pane);
   }
 }

--- a/gui/src/main/java/org/astraea/gui/tab/PartitionTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/PartitionTab.java
@@ -21,13 +21,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javafx.scene.control.Tab;
 import org.astraea.common.LinkedHashMap;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.Partition;
 import org.astraea.gui.Context;
 import org.astraea.gui.pane.PaneBuilder;
+import org.astraea.gui.pane.Tab;
 
 public class PartitionTab {
 
@@ -82,8 +82,6 @@ public class PartitionTab {
                                                     .thenComparing(Partition::partition)))
                                 .thenApply(PartitionTab::result)))
             .build();
-    var tab = new Tab("partition");
-    tab.setContent(pane);
-    return tab;
+    return Tab.of("partition", pane);
   }
 }

--- a/gui/src/main/java/org/astraea/gui/tab/ProducerTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/ProducerTab.java
@@ -21,11 +21,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javafx.scene.control.Tab;
 import org.astraea.common.LinkedHashMap;
 import org.astraea.common.admin.ProducerState;
 import org.astraea.gui.Context;
 import org.astraea.gui.pane.PaneBuilder;
+import org.astraea.gui.pane.Tab;
 
 public class ProducerTab {
 
@@ -75,8 +75,6 @@ public class ProducerTab {
                                                     .thenComparing(ProducerState::partition)))
                                 .thenApply(ProducerTab::result)))
             .build();
-    var tab = new Tab("producer");
-    tab.setContent(pane);
-    return tab;
+    return Tab.of("producer", pane);
   }
 }

--- a/gui/src/main/java/org/astraea/gui/tab/SettingTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/SettingTab.java
@@ -17,11 +17,11 @@
 package org.astraea.gui.tab;
 
 import java.util.Optional;
-import javafx.scene.control.Tab;
 import org.astraea.common.admin.AsyncAdmin;
 import org.astraea.common.metrics.MBeanClient;
 import org.astraea.gui.Context;
 import org.astraea.gui.pane.PaneBuilder;
+import org.astraea.gui.pane.Tab;
 
 public class SettingTab {
 
@@ -69,8 +69,6 @@ public class SettingTab {
                           });
                 })
             .build();
-    var tab = new Tab("setting");
-    tab.setContent(pane);
-    return tab;
+    return Tab.of("setting", pane);
   }
 }

--- a/gui/src/main/java/org/astraea/gui/tab/TopicTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/TopicTab.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import javafx.scene.control.Tab;
 import org.astraea.common.DataSize;
 import org.astraea.common.LinkedHashMap;
 import org.astraea.common.Utils;
@@ -29,33 +28,9 @@ import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.Partition;
 import org.astraea.gui.Context;
 import org.astraea.gui.pane.PaneBuilder;
+import org.astraea.gui.pane.Tab;
 
 public class TopicTab {
-  public static Tab of(Context context) {
-    var pane =
-        PaneBuilder.of()
-            .searchField("topic name")
-            .buttonAction(
-                (input, logger) ->
-                    context.submit(
-                        admin ->
-                            admin
-                                .topicNames(true)
-                                .thenApply(
-                                    names ->
-                                        names.stream()
-                                            .filter(input::matchSearch)
-                                            .collect(Collectors.toSet()))
-                                .thenCompose(
-                                    names ->
-                                        admin
-                                            .partitions(names)
-                                            .thenCombine(admin.brokers(), TopicTab::beans))))
-            .build();
-    var tab = new Tab("topic");
-    tab.setContent(pane);
-    return tab;
-  }
 
   private static List<Map<String, Object>> beans(List<Partition> partitions, List<Broker> nodes) {
     var topicSize =
@@ -101,5 +76,29 @@ public class TopicTab {
               return result;
             })
         .collect(Collectors.toList());
+  }
+
+  public static Tab of(Context context) {
+    var pane =
+        PaneBuilder.of()
+            .searchField("topic name")
+            .buttonAction(
+                (input, logger) ->
+                    context.submit(
+                        admin ->
+                            admin
+                                .topicNames(true)
+                                .thenApply(
+                                    names ->
+                                        names.stream()
+                                            .filter(input::matchSearch)
+                                            .collect(Collectors.toSet()))
+                                .thenCompose(
+                                    names ->
+                                        admin
+                                            .partitions(names)
+                                            .thenCombine(admin.brokers(), TopicTab::beans))))
+            .build();
+    return Tab.of("topic", pane);
   }
 }

--- a/gui/src/main/java/org/astraea/gui/tab/TransactionTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/TransactionTab.java
@@ -20,12 +20,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javafx.scene.control.Tab;
 import org.astraea.common.LinkedHashMap;
 import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.admin.Transaction;
 import org.astraea.gui.Context;
 import org.astraea.gui.pane.PaneBuilder;
+import org.astraea.gui.pane.Tab;
 
 public class TransactionTab {
 
@@ -70,8 +70,6 @@ public class TransactionTab {
                                                                     input.matchSearch(tp.topic()))))
                                 .thenApply(TransactionTab::result)))
             .build();
-    var tab = new Tab("transaction");
-    tab.setContent(pane);
-    return tab;
+    return Tab.of("transaction", pane);
   }
 }

--- a/gui/src/main/java/org/astraea/gui/tab/UpdateBrokerTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/UpdateBrokerTab.java
@@ -18,10 +18,10 @@ package org.astraea.gui.tab;
 
 import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
-import javafx.scene.control.Tab;
 import org.astraea.common.admin.BrokerConfigs;
 import org.astraea.gui.Context;
 import org.astraea.gui.pane.PaneBuilder;
+import org.astraea.gui.pane.Tab;
 
 public class UpdateBrokerTab {
 
@@ -55,8 +55,6 @@ public class UpdateBrokerTab {
                                   }));
                 })
             .build();
-    var tab = new Tab("update broker");
-    tab.setContent(pane);
-    return tab;
+    return Tab.of("update broker", pane);
   }
 }

--- a/gui/src/main/java/org/astraea/gui/tab/UpdateTopicTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/UpdateTopicTab.java
@@ -19,10 +19,10 @@ package org.astraea.gui.tab;
 import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import javafx.scene.control.Tab;
 import org.astraea.common.admin.TopicConfigs;
 import org.astraea.gui.Context;
 import org.astraea.gui.pane.PaneBuilder;
+import org.astraea.gui.pane.Tab;
 
 public class UpdateTopicTab {
 
@@ -63,8 +63,6 @@ public class UpdateTopicTab {
                                   }));
                 })
             .build();
-    var tab = new Tab("update topic");
-    tab.setContent(pane);
-    return tab;
+    return Tab.of("update topic", pane);
   }
 }

--- a/gui/src/main/java/org/astraea/gui/text/Label.java
+++ b/gui/src/main/java/org/astraea/gui/text/Label.java
@@ -14,27 +14,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.astraea.gui.button;
+package org.astraea.gui.text;
 
-import javafx.application.Platform;
+import javafx.scene.text.Font;
+import javafx.scene.text.FontWeight;
 
-public class Button extends javafx.scene.control.Button {
+public class Label extends javafx.scene.control.Label {
 
-  public static Button of(String name) {
-    return new Button(name);
+  public static Label of(String content) {
+    return new Label(content, content);
   }
 
-  private Button(String topic) {
-    super(topic);
+  public static Label highlight(String content) {
+    var label = new Label(content, content + "*");
+    label.setFont(Font.font("Verdana", FontWeight.EXTRA_BOLD, 12));
+    return label;
   }
 
-  public void disable() {
-    if (Platform.isFxApplicationThread()) setDisable(true);
-    else Platform.runLater(() -> setDisable(true));
+  private final String key;
+
+  private Label(String key, String content) {
+    super(content);
+    this.key = key;
   }
 
-  public void enable() {
-    if (Platform.isFxApplicationThread()) setDisable(false);
-    else Platform.runLater(() -> setDisable(false));
+  /** @return the key associated to this label. Noted that the key may be different from text */
+  public String key() {
+    return key;
   }
 }

--- a/gui/src/main/java/org/astraea/gui/text/TextArea.java
+++ b/gui/src/main/java/org/astraea/gui/text/TextArea.java
@@ -21,13 +21,12 @@ import org.astraea.common.Utils;
 
 public class TextArea extends javafx.scene.control.TextArea {
 
-  public TextArea() {
-    this("");
+  public static TextArea of() {
+    return new TextArea();
   }
 
-  public TextArea(String text) {
-    super(text);
-    this.setEditable(false);
+  private TextArea() {
+    super();
   }
 
   public void text(String text, Throwable e) {

--- a/gui/src/main/java/org/astraea/gui/text/TextField.java
+++ b/gui/src/main/java/org/astraea/gui/text/TextField.java
@@ -30,17 +30,15 @@ public class TextField extends javafx.scene.control.TextField {
     return field;
   }
 
-  public static TextField copyableField(String content) {
-    var field = new TextField(content);
-    field.setEditable(false);
-    return field;
+  public static TextField of() {
+    return new TextField();
   }
 
-  public TextField() {
+  private TextField() {
     super();
   }
 
-  public TextField(String text) {
+  private TextField(String text) {
     super(text);
   }
 }


### PR DESCRIPTION
`PaneBuilder`內部充斥著各種特規格式化，導致`PaneBuilder`變得肥大且臃腫，這隻PR將各個元件的客製化移動到各個元件的helper，這樣的好處有兩個:
1. `PaneBuilder`可以大幅度簡化
2. 其他pane也可以共用元件的特規化