### PR TITLE
Implementation of `BalancerBuilder#metricSource`

### DIFF
--- a/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
@@ -17,10 +17,14 @@
 package org.astraea.common.balancer;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.astraea.common.Utils;
@@ -35,11 +39,14 @@ import org.astraea.common.balancer.generator.ShufflePlanGenerator;
 import org.astraea.common.cost.ClusterCost;
 import org.astraea.common.cost.HasClusterCost;
 import org.astraea.common.cost.ReplicaLeaderCost;
+import org.astraea.common.metrics.BeanObject;
+import org.astraea.common.metrics.HasBeanObject;
 import org.astraea.common.scenario.Scenario;
 import org.astraea.it.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
 
 class BalancerTest extends RequireBrokerCluster {
 
@@ -178,5 +185,61 @@ class BalancerTest extends RequireBrokerCluster {
       Assertions.assertFalse(future.isCompletedExceptionally());
       Assertions.assertNotNull(future.get());
     }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testWithMetrics(boolean greedy) {
+    var counter = new AtomicLong();
+    Supplier<ClusterBean> metricSource =
+        () -> {
+          // increment the counter as the bean updated
+          final var value = counter.getAndIncrement();
+          final var mock = Mockito.mock(HasBeanObject.class);
+          Mockito.when(mock.createdTimestamp()).thenReturn(value);
+          Mockito.when(mock.beanObject()).thenReturn(new BeanObject("", Map.of(), Map.of()));
+          return ClusterBean.of(Map.of(0, List.of(mock)));
+        };
+    Consumer<Long> test =
+        (expected) -> {
+          var called = new AtomicBoolean();
+          var theCostFunction =
+              new HasClusterCost() {
+                @Override
+                public ClusterCost clusterCost(
+                    ClusterInfo<Replica> clusterInfo, ClusterBean clusterBean) {
+                  Assertions.assertEquals(1, clusterBean.all().get(0).size());
+                  Assertions.assertEquals(
+                      expected,
+                      clusterBean.all().get(0).stream()
+                          .findFirst()
+                          .orElseThrow()
+                          .createdTimestamp(),
+                      "The metric counter increased");
+                  called.set(true);
+                  return () -> 0;
+                }
+              };
+          Balancer.builder()
+              .planGenerator(new ShufflePlanGenerator(50, 100))
+              .clusterCost(theCostFunction)
+              .metricSource(metricSource)
+              .limit(500)
+              .greedy(greedy)
+              .build()
+              .offer(ClusterInfo.empty(), Map.of());
+          Assertions.assertTrue(called.get(), "The cost function has been invoked");
+        };
+
+    test.accept(0L);
+    test.accept(1L);
+    test.accept(2L);
+    test.accept(3L);
+    test.accept(4L);
+    test.accept(5L);
+    test.accept(6L);
+    test.accept(7L);
+    test.accept(8L);
+    test.accept(9L);
   }
 }


### PR DESCRIPTION
Context: #754

這個 PR 給 `BalancerBuilder` 新增一個函數，呼叫者可以傳入 `Supplier<ClusterBean>`，這個 `Supplier` 每次呼叫應該要提供最新的 Cluster bean 資訊，這個資訊應該由建立 `Balancer` 的模組提供，以隔離撈取效能資訊和搜尋計劃的邏輯。

這個 PR 結束後的下一步是：補上 Web API 撈取 metrics 的部分，如此一來 Web APIs 就能夠支援有 Fetcher 需求的 Cost Function