### PR TITLE
fix `ClusterInfo#diff`

### DIFF
--- a/common/src/main/java/org/astraea/common/admin/ClusterInfo.java
+++ b/common/src/main/java/org/astraea/common/admin/ClusterInfo.java
@@ -67,7 +67,9 @@ public interface ClusterInfo<T extends ReplicaInfo> {
                             r.nodeInfo().id() == beforeReplica.nodeInfo().id()
                                 && r.partition() == beforeReplica.partition()
                                 && r.topic().equals(beforeReplica.topic())
-                                && r.path().equals(beforeReplica.path())))
+                                && r.path().equals(beforeReplica.path())
+                                && r.isLeader() == beforeReplica.isLeader()
+                                && r.isPreferredLeader() == beforeReplica.isPreferredLeader()))
         .collect(Collectors.toSet());
   }
 

--- a/common/src/test/java/org/astraea/common/admin/ClusterInfoTest.java
+++ b/common/src/test/java/org/astraea/common/admin/ClusterInfoTest.java
@@ -32,6 +32,7 @@ public class ClusterInfoTest {
     test-1-0 : change only the data folder
     test-1-1 : change the data folder and host
     test-1-2 : no change
+    test-2-0 : only change leader, not change the data folder and host
      */
     var beforeReplicas =
         List.of(
@@ -70,6 +71,30 @@ public class ClusterInfoTest {
                 false,
                 false,
                 false,
+                "/data-folder-01"),
+            Replica.of(
+                "test-2",
+                0,
+                NodeInfo.of(0, "", -1),
+                -1,
+                -1,
+                true,
+                true,
+                false,
+                false,
+                false,
+                "/data-folder-01"),
+            Replica.of(
+                "test-2",
+                0,
+                NodeInfo.of(1, "", -1),
+                -1,
+                -1,
+                false,
+                true,
+                false,
+                false,
+                true,
                 "/data-folder-01"));
     var afterReplicas =
         List.of(
@@ -108,6 +133,30 @@ public class ClusterInfoTest {
                 false,
                 false,
                 false,
+                "/data-folder-01"),
+            Replica.of(
+                "test-2",
+                0,
+                NodeInfo.of(0, "", -1),
+                -1,
+                -1,
+                false,
+                true,
+                false,
+                false,
+                true,
+                "/data-folder-01"),
+            Replica.of(
+                "test-2",
+                0,
+                NodeInfo.of(1, "", -1),
+                -1,
+                -1,
+                true,
+                true,
+                false,
+                false,
+                false,
                 "/data-folder-01"));
     var nodeInfos = Set.of(NodeInfo.of(0, "", -1), NodeInfo.of(1, "", -1), NodeInfo.of(2, "", -1));
     var before = ClusterInfo.of(nodeInfos, beforeReplicas);
@@ -115,7 +164,7 @@ public class ClusterInfoTest {
     var changes = ClusterInfo.diff(before, after);
 
     Assertions.assertNotEquals(0, after.topics().size());
-    Assertions.assertEquals(2, changes.size());
+    Assertions.assertEquals(4, changes.size());
     Assertions.assertEquals(
         1,
         changes.stream()
@@ -130,6 +179,11 @@ public class ClusterInfoTest {
         0,
         changes.stream()
             .filter(replica -> replica.topic().equals("test-1") && replica.partition() == 2)
+            .count());
+    Assertions.assertEquals(
+        2,
+        changes.stream()
+            .filter(replica -> replica.topic().equals("test-2") && replica.partition() == 0)
             .count());
   }
 

--- a/common/src/test/java/org/astraea/common/admin/ClusterInfoTest.java
+++ b/common/src/test/java/org/astraea/common/admin/ClusterInfoTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import org.apache.kafka.common.Cluster;
+import org.astraea.common.cost.ReplicaLeaderCost;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -162,6 +163,11 @@ public class ClusterInfoTest {
     var before = ClusterInfo.of(nodeInfos, beforeReplicas);
     var after = ClusterInfo.of(nodeInfos, afterReplicas);
     var changes = ClusterInfo.diff(before, after);
+
+    // test diff in ReplicaLeaderCost
+    var leaderMoveCost = new ReplicaLeaderCost().moveCost(before, after, ClusterBean.EMPTY);
+    // move 2 leaders
+    Assertions.assertEquals(leaderMoveCost.totalCost(), 2);
 
     Assertions.assertNotEquals(0, after.topics().size());
     Assertions.assertEquals(4, changes.size());


### PR DESCRIPTION
在diff計算兩個`ClusterInfo`的分佈差異時，也必須要考慮到partitionLeader以及preferredLeader，若是沒有考慮這兩個，在計算 `ReplicaLeaderCost#MoveCost`的時候，只有更換Leader(preferredLeader)而沒有搬移到其他Broker或data folder的replica會被忽略掉