### PR TITLE
Make consistent order for AsyncAdmin

### DIFF
--- a/common/src/main/java/org/astraea/common/admin/NodeInfo.java
+++ b/common/src/main/java/org/astraea/common/admin/NodeInfo.java
@@ -18,7 +18,7 @@ package org.astraea.common.admin;
 
 import java.util.Objects;
 
-public interface NodeInfo {
+public interface NodeInfo extends Comparable<NodeInfo> {
 
   static NodeInfo of(org.apache.kafka.common.Node node) {
     return of(node.id(), node.host(), node.port());
@@ -77,5 +77,14 @@ public interface NodeInfo {
   /** @return true if the node is offline. An offline node can't offer host or port information. */
   default boolean offline() {
     return host() == null || host().isEmpty() || port() < 0;
+  }
+
+  @Override
+  default int compareTo(NodeInfo other) {
+    var r = Integer.compare(id(), other.id());
+    if (r != 0) return r;
+    r = host().compareTo(other.host());
+    if (r != 0) return r;
+    return Integer.compare(port(), other.port());
   }
 }

--- a/common/src/main/java/org/astraea/common/balancer/executor/RebalanceAdminImpl.java
+++ b/common/src/main/java/org/astraea/common/balancer/executor/RebalanceAdminImpl.java
@@ -144,9 +144,7 @@ class RebalanceAdminImpl implements RebalanceAdmin {
                     .filter(x -> x.topic().equals(log.topic()))
                     .filter(x -> x.partition() == log.partition())
                     .filter(x -> x.nodeInfo().id() == log.brokerId())
-                    .findFirst()
-                    .map(x -> x.inSync() && !x.isFuture())
-                    .orElse(false)));
+                    .allMatch(x -> x.inSync() && !x.isFuture())));
   }
 
   @Override
@@ -159,10 +157,8 @@ class RebalanceAdminImpl implements RebalanceAdmin {
                 admin.replicas(Set.of(topicPartition.topic())).stream()
                     .filter(x -> x.topic().equals(topicPartition.topic()))
                     .filter(x -> x.partition() == topicPartition.partition())
-                    .findFirst()
                     .filter(Replica::isPreferredLeader)
-                    .map(ReplicaInfo::isLeader)
-                    .orElseThrow()));
+                    .allMatch(ReplicaInfo::isLeader)));
   }
 
   private Supplier<Boolean> debounceCheck(Duration timeout, Supplier<Boolean> testDone) {

--- a/common/src/test/java/org/astraea/common/admin/AsyncAdminTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AsyncAdminTest.java
@@ -18,16 +18,68 @@ package org.astraea.common.admin;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 import org.astraea.common.Utils;
 import org.astraea.it.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class AsyncAdminTest extends RequireBrokerCluster {
+
+  @Test
+  void testOrder() throws ExecutionException, InterruptedException {
+    try (var admin = AsyncAdmin.of(bootstrapServers())) {
+      admin.creator().topic(Utils.randomString()).run().toCompletableFuture().get();
+      admin.creator().topic(Utils.randomString()).run().toCompletableFuture().get();
+      admin.creator().topic(Utils.randomString()).run().toCompletableFuture().get();
+      admin.creator().topic(Utils.randomString()).run().toCompletableFuture().get();
+      Utils.sleep(Duration.ofSeconds(3));
+
+      var topicNames = admin.topicNames(true).toCompletableFuture().get();
+      Assertions.assertInstanceOf(SortedSet.class, topicNames);
+
+      var topics = admin.topics(topicNames).toCompletableFuture().get();
+      Assertions.assertEquals(
+          topics.stream().sorted(Comparator.comparing(Topic::name)).collect(Collectors.toList()),
+          topics);
+
+      Assertions.assertInstanceOf(
+          SortedSet.class, admin.topicPartitions(topicNames).toCompletableFuture().get());
+
+      var partitions = admin.partitions(topicNames).toCompletableFuture().get();
+      Assertions.assertEquals(
+          partitions.stream()
+              .sorted(Comparator.comparing(Partition::topic).thenComparing(Partition::partition))
+              .collect(Collectors.toList()),
+          partitions);
+
+      Assertions.assertInstanceOf(
+          SortedSet.class, admin.topicPartitionReplicas(brokerIds()).toCompletableFuture().get());
+
+      Assertions.assertInstanceOf(SortedSet.class, admin.nodeInfos().toCompletableFuture().get());
+
+      var brokers = admin.brokers().toCompletableFuture().get();
+      Assertions.assertEquals(
+          brokers.stream().sorted(Comparator.comparing(Broker::id)).collect(Collectors.toList()),
+          brokers);
+
+      var replicas = admin.replicas(topicNames).toCompletableFuture().get();
+      Assertions.assertEquals(
+          replicas.stream()
+              .sorted(
+                  Comparator.comparing(Replica::topic)
+                      .thenComparing(Replica::partition)
+                      .thenComparing(r -> r.nodeInfo().id()))
+              .collect(Collectors.toList()),
+          replicas);
+    }
+  }
 
   @Test
   void testMoveLeaderBroker() throws ExecutionException, InterruptedException {

--- a/gui/src/main/java/org/astraea/gui/tab/TopicTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/TopicTab.java
@@ -50,6 +50,7 @@ public class TopicTab {
                     e -> e.getValue().stream().mapToLong(Map.Entry::getValue).sum()));
     var tps = partitions.stream().collect(Collectors.groupingBy(Partition::topic));
     return tps.keySet().stream()
+        .sorted()
         .map(
             topic -> {
               var result = new LinkedHashMap<String, Object>();

--- a/gui/src/main/java/org/astraea/gui/tab/UpdateTopicTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/UpdateTopicTab.java
@@ -17,6 +17,7 @@
 package org.astraea.gui.tab;
 
 import java.util.HashMap;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javafx.scene.Node;
@@ -71,7 +72,7 @@ public class UpdateTopicTab {
                         BorderPane.dynamic(
                             topics.stream()
                                 .map(Topic::name)
-                                .collect(Collectors.toUnmodifiableSet()),
+                                .collect(Collectors.toCollection(TreeSet::new)),
                             topic ->
                                 CompletableFuture.completedFuture(
                                     topics.stream()


### PR DESCRIPTION
這隻PR調整`AsyncAdmin`回傳的資料排序，由於我們大部分的資料都有 topic, partition，因此可以用該些資訊來排序