### PR TITLE
fix ReplicaLeaderCost

### DIFF
--- a/common/src/main/java/org/astraea/common/admin/ClusterInfo.java
+++ b/common/src/main/java/org/astraea/common/admin/ClusterInfo.java
@@ -245,6 +245,20 @@ public interface ClusterInfo<T extends ReplicaInfo> {
   }
 
   /**
+   * Get the list of replica leaders of given node
+   *
+   * @param broker the broker id
+   * @return A list of {@link ReplicaInfo}.
+   */
+  default List<T> replicaLeaders(int broker) {
+    return replicaStream()
+        .filter(r -> r.nodeInfo().id() == broker)
+        .filter(ReplicaInfo::isLeader)
+        .filter(ReplicaInfo::isOnline)
+        .collect(Collectors.toUnmodifiableList());
+  }
+
+  /**
    * Get the list of replica leaders of given topic on the given node
    *
    * @param broker the broker id

--- a/common/src/main/java/org/astraea/common/cost/ReplicaLeaderCost.java
+++ b/common/src/main/java/org/astraea/common/cost/ReplicaLeaderCost.java
@@ -77,11 +77,9 @@ public class ReplicaLeaderCost implements HasBrokerCost, HasClusterCost, HasMove
   }
 
   static Map<Integer, Integer> leaderCount(ClusterInfo<? extends ReplicaInfo> clusterInfo) {
-    return clusterInfo.replicaLeaders().stream()
-        .collect(Collectors.groupingBy(r -> r.nodeInfo().id()))
-        .entrySet()
-        .stream()
-        .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> e.getValue().size()));
+    return clusterInfo.nodes().stream()
+        .map(nodeInfo -> Map.entry(nodeInfo.id(), clusterInfo.replicaLeaders(nodeInfo.id()).size()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
   @Override


### PR DESCRIPTION
使用`ClusterInfo`來計算`BrokerCost`與`ClusterCost`也必須考慮到沒有持有任何replica的broker，否則造成計算`ClusterCost`時，結果不正確