### PR TITLE
Handle the exception thrown by older kafka

### DIFF
--- a/common/src/main/java/org/astraea/common/admin/AsyncAdminImpl.java
+++ b/common/src/main/java/org/astraea/common/admin/AsyncAdminImpl.java
@@ -347,15 +347,16 @@ class AsyncAdminImpl implements AsyncAdmin {
         updatableTopicPartitions,
         updatableTopicPartitions.thenCompose(
             ps ->
-                to(
-                    kafkaAdmin
+                to(kafkaAdmin
                         .listOffsets(
                             ps.stream()
                                 .collect(
                                     Collectors.toMap(
                                         TopicPartition::to,
                                         ignored -> new OffsetSpec.MaxTimestampSpec())))
-                        .all())),
+                        .all())
+                    // the old kafka does not support to fetch max timestamp
+                    .exceptionally(e -> Map.of())),
         (ps, result) ->
             ps.stream()
                 .collect(
@@ -538,6 +539,8 @@ class AsyncAdminImpl implements AsyncAdmin {
                     .map(TopicPartition::to)
                     .collect(Collectors.toUnmodifiableList()))
             .all())
+        // the old kafka does not support to fetch producer states
+        .exceptionally(e -> Map.of())
         .thenApply(
             ps ->
                 ps.entrySet().stream()


### PR DESCRIPTION
如題，有些資訊我們無法在舊版kafka中取得，因此改為空陣列回傳