### PR TITLE
Fix flaky SkewedPartitionScenarioTest

### DIFF
--- a/common/src/main/java/org/astraea/common/balancer/executor/RebalanceAdminImpl.java
+++ b/common/src/main/java/org/astraea/common/balancer/executor/RebalanceAdminImpl.java
@@ -130,13 +130,15 @@ class RebalanceAdminImpl implements RebalanceAdmin {
 
   @Override
   public CompletableFuture<Boolean> waitLogSynced(TopicPartitionReplica log, Duration timeout) {
-    return asyncAdmin.waitReplicasSynced(Set.of(log), timeout);
+    return asyncAdmin.waitReplicasSynced(Set.of(log), timeout).toCompletableFuture();
   }
 
   @Override
   public CompletableFuture<Boolean> waitPreferredLeaderSynced(
       TopicPartition topicPartition, Duration timeout) {
-    return asyncAdmin.waitPreferredLeaderSynced(Set.of(topicPartition), timeout);
+    return asyncAdmin
+        .waitPreferredLeaderSynced(Set.of(topicPartition), timeout)
+        .toCompletableFuture();
   }
 
   @Override

--- a/common/src/main/java/org/astraea/common/scenario/SkewedPartitionScenario.java
+++ b/common/src/main/java/org/astraea/common/scenario/SkewedPartitionScenario.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
@@ -56,6 +57,10 @@ public class SkewedPartitionScenario implements Scenario {
         .numberOfPartitions(partitions)
         .numberOfReplicas(replicas)
         .run()
+        .thenCompose(
+            ignored ->
+                admin.waitPartitionLeaderSynced(
+                    Map.of(topicName, partitions), Duration.ofSeconds(4)))
         .thenCompose(ignored -> admin.brokers())
         .thenApply(
             brokers -> brokers.stream().map(NodeInfo::id).sorted().collect(Collectors.toList()))

--- a/common/src/test/java/org/astraea/common/admin/ClusterInfoWithOfflineNodeTest.java
+++ b/common/src/test/java/org/astraea/common/admin/ClusterInfoWithOfflineNodeTest.java
@@ -19,7 +19,6 @@ package org.astraea.common.admin;
 import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Collectors;
 import org.astraea.common.Utils;
 import org.astraea.it.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
@@ -71,12 +70,6 @@ public class ClusterInfoWithOfflineNodeTest extends RequireBrokerCluster {
       Assertions.assertTrue(
           after.replicaLeaders(topicName).stream()
               .allMatch(x -> x.nodeInfo().id() != brokerToClose));
-      System.out.println(
-          "[CHIA] "
-              + after.replicas(topicName).stream()
-                  .filter(ReplicaInfo::isOffline)
-                  .map(r -> r.nodeInfo().id())
-                  .collect(Collectors.toList()));
       Assertions.assertTrue(
           after.replicas(topicName).stream()
               .filter(ReplicaInfo::isOffline)


### PR DESCRIPTION
失敗的原因是`SkewedPartitionScenario`送出建立 topic 的請求後會馬上接著索取相關的資訊，這中間可能會遇到 metadata 尚未同步的意外，因此這隻PR在建立 topic 後增加一個檢查確保 metadata 盡可能同步完成