### PR TITLE
Deps image should include all test dependencies

### DIFF
--- a/docker/build_deps_image.sh
+++ b/docker/build_deps_image.sh
@@ -45,7 +45,9 @@ RUN unzip gradle-5.6.4-bin.zip
 WORKDIR /astraea
 RUN git clone https://github.com/skiptests/astraea.git /astraea
 RUN ./gradlew clean build -x test
-# trigger download of database
+# download test dependencies
+RUN ./gradlew clean compileTestJava
+# download database
 RUN ./gradlew cleanTest it:test --tests DatabaseTest
 
 WORKDIR /root


### PR DESCRIPTION
之前只有一個模組時，跑其中一隻測試就可以下載所有的 test dependencies，但現在有多個模組了，所以我們額外加一個指令去下載