### PR TITLE
multiMoveCostToBalancer

### DIFF
--- a/app/src/main/java/org/astraea/app/web/BalancerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BalancerHandler.java
@@ -157,7 +157,7 @@ class BalancerHandler implements Handler {
                   Balancer.builder()
                       .planGenerator(generator)
                       .clusterCost(clusterCostFunction)
-                      .moveCost(moveCostFunction)
+                      .moveCost(List.of(moveCostFunction))
                       .limit(loop)
                       .limit(timeout)
                       .build()
@@ -201,7 +201,7 @@ class BalancerHandler implements Handler {
                       clusterCostFunction.getClass().getSimpleName(),
                       changes,
                       bestPlan
-                          .map(p -> List.of(new MigrationCost(p.moveCost())))
+                          .map(p -> List.of(new MigrationCost(p.moveCost().iterator().next())))
                           .orElseGet(List::of));
               return new PlanInfo(report, bestPlan.orElseThrow());
             });

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -251,7 +251,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
               .clusterCost(clusterCostFunction)
               .clusterConstraint((before, after) -> after.value() <= before.value())
               .moveCost(List.of(moveCostFunction))
-              .movementConstraint(Map.of("unknown", moveCost -> true))
+              .movementConstraint(moveCosts -> true)
               .build()
               .offer(admin.clusterInfo(), ignore -> true, admin.brokerFolders());
 
@@ -266,7 +266,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                   .clusterCost(clusterCostFunction)
                   .clusterConstraint((before, after) -> true)
                   .moveCost(List.of(moveCostFunction))
-                  .movementConstraint(Map.of("unknown", moveCost -> true))
+                  .movementConstraint(moveCosts -> true)
                   .limit(0)
                   .build()
                   .offer(admin.clusterInfo(), ignore -> true, admin.brokerFolders()));
@@ -279,7 +279,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
               .clusterCost(clusterCostFunction)
               .clusterConstraint((before, after) -> false)
               .moveCost(List.of(moveCostFunction))
-              .movementConstraint(Map.of("unknown", moveCost -> true))
+              .movementConstraint(moveCosts -> true)
               .build()
               .offer(admin.clusterInfo(), ignore -> true, admin.brokerFolders()));
 
@@ -291,7 +291,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
               .clusterCost(clusterCostFunction)
               .clusterConstraint((before, after) -> true)
               .moveCost(List.of(moveCostFunction))
-              .movementConstraint(Map.of("unknown", moveCost -> false))
+              .movementConstraint(moveCosts -> false)
               .build()
               .offer(admin.clusterInfo(), ignore -> true, admin.brokerFolders()));
     }

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -250,8 +250,8 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
               .planGenerator(RebalancePlanGenerator.random(30))
               .clusterCost(clusterCostFunction)
               .clusterConstraint((before, after) -> after.value() <= before.value())
-              .moveCost(moveCostFunction)
-              .movementConstraint(moveCost -> true)
+              .moveCost(List.of(moveCostFunction))
+              .movementConstraint(Map.of("unknown", moveCost -> true))
               .build()
               .offer(admin.clusterInfo(), ignore -> true, admin.brokerFolders());
 
@@ -265,8 +265,8 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                   .planGenerator(RebalancePlanGenerator.random(30))
                   .clusterCost(clusterCostFunction)
                   .clusterConstraint((before, after) -> true)
-                  .moveCost(moveCostFunction)
-                  .movementConstraint(moveCost -> true)
+                  .moveCost(List.of(moveCostFunction))
+                  .movementConstraint(Map.of("unknown", moveCost -> true))
                   .limit(0)
                   .build()
                   .offer(admin.clusterInfo(), ignore -> true, admin.brokerFolders()));
@@ -278,8 +278,8 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
               .planGenerator(RebalancePlanGenerator.random(30))
               .clusterCost(clusterCostFunction)
               .clusterConstraint((before, after) -> false)
-              .moveCost(moveCostFunction)
-              .movementConstraint(moveCost -> true)
+              .moveCost(List.of(moveCostFunction))
+              .movementConstraint(Map.of("unknown", moveCost -> true))
               .build()
               .offer(admin.clusterInfo(), ignore -> true, admin.brokerFolders()));
 
@@ -290,8 +290,8 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
               .planGenerator(RebalancePlanGenerator.random(30))
               .clusterCost(clusterCostFunction)
               .clusterConstraint((before, after) -> true)
-              .moveCost(moveCostFunction)
-              .movementConstraint(moveCost -> false)
+              .moveCost(List.of(moveCostFunction))
+              .movementConstraint(Map.of("unknown", moveCost -> false))
               .build()
               .offer(admin.clusterInfo(), ignore -> true, admin.brokerFolders()));
     }

--- a/common/src/main/java/org/astraea/common/balancer/Balancer.java
+++ b/common/src/main/java/org/astraea/common/balancer/Balancer.java
@@ -16,6 +16,7 @@
  */
 package org.astraea.common.balancer;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -46,7 +47,7 @@ public interface Balancer {
   class Plan {
     final RebalancePlanProposal proposal;
     final ClusterCost clusterCost;
-    final MoveCost moveCost;
+    final List<MoveCost> moveCost;
 
     public RebalancePlanProposal proposal() {
       return proposal;
@@ -56,11 +57,11 @@ public interface Balancer {
       return clusterCost;
     }
 
-    public MoveCost moveCost() {
+    public List<MoveCost> moveCost() {
       return moveCost;
     }
 
-    public Plan(RebalancePlanProposal proposal, ClusterCost clusterCost, MoveCost moveCost) {
+    public Plan(RebalancePlanProposal proposal, ClusterCost clusterCost, List<MoveCost> moveCost) {
       this.proposal = proposal;
       this.clusterCost = clusterCost;
       this.moveCost = moveCost;

--- a/common/src/main/java/org/astraea/common/balancer/BalancerBuilder.java
+++ b/common/src/main/java/org/astraea/common/balancer/BalancerBuilder.java
@@ -19,7 +19,6 @@ package org.astraea.common.balancer;
 import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -44,7 +43,7 @@ public class BalancerBuilder {
   private List<HasMoveCost> moveCostFunction = List.of(HasMoveCost.EMPTY);
   private BiPredicate<ClusterCost, ClusterCost> clusterConstraint =
       (before, after) -> after.value() < before.value();
-  private Map<String, Predicate<MoveCost>> movementConstraint = Map.of("", ignore -> true);
+  private Predicate<List<MoveCost>> movementConstraint = ignore -> true;
   private int searchLimit = Integer.MAX_VALUE;
   private Duration executionTime = Duration.ofSeconds(3);
   private Supplier<ClusterBean> metricSource = () -> ClusterBean.EMPTY;
@@ -109,7 +108,7 @@ public class BalancerBuilder {
    *     terms of the ongoing cost caused by execute this rebalance plan).
    * @return this
    */
-  public BalancerBuilder movementConstraint(Map<String, Predicate<MoveCost>> moveConstraint) {
+  public BalancerBuilder movementConstraint(Predicate<List<MoveCost>> moveConstraint) {
     this.movementConstraint = moveConstraint;
     return this;
   }
@@ -205,14 +204,7 @@ public class BalancerBuilder {
                         .collect(Collectors.toList()));
               })
           .filter(plan -> clusterConstraint.test(currentCost, plan.clusterCost))
-          .filter(
-              plan ->
-                  plan.moveCost().stream()
-                      .allMatch(
-                          moveCost ->
-                              movementConstraint
-                                  .getOrDefault(moveCost.name(), (ignore) -> true)
-                                  .test(moveCost)))
+          .filter(plan -> movementConstraint.test(plan.moveCost))
           .min(Comparator.comparing(plan -> plan.clusterCost.value()));
     };
   }
@@ -245,14 +237,7 @@ public class BalancerBuilder {
                                 .collect(Collectors.toList()));
                       })
                   .filter(plan -> clusterConstraint.test(currentCost, plan.clusterCost))
-                  .filter(
-                      plan ->
-                          plan.moveCost().stream()
-                              .allMatch(
-                                  moveCost ->
-                                      movementConstraint
-                                          .getOrDefault(moveCost.name(), (ignore) -> true)
-                                          .test(moveCost)))
+                  .filter(plan -> movementConstraint.test(plan.moveCost))
                   .findFirst();
       var currentCost = clusterCostFunction.clusterCost(originClusterInfo, metrics);
       var currentAllocation =


### PR DESCRIPTION
為了讓使用者可以在Balancer的GUI可以設定多個`MoveCost`的上限，此PR將`Blaancer`改成可以吃多個`HasMoveCost`