### PR TITLE
migrateLeaderForGUI

### DIFF
--- a/gui/src/main/java/org/astraea/gui/tab/BalancerTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/BalancerTab.java
@@ -103,7 +103,7 @@ public class BalancerTab {
                       : "not change",
                   PREVIOUS_FOLLOWER_KEY,
                   previousFollowers.size() == 0
-                      ? "not change"
+                      ? "no follower"
                       : previousFollowers.stream()
                           .map(r -> r.nodeInfo().id() + ":" + r.path())
                           .collect(Collectors.joining(",")),

--- a/gui/src/main/java/org/astraea/gui/tab/BalancerTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/BalancerTab.java
@@ -18,7 +18,6 @@ package org.astraea.gui.tab;
 
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -108,20 +107,6 @@ public class BalancerTab {
               if (!newFollowers.isBlank()) result.put(NEW_FOLLOWER_KEY, newFollowers);
               return result;
             })
-        .collect(Collectors.toList());
-  }
-
-  private static List<Replica> diff(Collection<Replica> before, Collection<Replica> after) {
-    return before.stream()
-        .filter(
-            beforeReplica ->
-                after.stream()
-                    .noneMatch(
-                        r ->
-                            r.nodeInfo().id() == beforeReplica.nodeInfo().id()
-                                && r.topic().equals(beforeReplica.topic())
-                                && r.partition() == beforeReplica.partition()
-                                && r.path().equals(beforeReplica.path())))
         .collect(Collectors.toList());
   }
 

--- a/gui/src/main/java/org/astraea/gui/tab/BalancerTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/BalancerTab.java
@@ -100,10 +100,10 @@ public class BalancerTab {
                   NEW_LEADER_KEY,
                   migratedReplicas.stream().anyMatch(ReplicaInfo::isLeader)
                       ? newLeader.nodeInfo().id() + ":" + newLeader.path()
-                      : "not change",
+                      : "",
                   PREVIOUS_FOLLOWER_KEY,
                   previousFollowers.size() == 0
-                      ? "no follower"
+                      ? ""
                       : previousFollowers.stream()
                           .map(r -> r.nodeInfo().id() + ":" + r.path())
                           .collect(Collectors.joining(",")),
@@ -112,7 +112,7 @@ public class BalancerTab {
                       ? newFollowers.stream()
                           .map(r -> r.nodeInfo().id() + ":" + r.path())
                           .collect(Collectors.joining(","))
-                      : "not change");
+                      : "");
             })
         .collect(Collectors.toList());
   }


### PR DESCRIPTION
 這支PR在balancer GUI新增`migrated leader`，可以讓使用者知道產生的搬移計畫是否有移動到partition leader
看起來如下:
![image](https://user-images.githubusercontent.com/80746615/197328434-e110bf2c-1da0-42fb-a67c-5aa36d768566.png)
