### PR TITLE
Allow `Receiver` to launch a thread to trigger metrics update

### DIFF
--- a/common/src/main/java/org/astraea/common/metrics/collector/BeanCollector.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/BeanCollector.java
@@ -25,6 +25,10 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiFunction;
@@ -87,6 +91,7 @@ public class BeanCollector {
       private String host;
       private int port = -1;
       private Fetcher fetcher;
+      private boolean autoUpdate = false;
 
       @Override
       public Register host(String host) {
@@ -115,6 +120,12 @@ public class BeanCollector {
       }
 
       @Override
+      public Register autoUpdate() {
+        this.autoUpdate = true;
+        return this;
+      }
+
+      @Override
       public Receiver build() {
         if (!local) {
           Utils.requirePositive(port);
@@ -126,6 +137,17 @@ public class BeanCollector {
         var receiver =
             new Receiver() {
               private final Map<Long, HasBeanObject> objects = new ConcurrentSkipListMap<>();
+              private final boolean shouldAutoUpdate = autoUpdate;
+              private final ScheduledExecutorService updateThread =
+                  shouldAutoUpdate ? Executors.newScheduledThreadPool(1) : null;
+              private final ScheduledFuture<?> updateTask =
+                  shouldAutoUpdate
+                      ? updateThread.scheduleAtFixedRate(
+                          this::doUpdate,
+                          interval.toMillis(),
+                          interval.toMillis(),
+                          TimeUnit.MILLISECONDS)
+                      : null;
 
               @Override
               public String host() {
@@ -139,12 +161,17 @@ public class BeanCollector {
 
               @Override
               public Collection<HasBeanObject> current() {
-                tryUpdate();
+                if (!shouldAutoUpdate) tryUpdate();
                 return Collections.unmodifiableCollection(objects.values());
               }
 
               @Override
               public void close() {
+                if (shouldAutoUpdate) {
+                  updateTask.cancel(false);
+                  updateThread.shutdown();
+                  Utils.packException(() -> updateThread.awaitTermination(5, TimeUnit.SECONDS));
+                }
                 node.lock.lock();
                 try {
                   node.receivers.remove(this);
@@ -162,7 +189,11 @@ public class BeanCollector {
                         .max((Long::compare))
                         .map(last -> last + interval.toMillis() <= System.currentTimeMillis())
                         .orElse(true);
-                if (needUpdate && node.lock.tryLock()) {
+                if (needUpdate) doUpdate();
+              }
+
+              private synchronized void doUpdate() {
+                if (node.lock.tryLock()) {
                   try {
                     if (node.mBeanClient == null)
                       node.mBeanClient =

--- a/common/src/main/java/org/astraea/common/metrics/collector/BeanCollector.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/BeanCollector.java
@@ -159,7 +159,7 @@ public class BeanCollector {
               }
 
               private boolean isAutoUpdate() {
-                return updateThread != null;
+                return updateTask != null;
               }
 
               @Override

--- a/common/src/main/java/org/astraea/common/metrics/collector/Register.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/Register.java
@@ -43,6 +43,13 @@ public interface Register {
    */
   Register fetcher(Fetcher fetcher);
 
+  /**
+   * demand to schedule metric updates periodically.
+   *
+   * @return this register
+   */
+  Register autoUpdate();
+
   /** @return create a Receiver */
   Receiver build();
 }


### PR DESCRIPTION
Context: https://github.com/skiptests/astraea/pull/955#discussion_r1003189128

給 `BeanCollector` 旗下的 `Register` 新增一個 `Register#autoUpdate`，這個 Flag 能夠讓 `Receiver` 自己建立一個執行序以定時觸發效能指標取樣。