### PR TITLE
Replace AdoptOpenJDK by zulu for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: build
         run: ./gradlew clean build testClasses -x test --no-daemon
       - name: unit tests


### PR DESCRIPTION
https://github.com/skiptests/astraea/pull/848#discussion_r999519092

除了上述的問題外，我們在GUI文件上也是用 zulu，因此這隻PR讓CI也改用zulu