### PR TITLE
Always build/test all code when running CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-      - name: build
-        run: ./gradlew clean build -x test --no-daemon
+      - name: compile
+        run: ./gradlew clean build testClasses -x test --no-daemon
       - name: unit tests
-        run: ./gradlew clean test --no-daemon --console plain -PmaxParallelForks=3
+        run: ./gradlew clean test --no-daemon --console plain -PmaxParallelForks=3 --continue

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-      - name: compile
+      - name: build
         run: ./gradlew clean build testClasses -x test --no-daemon
       - name: unit tests
         run: ./gradlew clean test --no-daemon --console plain -PmaxParallelForks=3 --continue


### PR DESCRIPTION
原本的 build 只會建構 production code，這樣會導致 test code 無法編譯時的錯誤被延後，另外跑測試的時候應該總是跑完所有模組，不然會在前面模組發生錯誤時就停下來，進而使得我們無法得之後面模組的測試是否正常