### PR TITLE
Enable to append/subtract configs from AsyncAdmin

### DIFF
--- a/common/src/main/java/org/astraea/common/admin/AsyncAdmin.java
+++ b/common/src/main/java/org/astraea/common/admin/AsyncAdmin.java
@@ -284,9 +284,17 @@ public interface AsyncAdmin extends AutoCloseable {
    * append the value to config. Noted that it appends nothing if the existent value is "*".
    *
    * @param topic to append
+   * @param subtracted values
+   */
+  CompletionStage<Void> appendConfigs(String topic, Map<String, String> subtracted);
+
+  /**
+   * subtract the value to config. Noted that it throws exception if the existent value is "*".
+   *
+   * @param topic to append
    * @param appended values
    */
-  CompletionStage<Void> appendConfigs(String topic, Map<String, String> appended);
+  CompletionStage<Void> subtractConfigs(String topic, Map<String, String> appended);
 
   /**
    * unset the value associated to given keys. The unset config will become either null of default
@@ -296,14 +304,6 @@ public interface AsyncAdmin extends AutoCloseable {
 
   /** @param override defines the key and new value. The other undefined keys won't get changed. */
   CompletionStage<Void> setConfigs(int brokerId, Map<String, String> override);
-
-  /**
-   * append the value to config. Noted that it appends nothing if the existent value is "*".
-   *
-   * @param brokerId to append
-   * @param appended values
-   */
-  CompletionStage<Void> appendConfigs(int brokerId, Map<String, String> appended);
 
   /**
    * unset the value associated to given keys. The unset config will become either null of default

--- a/common/src/main/java/org/astraea/common/admin/AsyncAdmin.java
+++ b/common/src/main/java/org/astraea/common/admin/AsyncAdmin.java
@@ -281,6 +281,14 @@ public interface AsyncAdmin extends AutoCloseable {
   CompletionStage<Void> setConfigs(String topic, Map<String, String> override);
 
   /**
+   * append the value to config. Noted that it appends nothing if the existent value is "*".
+   *
+   * @param topic to append
+   * @param appended values
+   */
+  CompletionStage<Void> appendConfigs(String topic, Map<String, String> appended);
+
+  /**
    * unset the value associated to given keys. The unset config will become either null of default
    * value. Normally, the default value is defined by server.properties or hardcode in source code.
    */
@@ -288,6 +296,14 @@ public interface AsyncAdmin extends AutoCloseable {
 
   /** @param override defines the key and new value. The other undefined keys won't get changed. */
   CompletionStage<Void> setConfigs(int brokerId, Map<String, String> override);
+
+  /**
+   * append the value to config. Noted that it appends nothing if the existent value is "*".
+   *
+   * @param brokerId to append
+   * @param appended values
+   */
+  CompletionStage<Void> appendConfigs(int brokerId, Map<String, String> appended);
 
   /**
    * unset the value associated to given keys. The unset config will become either null of default

--- a/common/src/main/java/org/astraea/common/admin/BrokerConfigs.java
+++ b/common/src/main/java/org/astraea/common/admin/BrokerConfigs.java
@@ -47,8 +47,6 @@ public final class BrokerConfigs {
   public static final String MAX_CONNECTIONS_PER_IP_CONFIG = "max.connections.per.ip";
   public static final String MAX_CONNECTIONS_PER_IP_OVERRIDES_CONFIG =
       "max.connections.per.ip.overrides";
-  public static final String MAX_CONNECTION_CREATION_RATE_PR_CONFIG =
-      "max.connection.creation.rate";
   public static final String LOG_SEGMENT_BYTES_CONFIG = "log.segment.bytes";
   public static final String LOG_ROLL_TIME_MILLIS_CONFIG = "log.roll.ms";
   public static final String LOG_ROLL_TIME_JITTER_MILLIS_CONFIG = "log.roll.jitter.ms";

--- a/common/src/main/java/org/astraea/common/admin/Config.java
+++ b/common/src/main/java/org/astraea/common/admin/Config.java
@@ -27,7 +27,7 @@ public interface Config {
   static Config of(org.apache.kafka.clients.admin.Config config) {
     var configs =
         config.entries().stream()
-            .filter(e -> e.value() != null)
+            .filter(e -> e.value() != null && !e.value().isBlank())
             .collect(Collectors.toUnmodifiableMap(ConfigEntry::name, ConfigEntry::value));
     return new Config() {
       @Override

--- a/common/src/test/java/org/astraea/common/admin/AsyncAdminTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AsyncAdminTest.java
@@ -1494,4 +1494,139 @@ public class AsyncAdminTest extends RequireBrokerCluster {
       Assertions.assertEquals(t + 3, ts.get(TopicPartition.of(topic, 3)));
     }
   }
+
+  @Test
+  void testAppendConfigsToTopic() throws ExecutionException, InterruptedException {
+    var topic = Utils.randomString();
+    try (var admin = AsyncAdmin.of(bootstrapServers())) {
+      admin
+          .creator()
+          .topic(topic)
+          .numberOfPartitions(1)
+          .numberOfReplicas((short) 3)
+          .run()
+          .toCompletableFuture()
+          .get();
+
+      Utils.sleep(Duration.ofSeconds(3));
+
+      // append to nonexistent value
+      Assertions.assertEquals(
+          Optional.empty(),
+          admin
+              .topics(Set.of(topic))
+              .toCompletableFuture()
+              .get()
+              .get(0)
+              .config()
+              .value(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG));
+      admin
+          .appendConfigs(
+              topic, Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "1:1001"))
+          .toCompletableFuture()
+          .get();
+      Assertions.assertEquals(
+          "1:1001",
+          admin
+              .topics(Set.of(topic))
+              .toCompletableFuture()
+              .get()
+              .get(0)
+              .config()
+              .value(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG)
+              .get());
+
+      // append to existent value
+      admin
+          .appendConfigs(
+              topic, Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "2:1002"))
+          .toCompletableFuture()
+          .get();
+      Assertions.assertEquals(
+          "1:1001,2:1002",
+          admin
+              .topics(Set.of(topic))
+              .toCompletableFuture()
+              .get()
+              .get(0)
+              .config()
+              .value(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG)
+              .get());
+
+      // append duplicate value
+      admin
+          .appendConfigs(
+              topic, Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "2:1002"))
+          .toCompletableFuture()
+          .get();
+      Assertions.assertEquals(
+          "1:1001,2:1002",
+          admin
+              .topics(Set.of(topic))
+              .toCompletableFuture()
+              .get()
+              .get(0)
+              .config()
+              .value(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG)
+              .get());
+
+      // append to wildcard
+      admin
+          .setConfigs(
+              topic, Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "*"))
+          .toCompletableFuture()
+          .get();
+      Assertions.assertEquals(
+          "*",
+          admin
+              .topics(Set.of(topic))
+              .toCompletableFuture()
+              .get()
+              .get(0)
+              .config()
+              .value(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG)
+              .get());
+      admin
+          .appendConfigs(
+              topic, Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "1:1001"))
+          .toCompletableFuture()
+          .get();
+      Assertions.assertEquals(
+          "*",
+          admin
+              .topics(Set.of(topic))
+              .toCompletableFuture()
+              .get()
+              .get(0)
+              .config()
+              .value(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG)
+              .get());
+    }
+  }
+
+  @Test
+  void testValueOfConfigs() throws ExecutionException, InterruptedException {
+    try (var admin = AsyncAdmin.of(bootstrapServers())) {
+      admin
+          .topics(admin.topicNames(true).toCompletableFuture().get())
+          .toCompletableFuture()
+          .get()
+          .forEach(
+              t ->
+                  t.config()
+                      .raw()
+                      .forEach(
+                          (k, v) -> Assertions.assertNotEquals(0, v.trim().length(), "key: " + k)));
+      admin
+          .brokers()
+          .toCompletableFuture()
+          .get()
+          .forEach(
+              t ->
+                  t.config()
+                      .raw()
+                      .forEach(
+                          (k, v) -> Assertions.assertNotEquals(0, v.trim().length(), "key: " + k)));
+    }
+  }
 }

--- a/common/src/test/java/org/astraea/common/admin/BrokerConfigsTest.java
+++ b/common/src/test/java/org/astraea/common/admin/BrokerConfigsTest.java
@@ -36,4 +36,11 @@ public class BrokerConfigsTest {
     Assertions.assertTrue(
         BrokerConfigs.DYNAMICAL_CONFIGS.contains(BrokerConfigs.NUM_REPLICA_FETCHERS_CONFIG));
   }
+
+  @Test
+  void testDuplicate() {
+    Assertions.assertEquals(
+        BrokerConfigs.DYNAMICAL_CONFIGS.size(),
+        BrokerConfigs.DYNAMICAL_CONFIGS.stream().distinct().count());
+  }
 }


### PR DESCRIPTION
為了後續方便使用，在過程中做了幾個蜜糖：

*APPEND*
1. 值重複時則不append
2. 空值時改成 set，避免遇到bug (https://github.com/apache/kafka/pull/12503)
3. 值為*時也不append

*SUBTRACT*
1. 值為空時不subtract
2. 沒有對應的值時也不subtract
3. 值為*時則拋出錯誤