### PR TITLE
Raneme Replica#dataFolder to Replica#path

### DIFF
--- a/app/src/main/java/org/astraea/app/web/BalancerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BalancerHandler.java
@@ -233,7 +233,7 @@ class BalancerHandler implements Handler {
                               Comparator.comparing(Replica::isPreferredLeader)
                                   .reversed()
                                   .thenComparing(x -> x.nodeInfo().id()))
-                          .map(x -> Map.entry(x.nodeInfo().id(), x.dataFolder()))
+                          .map(x -> Map.entry(x.nodeInfo().id(), x.path()))
                           .collect(Collectors.toUnmodifiableList());
                   var expectedReplicaList =
                       Stream.concat(
@@ -281,7 +281,7 @@ class BalancerHandler implements Handler {
 
     Placement(Replica replica, Long size) {
       this.brokerId = replica.nodeInfo().id();
-      this.directory = replica.dataFolder();
+      this.directory = replica.path();
       this.size = size;
     }
   }

--- a/app/src/main/java/org/astraea/app/web/TopicHandler.java
+++ b/app/src/main/java/org/astraea/app/web/TopicHandler.java
@@ -220,7 +220,7 @@ class TopicHandler implements Handler {
           replica.isLeader(),
           replica.inSync(),
           replica.isFuture(),
-          replica.dataFolder());
+          replica.path());
     }
 
     Replica(

--- a/app/src/test/java/org/astraea/app/web/ReassignmentHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/ReassignmentHandlerTest.java
@@ -91,7 +91,7 @@ public class ReassignmentHandlerTest extends RequireBrokerCluster {
               .get();
 
       var currentBroker = currentReplica.nodeInfo().id();
-      var currentPath = currentReplica.dataFolder();
+      var currentPath = currentReplica.path();
       var nextPath =
           logFolders().get(currentBroker).stream()
               .filter(p -> !p.equals(currentPath))
@@ -125,7 +125,7 @@ public class ReassignmentHandlerTest extends RequireBrokerCluster {
               .filter(replica -> replica.partition() == 0)
               .findFirst()
               .get()
-              .dataFolder());
+              .path());
     }
   }
 

--- a/common/src/main/java/org/astraea/common/admin/ClusterInfo.java
+++ b/common/src/main/java/org/astraea/common/admin/ClusterInfo.java
@@ -64,7 +64,7 @@ public interface ClusterInfo<T extends ReplicaInfo> {
                             r.nodeInfo().id() == beforeReplica.nodeInfo().id()
                                 && r.partition() == beforeReplica.partition()
                                 && r.topic().equals(beforeReplica.topic())
-                                && r.dataFolder().equals(beforeReplica.dataFolder())))
+                                && r.path().equals(beforeReplica.path())))
         .collect(Collectors.toSet());
   }
 

--- a/common/src/main/java/org/astraea/common/admin/Replica.java
+++ b/common/src/main/java/org/astraea/common/admin/Replica.java
@@ -29,7 +29,7 @@ public interface Replica extends ReplicaInfo {
       boolean isFuture,
       boolean offline,
       boolean isPreferredLeader,
-      String dataFolder) {
+      String path) {
     return Replica.builder()
         .topic(topic)
         .partition(partition)
@@ -41,7 +41,7 @@ public interface Replica extends ReplicaInfo {
         .isFuture(isFuture)
         .offline(offline)
         .isPreferredLeader(isPreferredLeader)
-        .dataFolder(dataFolder)
+        .path(path)
         .build();
   }
 
@@ -86,5 +86,5 @@ public interface Replica extends ReplicaInfo {
    * @return that indicates the data folder path which stored this replica on a specific Kafka node.
    *     It returns null if the host of replica is offline
    */
-  String dataFolder();
+  String path();
 }

--- a/common/src/main/java/org/astraea/common/admin/ReplicaBuilder.java
+++ b/common/src/main/java/org/astraea/common/admin/ReplicaBuilder.java
@@ -30,7 +30,7 @@ public class ReplicaBuilder {
   private boolean isFuture;
   private boolean offline;
   private boolean isPreferredLeader;
-  private String dataFolder;
+  private String path;
 
   ReplicaBuilder replica(Replica replica) {
     this.topic = replica.topic();
@@ -43,7 +43,7 @@ public class ReplicaBuilder {
     this.isFuture = replica.isFuture();
     this.offline = replica.isOffline();
     this.isPreferredLeader = replica.isPreferredLeader();
-    this.dataFolder = replica.dataFolder();
+    this.path = replica.path();
 
     return this;
   }
@@ -98,8 +98,8 @@ public class ReplicaBuilder {
     return this;
   }
 
-  public ReplicaBuilder dataFolder(String dataFolder) {
-    this.dataFolder = dataFolder;
+  public ReplicaBuilder path(String path) {
+    this.path = path;
     return this;
   }
 
@@ -123,7 +123,7 @@ public class ReplicaBuilder {
             && isPreferredLeader == replica.isPreferredLeader()
             && offline == replica.isOffline()
             && Objects.equals(topic, replica.topic())
-            && Objects.equals(dataFolder, replica.dataFolder());
+            && Objects.equals(path, replica.path());
       }
 
       @Override
@@ -139,7 +139,7 @@ public class ReplicaBuilder {
             isFuture,
             isPreferredLeader,
             offline,
-            dataFolder);
+            path);
       }
 
       @Override
@@ -167,7 +167,7 @@ public class ReplicaBuilder {
             + ", offline="
             + offline
             + ", path='"
-            + dataFolder
+            + path
             + '\''
             + '}';
       }
@@ -223,8 +223,8 @@ public class ReplicaBuilder {
       }
 
       @Override
-      public String dataFolder() {
-        return dataFolder;
+      public String path() {
+        return path;
       }
     };
   }

--- a/common/src/main/java/org/astraea/common/balancer/executor/StraightPlanExecutor.java
+++ b/common/src/main/java/org/astraea/common/balancer/executor/StraightPlanExecutor.java
@@ -50,7 +50,7 @@ public class StraightPlanExecutor implements RebalancePlanExecutor {
                         .collect(
                             Collectors.toMap(
                                 e -> e.nodeInfo().id(),
-                                Replica::dataFolder,
+                                Replica::path,
                                 (e1, e2) -> e1,
                                 LinkedHashMap::new)));
 

--- a/common/src/main/java/org/astraea/common/balancer/log/ClusterLogAllocation.java
+++ b/common/src/main/java/org/astraea/common/balancer/log/ClusterLogAllocation.java
@@ -110,9 +110,9 @@ public interface ClusterLogAllocation {
   /**
    * Determine if both of the replicas can be considered as equal in terms of its placement.
    *
-   * @param sourceReplicas the source replicas. null value of {@link Replica#dataFolder()} will be
+   * @param sourceReplicas the source replicas. null value of {@link Replica#path()} will be
    *     interpreted as the actual location doesn't matter.
-   * @param targetReplicas the target replicas. null value of {@link Replica#dataFolder()} will be
+   * @param targetReplicas the target replicas. null value of {@link Replica#path()} will be
    *     interpreted as the actual location is unknown.
    * @return true if both replicas of specific topic/partitions can be considered as equal in terms
    *     of its placement.
@@ -140,7 +140,7 @@ public interface ClusterLogAllocation {
               final var target = targetIds.get(index);
               return source.isPreferredLeader() == target.isPreferredLeader()
                   && source.nodeInfo().id() == target.nodeInfo().id()
-                  && Objects.equals(source.dataFolder(), target.dataFolder());
+                  && Objects.equals(source.path(), target.path());
             });
   }
 
@@ -158,7 +158,7 @@ public interface ClusterLogAllocation {
                   .forEach(
                       log ->
                           stringBuilder.append(
-                              String.format("(%s, %s) ", log.nodeInfo().id(), log.dataFolder())));
+                              String.format("(%s, %s) ", log.nodeInfo().id(), log.path())));
 
               stringBuilder.append(System.lineSeparator());
             });
@@ -293,7 +293,7 @@ public interface ClusterLogAllocation {
           source.isFuture(),
           source.isOffline(),
           isPreferredLeader,
-          source.dataFolder());
+          source.path());
     }
   }
 
@@ -303,6 +303,6 @@ public interface ClusterLogAllocation {
   }
 
   static Replica update(Replica source, NodeInfo newBroker, String newDir) {
-    return Replica.builder(source).nodeInfo(newBroker).dataFolder(newDir).build();
+    return Replica.builder(source).nodeInfo(newBroker).path(newDir).build();
   }
 }

--- a/common/src/test/java/org/astraea/common/admin/AsyncAdminTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AsyncAdminTest.java
@@ -220,7 +220,7 @@ public class AsyncAdminTest extends RequireBrokerCluster {
       Assertions.assertEquals(1, newReplicas.size());
 
       var newReplica = newReplicas.get(0);
-      Assertions.assertEquals(idAndFolder.get(newReplica.nodeInfo().id()), newReplica.dataFolder());
+      Assertions.assertEquals(idAndFolder.get(newReplica.nodeInfo().id()), newReplica.path());
     }
   }
 
@@ -338,13 +338,7 @@ public class AsyncAdminTest extends RequireBrokerCluster {
         Utils.sleep(Duration.ofSeconds(2));
         Assertions.assertEquals(
             path,
-            admin
-                .replicas(Set.of(topic))
-                .toCompletableFuture()
-                .get()
-                .iterator()
-                .next()
-                .dataFolder());
+            admin.replicas(Set.of(topic)).toCompletableFuture().get().iterator().next().path());
       }
     }
   }
@@ -394,8 +388,7 @@ public class AsyncAdminTest extends RequireBrokerCluster {
       var logFolders =
           logFolders().values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
       partitions.forEach(
-          replica ->
-              Assertions.assertTrue(logFolders.stream().anyMatch(replica.dataFolder()::contains)));
+          replica -> Assertions.assertTrue(logFolders.stream().anyMatch(replica.path()::contains)));
       brokerIds()
           .forEach(
               id -> {
@@ -514,7 +507,7 @@ public class AsyncAdminTest extends RequireBrokerCluster {
                                       .filter(replica -> replica.partition() == 0)
                                       .findFirst()
                                       .get()
-                                      .dataFolder())))
+                                      .path())))
               .collect(Collectors.toSet());
 
       admin.moveToFolders(
@@ -526,10 +519,7 @@ public class AsyncAdminTest extends RequireBrokerCluster {
                     var partitionReplicas =
                         admin.replicas(Set.of(topic)).toCompletableFuture().get();
                     return partitionReplicas.size() == 1
-                        && partitionReplicas
-                            .get(0)
-                            .dataFolder()
-                            .equals(otherPath.iterator().next());
+                        && partitionReplicas.get(0).path().equals(otherPath.iterator().next());
                   }));
     }
   }

--- a/common/src/test/java/org/astraea/common/admin/SomePartitionOfflineTest.java
+++ b/common/src/test/java/org/astraea/common/admin/SomePartitionOfflineTest.java
@@ -58,7 +58,7 @@ public class SomePartitionOfflineTest extends RequireBrokerCluster {
                 Assertions.assertTrue(replica.isOffline());
                 Assertions.assertEquals(-1, replica.size());
                 Assertions.assertEquals(-1, replica.lag());
-                Assertions.assertNull(replica.dataFolder());
+                Assertions.assertNull(replica.path());
               });
     }
   }

--- a/common/src/test/java/org/astraea/common/balancer/BalancerUtilsIntegratedTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerUtilsIntegratedTest.java
@@ -69,7 +69,7 @@ public class BalancerUtilsIntegratedTest extends RequireBrokerCluster {
                           false,
                           false,
                           true,
-                          replica.dataFolder()))));
+                          replica.path()))));
 
       Assertions.assertEquals(clusterInfo.replicas().size(), merged.replicas().size());
       Assertions.assertEquals(clusterInfo.topics().size(), merged.topics().size());

--- a/common/src/test/java/org/astraea/common/balancer/executor/RebalanceAdminTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/executor/RebalanceAdminTest.java
@@ -79,9 +79,9 @@ class RebalanceAdminTest extends RequireBrokerCluster {
       Assertions.assertEquals(
           List.of(0, 1, 2),
           replicas.stream().map(Replica::nodeInfo).map(NodeInfo::id).collect(Collectors.toList()));
-      Assertions.assertEquals(logFolder0, replicas.get(0).dataFolder());
-      Assertions.assertEquals(logFolder1, replicas.get(1).dataFolder());
-      Assertions.assertEquals(logFolder2, replicas.get(2).dataFolder());
+      Assertions.assertEquals(logFolder0, replicas.get(0).path());
+      Assertions.assertEquals(logFolder1, replicas.get(1).path());
+      Assertions.assertEquals(logFolder2, replicas.get(2).path());
     }
   }
 
@@ -122,7 +122,7 @@ class RebalanceAdminTest extends RequireBrokerCluster {
       var originalReplica = replicaNow.get();
       var nextDir =
           logFolders().get(originalReplica.nodeInfo().id()).stream()
-              .filter(name -> !name.equals(originalReplica.dataFolder()))
+              .filter(name -> !name.equals(originalReplica.path()))
               .findAny()
               .orElseThrow();
 
@@ -170,7 +170,7 @@ class RebalanceAdminTest extends RequireBrokerCluster {
               .get();
       var otherDataDir =
           admin.brokerFolders().get(beginReplica.nodeInfo().id()).stream()
-              .filter(dir -> !dir.equals(beginReplica.dataFolder()))
+              .filter(dir -> !dir.equals(beginReplica.path()))
               .findAny()
               .orElseThrow();
       prepareData(topic, 0, DataSize.MiB.of(32));

--- a/common/src/test/java/org/astraea/common/balancer/log/ClusterLogAllocationTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/log/ClusterLogAllocationTest.java
@@ -211,7 +211,7 @@ class ClusterLogAllocationTest extends RequireBrokerCluster {
             .filter(replica -> replica.nodeInfo().id() == 9999)
             .findFirst()
             .orElseThrow()
-            .dataFolder());
+            .path());
   }
 
   @ParameterizedTest
@@ -505,13 +505,13 @@ class ClusterLogAllocationTest extends RequireBrokerCluster {
             "/tmp/default/dir");
 
     Assertions.assertEquals(
-        "/other", ClusterLogAllocation.update(replica, nodeInfo.id(), "/other").dataFolder());
+        "/other", ClusterLogAllocation.update(replica, nodeInfo.id(), "/other").path());
     Assertions.assertEquals(
         nodeInfo, ClusterLogAllocation.update(replica, nodeInfo.id(), "/other").nodeInfo());
     Assertions.assertEquals(
         5566, ClusterLogAllocation.update(replica, 5566, "/other").nodeInfo().id());
     Assertions.assertEquals(
-        "/other", ClusterLogAllocation.update(replica, newNodeInfo, "/other").dataFolder());
+        "/other", ClusterLogAllocation.update(replica, newNodeInfo, "/other").path());
     Assertions.assertEquals(
         newNodeInfo, ClusterLogAllocation.update(replica, newNodeInfo, "/other").nodeInfo());
     Assertions.assertEquals(

--- a/gui/src/main/java/org/astraea/gui/tab/ReplicaTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/ReplicaTab.java
@@ -49,7 +49,7 @@ public class ReplicaTab {
                   "broker",
                   replica.nodeInfo().id(),
                   "path",
-                  replica.dataFolder(),
+                  replica.path(),
                   "size",
                   DataSize.Byte.of(replica.size()),
                   "leader size",


### PR DESCRIPTION
`dataFolder`這個字已經被用於`Broker`中用來表達資料結構，因此更換一個名字避免混淆