### PR TITLE
Enable to update configs in batch

### DIFF
--- a/app/src/main/java/org/astraea/app/web/ThrottleHandler.java
+++ b/app/src/main/java/org/astraea/app/web/ThrottleHandler.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.astraea.common.DataRate;
 import org.astraea.common.EnumInfo;
 import org.astraea.common.FutureUtils;
 import org.astraea.common.admin.AsyncAdmin;
@@ -159,9 +158,18 @@ public class ThrottleHandler implements Handler {
                                                                   .collect(
                                                                       Collectors.joining(","))))));
                             })
-                        .collect(Collectors.toList()));
+                        .collect(
+                            Collectors.toMap(
+                                Map.Entry::getKey,
+                                Map.Entry::getValue,
+                                (l, r) -> {
+                                  // Merge the duplicate topic requests by order
+                                  var merged = new HashMap<>(l);
+                                  merged.putAll(r);
+                                  return merged;
+                                })));
 
-    var brokerToAppend =
+    Map<Integer, Map<String, String>> brokerToSets =
         channel
             .request()
             .<Collection<BrokerThrottle>>get(
@@ -186,20 +194,8 @@ public class ThrottleHandler implements Handler {
                     }));
 
     return topicToAppends
-        .thenCompose(
-            ts ->
-                FutureUtils.sequence(
-                    ts.stream()
-                        .map(
-                            t ->
-                                admin.appendConfigs(t.getKey(), t.getValue()).toCompletableFuture())
-                        .collect(Collectors.toList())))
-        .thenCompose(
-            ignored ->
-                FutureUtils.sequence(
-                    brokerToAppend.entrySet().stream()
-                        .map(e -> admin.setConfigs(e.getKey(), e.getValue()).toCompletableFuture())
-                        .collect(Collectors.toList())))
+        .thenCompose(admin::appendTopicConfigs)
+        .thenCompose(ignored -> admin.setBrokerConfigs(brokerToSets))
         .thenApply(ignored -> Response.ACCEPT);
   }
 
@@ -257,7 +253,7 @@ public class ThrottleHandler implements Handler {
                                                   entry.getValue().stream()
                                                       .map(r -> r.partition() + ":" + r.brokerId())
                                                       .collect(Collectors.joining(","))))))
-                      .collect(Collectors.toList());
+                      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
                 });
 
     var brokerToUnset =
@@ -307,28 +303,8 @@ public class ThrottleHandler implements Handler {
                                         .collect(Collectors.toSet()))));
 
     return topicToSubtracts
-        .thenCompose(
-            ts ->
-                FutureUtils.sequence(
-                    ts.stream()
-                        .map(
-                            t ->
-                                admin
-                                    .subtractConfigs(t.getKey(), t.getValue())
-                                    .toCompletableFuture())
-                        .collect(Collectors.toList())))
-        .thenCompose(
-            ignored ->
-                brokerToUnset.thenCompose(
-                    bs ->
-                        FutureUtils.sequence(
-                            bs.entrySet().stream()
-                                .map(
-                                    e ->
-                                        admin
-                                            .unsetConfigs(e.getKey(), e.getValue())
-                                            .toCompletableFuture())
-                                .collect(Collectors.toList()))))
+        .thenCompose(admin::subtractTopicConfigs)
+        .thenCompose(ignored -> brokerToUnset.thenCompose(admin::unsetBrokerConfigs))
         .thenApply(ignored -> Response.ACCEPT);
   }
 
@@ -389,13 +365,6 @@ public class ThrottleHandler implements Handler {
     final int id;
     final Long follower;
     final Long leader;
-
-    static BrokerThrottle of(int id, DataRate ingress, DataRate egress) {
-      return new BrokerThrottle(
-          id,
-          (ingress != null) ? ((long) ingress.byteRate()) : (null),
-          (egress != null) ? ((long) egress.byteRate()) : (null));
-    }
 
     BrokerThrottle(int id, Long ingress, Long egress) {
       this.id = id;

--- a/common/src/main/java/org/astraea/common/admin/AsyncAdmin.java
+++ b/common/src/main/java/org/astraea/common/admin/AsyncAdmin.java
@@ -281,38 +281,36 @@ public interface AsyncAdmin extends AutoCloseable {
   CompletionStage<Void> addPartitions(String topic, int total);
 
   /** @param override defines the key and new value. The other undefined keys won't get changed. */
-  CompletionStage<Void> setConfigs(String topic, Map<String, String> override);
+  CompletionStage<Void> setTopicConfigs(Map<String, Map<String, String>> override);
 
   /**
    * append the value to config. Noted that it appends nothing if the existent value is "*".
    *
-   * @param topic to append
-   * @param subtracted values
+   * @param appended values
    */
-  CompletionStage<Void> appendConfigs(String topic, Map<String, String> subtracted);
+  CompletionStage<Void> appendTopicConfigs(Map<String, Map<String, String>> appended);
 
   /**
    * subtract the value to config. Noted that it throws exception if the existent value is "*".
    *
-   * @param topic to append
-   * @param appended values
+   * @param subtract values
    */
-  CompletionStage<Void> subtractConfigs(String topic, Map<String, String> appended);
+  CompletionStage<Void> subtractTopicConfigs(Map<String, Map<String, String>> subtract);
 
   /**
    * unset the value associated to given keys. The unset config will become either null of default
    * value. Normally, the default value is defined by server.properties or hardcode in source code.
    */
-  CompletionStage<Void> unsetConfigs(String topic, Set<String> keys);
+  CompletionStage<Void> unsetTopicConfigs(Map<String, Set<String>> unset);
 
   /** @param override defines the key and new value. The other undefined keys won't get changed. */
-  CompletionStage<Void> setConfigs(int brokerId, Map<String, String> override);
+  CompletionStage<Void> setBrokerConfigs(Map<Integer, Map<String, String>> override);
 
   /**
    * unset the value associated to given keys. The unset config will become either null of default
    * value. Normally, the default value is defined by server.properties or hardcode in source code.
    */
-  CompletionStage<Void> unsetConfigs(int brokerId, Set<String> keys);
+  CompletionStage<Void> unsetBrokerConfigs(Map<Integer, Set<String>> unset);
 
   /** delete topics by topic names */
   CompletionStage<Void> deleteTopics(Set<String> topics);

--- a/common/src/main/java/org/astraea/common/admin/Broker.java
+++ b/common/src/main/java/org/astraea/common/admin/Broker.java
@@ -28,10 +28,10 @@ public interface Broker extends NodeInfo {
   static Broker of(
       boolean isController,
       org.apache.kafka.common.Node nodeInfo,
-      org.apache.kafka.clients.admin.Config kafkaConfig,
+      Map<String, String> configs,
       Map<String, DescribeLogDirsResponse.LogDirInfo> dirs,
       Collection<org.apache.kafka.clients.admin.TopicDescription> topics) {
-    var config = Config.of(kafkaConfig);
+    var config = Config.of(configs);
     var partitionsFromTopicDesc =
         topics.stream()
             .flatMap(

--- a/common/src/main/java/org/astraea/common/admin/Config.java
+++ b/common/src/main/java/org/astraea/common/admin/Config.java
@@ -18,17 +18,10 @@ package org.astraea.common.admin;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import org.apache.kafka.clients.admin.ConfigEntry;
 
 /** this interface used to represent the resource (topic or broker) configuration. */
 public interface Config {
-
-  static Config of(org.apache.kafka.clients.admin.Config config) {
-    var configs =
-        config.entries().stream()
-            .filter(e -> e.value() != null && !e.value().isBlank())
-            .collect(Collectors.toUnmodifiableMap(ConfigEntry::name, ConfigEntry::value));
+  static Config of(Map<String, String> configs) {
     return new Config() {
       @Override
       public Map<String, String> raw() {

--- a/common/src/main/java/org/astraea/common/admin/Topic.java
+++ b/common/src/main/java/org/astraea/common/admin/Topic.java
@@ -16,6 +16,7 @@
  */
 package org.astraea.common.admin;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -24,7 +25,7 @@ public interface Topic {
   static Topic of(
       String name,
       org.apache.kafka.clients.admin.TopicDescription topicDescription,
-      org.apache.kafka.clients.admin.Config kafkaConfig) {
+      Map<String, String> kafkaConfig) {
 
     var config = Config.of(kafkaConfig);
     var topicPartitions =

--- a/common/src/test/java/org/astraea/common/admin/AsyncAdminTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AsyncAdminTest.java
@@ -345,7 +345,7 @@ public class AsyncAdminTest extends RequireBrokerCluster {
       Utils.sleep(Duration.ofSeconds(2));
 
       admin
-          .setConfigs(topic, Map.of(TopicConfigs.FILE_DELETE_DELAY_MS_CONFIG, "3000"))
+          .setTopicConfigs(Map.of(topic, Map.of(TopicConfigs.FILE_DELETE_DELAY_MS_CONFIG, "3000")))
           .toCompletableFuture()
           .get();
       Utils.sleep(Duration.ofSeconds(2));
@@ -353,7 +353,7 @@ public class AsyncAdminTest extends RequireBrokerCluster {
       Assertions.assertEquals("3000", config.value(TopicConfigs.FILE_DELETE_DELAY_MS_CONFIG).get());
 
       admin
-          .unsetConfigs(topic, Set.of(TopicConfigs.FILE_DELETE_DELAY_MS_CONFIG))
+          .unsetTopicConfigs(Map.of(topic, Set.of(TopicConfigs.FILE_DELETE_DELAY_MS_CONFIG)))
           .toCompletableFuture()
           .get();
       Utils.sleep(Duration.ofSeconds(2));
@@ -365,14 +365,13 @@ public class AsyncAdminTest extends RequireBrokerCluster {
 
   @Test
   void testSetAndUnsetBrokerConfig() throws ExecutionException, InterruptedException {
-    var topic = Utils.randomString();
     try (var admin = AsyncAdmin.of(bootstrapServers())) {
       var broker = admin.brokers().toCompletableFuture().get().get(0);
       var id = broker.id();
       Assertions.assertEquals("producer", broker.config().value("compression.type").get());
 
       admin
-          .setConfigs(id, Map.of(BrokerConfigs.COMPRESSION_TYPE_CONFIG, "gzip"))
+          .setBrokerConfigs(Map.of(id, Map.of(BrokerConfigs.COMPRESSION_TYPE_CONFIG, "gzip")))
           .toCompletableFuture()
           .get();
       Utils.sleep(Duration.ofSeconds(2));
@@ -385,7 +384,7 @@ public class AsyncAdminTest extends RequireBrokerCluster {
           "gzip", broker.config().value(BrokerConfigs.COMPRESSION_TYPE_CONFIG).get());
 
       admin
-          .unsetConfigs(id, Set.of(BrokerConfigs.COMPRESSION_TYPE_CONFIG))
+          .unsetBrokerConfigs(Map.of(id, Set.of(BrokerConfigs.COMPRESSION_TYPE_CONFIG)))
           .toCompletableFuture()
           .get();
       Utils.sleep(Duration.ofSeconds(2));
@@ -1545,8 +1544,10 @@ public class AsyncAdminTest extends RequireBrokerCluster {
               .config()
               .value(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG));
       admin
-          .appendConfigs(
-              topic, Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "1:1001"))
+          .appendTopicConfigs(
+              Map.of(
+                  topic,
+                  Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "1:1001")))
           .toCompletableFuture()
           .get();
       Assertions.assertEquals(
@@ -1562,8 +1563,10 @@ public class AsyncAdminTest extends RequireBrokerCluster {
 
       // append to existent value
       admin
-          .appendConfigs(
-              topic, Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "2:1002"))
+          .appendTopicConfigs(
+              Map.of(
+                  topic,
+                  Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "2:1002")))
           .toCompletableFuture()
           .get();
       Assertions.assertEquals(
@@ -1579,8 +1582,10 @@ public class AsyncAdminTest extends RequireBrokerCluster {
 
       // append duplicate value
       admin
-          .appendConfigs(
-              topic, Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "2:1002"))
+          .appendTopicConfigs(
+              Map.of(
+                  topic,
+                  Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "2:1002")))
           .toCompletableFuture()
           .get();
       Assertions.assertEquals(
@@ -1596,8 +1601,9 @@ public class AsyncAdminTest extends RequireBrokerCluster {
 
       // append to wildcard
       admin
-          .setConfigs(
-              topic, Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "*"))
+          .setTopicConfigs(
+              Map.of(
+                  topic, Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "*")))
           .toCompletableFuture()
           .get();
       Assertions.assertEquals(
@@ -1611,8 +1617,10 @@ public class AsyncAdminTest extends RequireBrokerCluster {
               .value(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG)
               .get());
       admin
-          .appendConfigs(
-              topic, Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "1:1001"))
+          .appendTopicConfigs(
+              Map.of(
+                  topic,
+                  Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "1:1001")))
           .toCompletableFuture()
           .get();
       Assertions.assertEquals(
@@ -1645,14 +1653,19 @@ public class AsyncAdminTest extends RequireBrokerCluster {
 
       // subtract existent value
       admin
-          .setConfigs(
-              topic,
-              Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "1:1001,2:1003"))
+          .setTopicConfigs(
+              Map.of(
+                  topic,
+                  Map.of(
+                      TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG,
+                      "1:1001,2:1003")))
           .toCompletableFuture()
           .get();
       admin
-          .subtractConfigs(
-              topic, Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "1:1001"))
+          .subtractTopicConfigs(
+              Map.of(
+                  topic,
+                  Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "1:1001")))
           .toCompletableFuture()
           .get();
       Assertions.assertEquals(
@@ -1668,8 +1681,10 @@ public class AsyncAdminTest extends RequireBrokerCluster {
 
       // subtract nonexistent value
       admin
-          .subtractConfigs(
-              topic, Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "1:1001"))
+          .subtractTopicConfigs(
+              Map.of(
+                  topic,
+                  Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "1:1001")))
           .toCompletableFuture()
           .get();
       Assertions.assertEquals(
@@ -1685,8 +1700,9 @@ public class AsyncAdminTest extends RequireBrokerCluster {
 
       // can't subtract *
       admin
-          .setConfigs(
-              topic, Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "*"))
+          .setTopicConfigs(
+              Map.of(
+                  topic, Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "*")))
           .toCompletableFuture()
           .get();
 
@@ -1696,11 +1712,12 @@ public class AsyncAdminTest extends RequireBrokerCluster {
                   ExecutionException.class,
                   () ->
                       admin
-                          .subtractConfigs(
-                              topic,
+                          .subtractTopicConfigs(
                               Map.of(
-                                  TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG,
-                                  "1:1001"))
+                                  topic,
+                                  Map.of(
+                                      TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG,
+                                      "1:1001")))
                           .toCompletableFuture()
                           .get())
               .getCause());
@@ -1760,7 +1777,7 @@ public class AsyncAdminTest extends RequireBrokerCluster {
               .stream()
               .filter(entry -> TopicConfigs.ALL_CONFIGS.contains(entry.getKey()))
               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-      admin.setConfigs(topic, sets).toCompletableFuture().get();
+      admin.setTopicConfigs(Map.of(topic, sets)).toCompletableFuture().get();
     }
   }
 
@@ -1772,7 +1789,7 @@ public class AsyncAdminTest extends RequireBrokerCluster {
           broker.config().raw().entrySet().stream()
               .filter(entry -> BrokerConfigs.DYNAMICAL_CONFIGS.contains(entry.getKey()))
               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-      admin.setConfigs(broker.id(), sets).toCompletableFuture().get();
+      admin.setBrokerConfigs(Map.of(broker.id(), sets)).toCompletableFuture().get();
     }
   }
 }

--- a/docs/web_server/web_api_throttles_chinese.md
+++ b/docs/web_server/web_api_throttles_chinese.md
@@ -110,6 +110,7 @@ topics 每個資料欄位
 
 topic 描述格式只支援 `name`, `name, partition`, `name, partition, broker`, `name, partition, broker, type` 這四種 key 的組合，目前此 API 不支援其他種類的組合，比如 `name, type`。當給與這類型的組合，API 會回傳錯誤。
 
+**注意：topics 欄位中如果有重複的描述，那麼該些資訊會彼此覆蓋，順序不一定**
 
 ## 刪除 throttle 設定
 


### PR DESCRIPTION
`ThrottleHandlerTest`中出現的錯誤是因為我們多個執行緒同時在變更 configs，由於 kafka metadata的資料模型在這個狀況下很容易出現不一致的狀態，因此這隻PR重新設計APIs，讓我們可以批次更新資料，避免太多 requests 造成的不一致