### PR TITLE
Fix flaky AsyncAdminTest#testPendingRequest

### DIFF
--- a/common/src/main/java/org/astraea/common/admin/AsyncAdmin.java
+++ b/common/src/main/java/org/astraea/common/admin/AsyncAdmin.java
@@ -45,7 +45,7 @@ public interface AsyncAdmin extends AutoCloseable {
   String clientId();
 
   /** @return the number of pending requests. */
-  int pendingRequests();
+  int runningRequests();
 
   // ---------------------------------[readonly]---------------------------------//
 


### PR DESCRIPTION
更改計算方式，內部變數並不是 thread-safe，這會導致無法取得最新的狀態，這隻PR改成我們自行統計轉換了多少 kafka APIs，這個方式雖然會比較不準，因為我們不知道APIs對應的真實請求數量，但也足以讓我們知道有多少呼叫還沒處理完

resolve #933