### PR TITLE
[GUI] TopicTab should show the topic metrics if metrics is enabled

### DIFF
--- a/gui/src/main/java/org/astraea/gui/Context.java
+++ b/gui/src/main/java/org/astraea/gui/Context.java
@@ -67,4 +67,8 @@ public class Context {
                                         b -> b, b -> MBeanClient.jndi(b.host(), jmxPort)))))
         .thenApply(executor);
   }
+
+  public boolean hasMetrics() {
+    return jmxPort.get() > 0;
+  }
 }

--- a/gui/src/main/java/org/astraea/gui/tab/MetricsTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/MetricsTab.java
@@ -37,7 +37,7 @@ import org.astraea.gui.pane.Tab;
 
 public class MetricsTab {
 
-  private static <T> Optional<T> tryToFetch(Supplier<T> function) {
+  static <T> Optional<T> tryToFetch(Supplier<T> function) {
     try {
       return Optional.of(function.get());
     } catch (Exception e) {
@@ -57,18 +57,14 @@ public class MetricsTab {
         "controller",
         client ->
             Arrays.stream(ControllerMetrics.Controller.values())
-                .map(m -> tryToFetch(() -> m.fetch(client)))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
+                .flatMap(m -> tryToFetch(() -> m.fetch(client)).stream())
                 .collect(Collectors.toMap(m -> m.metricsName(), m -> m.value()))),
 
     CONTROLLER_STATE(
         "controller state",
         client ->
             Arrays.stream(ControllerMetrics.ControllerState.values())
-                .map(m -> tryToFetch(() -> m.fetch(client)))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
+                .flatMap(m -> tryToFetch(() -> m.fetch(client)).stream())
                 .collect(Collectors.toMap(m -> m.metricsName(), m -> m.fiveMinuteRate()))),
     NETWORK(
         "network",
@@ -101,26 +97,20 @@ public class MetricsTab {
         "delayed operation",
         client ->
             Arrays.stream(ServerMetrics.DelayedOperationPurgatory.values())
-                .map(m -> tryToFetch(() -> m.fetch(client)))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
+                .flatMap(m -> tryToFetch(() -> m.fetch(client)).stream())
                 .collect(Collectors.toMap(m -> m.metricsName(), m -> m.value()))),
 
     REPLICA(
         "replica",
         client ->
             Arrays.stream(ServerMetrics.ReplicaManager.values())
-                .map(m -> tryToFetch(() -> m.fetch(client)))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
+                .flatMap(m -> tryToFetch(() -> m.fetch(client)).stream())
                 .collect(Collectors.toMap(m -> m.metricsName(), m -> m.value()))),
     BROKER_TOPIC(
-        "broker topics",
+        "broker topic",
         client ->
             Arrays.stream(ServerMetrics.BrokerTopic.values())
-                .map(m -> tryToFetch(() -> m.fetch(client)))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
+                .flatMap(m -> tryToFetch(() -> m.fetch(client)).stream())
                 .collect(
                     Collectors.toMap(
                         m -> m.metricsName(),

--- a/gui/src/main/java/org/astraea/gui/table/TableView.java
+++ b/gui/src/main/java/org/astraea/gui/table/TableView.java
@@ -16,10 +16,13 @@
  */
 package org.astraea.gui.table;
 
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.EventObject;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javafx.application.Platform;
@@ -70,7 +73,9 @@ public class TableView extends javafx.scene.control.TableView<Map<String, Object
   public void update(List<Map<String, Object>> data) {
     var columns =
         data.stream()
-            .flatMap(r -> r.keySet().stream())
+            .map(Map::keySet)
+            .sorted(Comparator.comparingInt((Set<String> o) -> o.size()).reversed())
+            .flatMap(Collection::stream)
             .collect(Collectors.toCollection(LinkedHashSet::new))
             .stream()
             .map(


### PR DESCRIPTION
<img width="1190" alt="截圖 2022-10-12 上午5 55 28" src="https://user-images.githubusercontent.com/6234750/195205562-bd18727b-cfc0-4b91-89e9-83822171b3dd.png">


當 JMX port 有設定時，會添加五個 metrics:
1. BytesInPerSec
2. BytesOutPerSec
3. MessagesInPerSec
4. TotalFetchRequestsPerSec
5. TotalProduceRequestsPerSec