### PR TITLE
[GUI] remove useless select items

### DIFF
--- a/common/src/main/java/org/astraea/common/admin/Partition.java
+++ b/common/src/main/java/org/astraea/common/admin/Partition.java
@@ -28,7 +28,8 @@ public interface Partition {
       List<NodeInfo> isr,
       long earliestOffset,
       long latestOffset,
-      Optional<Long> maxTimestamp) {
+      Optional<Long> maxTimestamp,
+      boolean internal) {
     return new Partition() {
 
       @Override
@@ -70,6 +71,11 @@ public interface Partition {
       public List<NodeInfo> isr() {
         return isr;
       }
+
+      @Override
+      public boolean internal() {
+        return internal;
+      }
     };
   }
 
@@ -99,4 +105,7 @@ public interface Partition {
   List<NodeInfo> replicas();
 
   List<NodeInfo> isr();
+
+  /** @return true if this topic is internal (system) topic */
+  boolean internal();
 }

--- a/common/src/test/java/org/astraea/common/admin/AsyncAdminTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AsyncAdminTest.java
@@ -685,6 +685,26 @@ public class AsyncAdminTest extends RequireBrokerCluster {
                   .size());
           Assertions.assertEquals(
               1, admin.consumerGroups(Set.of("abc")).toCompletableFuture().get().size());
+
+          // test internal
+          Assertions.assertNotEquals(
+              0,
+              admin
+                  .topics(admin.topicNames(true).toCompletableFuture().get())
+                  .toCompletableFuture()
+                  .get()
+                  .stream()
+                  .filter(Topic::internal)
+                  .count());
+          Assertions.assertNotEquals(
+              0,
+              admin
+                  .partitions(admin.topicNames(true).toCompletableFuture().get())
+                  .toCompletableFuture()
+                  .get()
+                  .stream()
+                  .filter(Partition::internal)
+                  .count());
         }
       }
     }

--- a/gui/src/main/java/org/astraea/gui/pane/PaneBuilder.java
+++ b/gui/src/main/java/org/astraea/gui/pane/PaneBuilder.java
@@ -98,7 +98,10 @@ public class PaneBuilder {
       BiFunction<Input, Logger, CompletionStage<List<Map<String, Object>>>> buttonAction) {
     this.buttonAction = buttonAction;
     var queryField =
-        TextInput.singleLine().hint("c0=aa||c1<20||c2>30MB||c3>=2022-10-22T04:57:43.530").build();
+        TextInput.singleLine()
+            .hint(
+                "press ENTER to query. example: topic=chia && size>10GB || *timestamp*>=2022-10-22T04:57:43.530")
+            .build();
     var sizeLabel = KeyLabel.of("");
 
     tableViewer =

--- a/gui/src/main/java/org/astraea/gui/tab/ClientTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/ClientTab.java
@@ -36,21 +36,16 @@ import org.astraea.common.admin.ProducerState;
 import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.admin.Transaction;
 import org.astraea.gui.Context;
-import org.astraea.gui.button.SelectBox;
-import org.astraea.gui.pane.Input;
 import org.astraea.gui.pane.PaneBuilder;
 import org.astraea.gui.pane.Tab;
 import org.astraea.gui.pane.TabPane;
 
 public class ClientTab {
 
-  private static final String ACTIVE_KEY = "active";
-
   private static List<Map<String, Object>> consumerResult(
-      List<ConsumerGroup> cgs, List<Partition> partitions, Input input) {
+      List<ConsumerGroup> cgs, List<Partition> partitions) {
     var pts = partitions.stream().collect(Collectors.groupingBy(Partition::topicPartition));
     return cgs.stream()
-        .filter(cg -> !input.selectedKeys().contains(ACTIVE_KEY) || !cg.assignment().isEmpty())
         .flatMap(
             cg ->
                 Stream.concat(
@@ -92,7 +87,6 @@ public class ClientTab {
     return Tab.of(
         "consumer",
         PaneBuilder.of()
-            .selectBox(SelectBox.single(List.of(ACTIVE_KEY)))
             .buttonAction(
                 (input, logger) ->
                     FutureUtils.combine(
@@ -104,7 +98,7 @@ public class ClientTab {
                             .admin()
                             .topicNames(true)
                             .thenCompose(names -> context.admin().partitions(names)),
-                        (cgs, partitions) -> consumerResult(cgs, partitions, input)))
+                        ClientTab::consumerResult))
             .build());
   }
 

--- a/gui/src/main/java/org/astraea/gui/tab/topic/PartitionTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/topic/PartitionTab.java
@@ -34,7 +34,6 @@ import org.astraea.common.admin.Partition;
 import org.astraea.common.admin.Topic;
 import org.astraea.common.admin.TopicPartition;
 import org.astraea.gui.Context;
-import org.astraea.gui.button.SelectBox;
 import org.astraea.gui.pane.PaneBuilder;
 import org.astraea.gui.pane.Tab;
 import org.astraea.gui.text.KeyLabel;
@@ -53,6 +52,7 @@ public class PartitionTab {
               var result = new LinkedHashMap<String, Object>();
               result.put(TOPIC_NAME_KEY, p.topic());
               result.put(PARTITION_KEY, p.partition());
+              result.put("internal", p.internal());
               p.leader().ifPresent(l -> result.put("leader", l.id()));
               result.put(
                   "replicas",
@@ -79,13 +79,11 @@ public class PartitionTab {
   }
 
   static Tab tab(Context context) {
-    var includeInternal = "internal";
     var moveToKey = "move to brokers";
     var offsetKey = "truncate to offset";
     return Tab.of(
         "partition",
         PaneBuilder.of()
-            .selectBox(SelectBox.single(List.of(includeInternal)))
             .tableViewAction(
                 MapUtils.of(
                     KeyLabel.of(moveToKey),
@@ -171,7 +169,7 @@ public class PartitionTab {
                 (input, logger) ->
                     context
                         .admin()
-                        .topicNames(input.selectedKeys().contains(includeInternal))
+                        .topicNames(true)
                         .thenCompose(context.admin()::partitions)
                         .thenApply(PartitionTab::basicResult))
             .build());

--- a/gui/src/main/java/org/astraea/gui/tab/topic/ReplicaTab.java
+++ b/gui/src/main/java/org/astraea/gui/tab/topic/ReplicaTab.java
@@ -16,127 +16,65 @@
  */
 package org.astraea.gui.tab.topic;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.astraea.common.DataSize;
-import org.astraea.common.MapUtils;
 import org.astraea.common.admin.Replica;
 import org.astraea.common.admin.ReplicaInfo;
 import org.astraea.gui.Context;
-import org.astraea.gui.button.SelectBox;
 import org.astraea.gui.pane.PaneBuilder;
 import org.astraea.gui.pane.Tab;
 
 public class ReplicaTab {
 
-  private static List<Map<String, Object>> offlineResult(List<Replica> replicas) {
-    return replicas.stream()
-        .filter(ReplicaInfo::isOffline)
-        .map(
-            replica ->
-                MapUtils.<String, Object>of(
-                    "topic",
-                    replica.topic(),
-                    "partition",
-                    replica.partition(),
-                    "broker",
-                    replica.nodeInfo().id(),
-                    "leader",
-                    replica.isLeader(),
-                    "isPreferredLeader",
-                    replica.isPreferredLeader()))
-        .collect(Collectors.toList());
-  }
-
-  private static List<Map<String, Object>> syncingResult(List<Replica> replicas) {
+  private static List<Map<String, Object>> allResult(List<Replica> replicas) {
     var leaderSizes =
         replicas.stream()
             .filter(ReplicaInfo::isLeader)
             .collect(Collectors.toMap(ReplicaInfo::topicPartition, Replica::size));
     return replicas.stream()
-        .filter(r -> !r.inSync())
-        .filter(r -> r.path() != null)
-        .filter(ReplicaInfo::isOnline)
         .map(
             replica -> {
               var leaderSize = leaderSizes.getOrDefault(replica.topicPartition(), 0L);
-              return MapUtils.<String, Object>of(
-                  "topic",
-                  replica.topic(),
-                  "partition",
-                  replica.partition(),
-                  "broker",
-                  replica.nodeInfo().id(),
-                  "path",
-                  replica.path(),
-                  "leader",
-                  replica.isLeader(),
-                  "isPreferredLeader",
-                  replica.isPreferredLeader(),
-                  "size",
-                  DataSize.Byte.of(replica.size()),
-                  "leader size",
-                  DataSize.Byte.of(leaderSize),
-                  "progress",
-                  String.format(
-                      "%.2f%%",
-                      leaderSize == 0
-                          ? 100D
-                          : ((double) replica.size() / (double) leaderSize) * 100));
+              var result = new LinkedHashMap<String, Object>();
+              result.put("topic", replica.topic());
+              result.put("partition", replica.partition());
+              result.put("broker", replica.nodeInfo().id());
+              if (replica.path() != null) result.put("path", replica.path());
+              result.put("isLeader", replica.isLeader());
+              result.put("isPreferredLeader", replica.isPreferredLeader());
+              result.put("isOffline", replica.isOffline());
+              result.put("isFuture", replica.isFuture());
+              result.put("lag", replica.lag());
+              result.put("size", DataSize.Byte.of(replica.size()));
+              if (leaderSize > replica.size()) {
+                result.put("leader size", DataSize.Byte.of(leaderSize));
+                result.put(
+                    "progress",
+                    String.format(
+                        "%.2f%%",
+                        leaderSize == 0
+                            ? 100D
+                            : ((double) replica.size() / (double) leaderSize) * 100));
+              }
+              return result;
             })
         .collect(Collectors.toList());
   }
 
-  private static List<Map<String, Object>> allResult(List<Replica> replicas) {
-    return replicas.stream()
-        .map(
-            replica ->
-                MapUtils.<String, Object>of(
-                    "topic",
-                    replica.topic(),
-                    "partition",
-                    replica.partition(),
-                    "broker",
-                    replica.nodeInfo().id(),
-                    "path",
-                    replica.path() == null ? "unknown" : replica.path(),
-                    "leader",
-                    replica.isLeader(),
-                    "isPreferredLeader",
-                    replica.isPreferredLeader(),
-                    "offline",
-                    replica.isOffline(),
-                    "future",
-                    replica.isFuture(),
-                    "lag",
-                    replica.lag(),
-                    "size",
-                    DataSize.Byte.of(replica.size())))
-        .collect(Collectors.toList());
-  }
-
   static Tab tab(Context context) {
-    var all = "all";
-    var syncing = "syncing";
-    var offline = "offline";
     return Tab.of(
         "replica",
         PaneBuilder.of()
-            .selectBox(SelectBox.single(List.of(all, syncing, offline)))
             .buttonAction(
                 (input, logger) ->
                     context
                         .admin()
                         .topicNames(true)
                         .thenCompose(context.admin()::replicas)
-                        .thenApply(
-                            replicas -> {
-                              var selected = input.selectedKeys();
-                              if (selected.contains(syncing)) return syncingResult(replicas);
-                              if (selected.contains(offline)) return offlineResult(replicas);
-                              return allResult(replicas);
-                            }))
+                        .thenApply(ReplicaTab::allResult))
             .build());
   }
 }


### PR DESCRIPTION
現在我們支援豐富的 table query，因此可以將一些重複功能的 select items移除，此外也將`internal`的資訊放回 table 內供使用者查詢