### PR TITLE
Add Lazy object to initialize objs lazily

### DIFF
--- a/common/src/main/java/org/astraea/common/Lazy.java
+++ b/common/src/main/java/org/astraea/common/Lazy.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public interface Lazy<T> {
+
+  static <T> Lazy<T> of(Supplier<T> supplier) {
+    return new Lazy<T>() {
+      private volatile T obj;
+
+      @Override
+      public T get() {
+        if (obj == null) {
+          synchronized (this) {
+            if (obj == null) obj = Objects.requireNonNull(supplier.get());
+          }
+        }
+        return obj;
+      }
+    };
+  }
+
+  /**
+   * the object will get created when this method is called the first time
+   *
+   * @return object
+   */
+  T get();
+}

--- a/common/src/main/java/org/astraea/common/admin/ClusterInfo.java
+++ b/common/src/main/java/org/astraea/common/admin/ClusterInfo.java
@@ -29,6 +29,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.astraea.common.Lazy;
 import org.astraea.common.balancer.log.ClusterLogAllocation;
 
 public interface ClusterInfo<T extends ReplicaInfo> {
@@ -420,85 +421,90 @@ public interface ClusterInfo<T extends ReplicaInfo> {
     private final Set<NodeInfo> nodeInfos;
     private final List<T> all;
 
-    private volatile Map<Map.Entry<Integer, String>, List<T>> byBrokerTopic;
-    private volatile Map<Integer, List<T>> byBroker;
-    private volatile Map<String, List<T>> byTopic;
-    private volatile Map<TopicPartition, List<T>> byPartition;
-    private volatile Map<TopicPartitionReplica, List<T>> byReplica;
+    private final Lazy<Map<Map.Entry<Integer, String>, List<T>>> byBrokerTopic;
+    private final Lazy<Map<Integer, List<T>>> byBroker;
+    private final Lazy<Map<String, List<T>>> byTopic;
+    private final Lazy<Map<TopicPartition, List<T>>> byPartition;
+    private final Lazy<Map<TopicPartitionReplica, List<T>>> byReplica;
 
     protected Optimized(Set<NodeInfo> nodeInfos, List<T> replicas) {
       this.nodeInfos = nodeInfos;
       this.all = replicas;
+      this.byBrokerTopic =
+          Lazy.of(
+              () ->
+                  all.stream()
+                      .collect(
+                          Collectors.groupingBy(
+                              r -> Map.entry(r.nodeInfo().id(), r.topic()),
+                              Collectors.toUnmodifiableList())));
+      this.byBroker =
+          Lazy.of(
+              () ->
+                  all.stream()
+                      .collect(
+                          Collectors.groupingBy(
+                              r -> r.nodeInfo().id(), Collectors.toUnmodifiableList())));
+
+      this.byTopic =
+          Lazy.of(
+              () ->
+                  all.stream()
+                      .collect(
+                          Collectors.groupingBy(
+                              ReplicaInfo::topic, Collectors.toUnmodifiableList())));
+
+      this.byPartition =
+          Lazy.of(
+              () ->
+                  all.stream()
+                      .collect(
+                          Collectors.groupingBy(
+                              ReplicaInfo::topicPartition, Collectors.toUnmodifiableList())));
+
+      this.byReplica =
+          Lazy.of(
+              () ->
+                  all.stream()
+                      .collect(
+                          Collectors.groupingBy(
+                              ReplicaInfo::topicPartitionReplica,
+                              Collectors.toUnmodifiableList())));
     }
 
     @Override
     public Stream<T> replicaStream(String topic) {
-      indexTopic();
-      return byTopic.getOrDefault(topic, List.of()).stream();
+      return byTopic.get().getOrDefault(topic, List.of()).stream();
     }
 
     @Override
     public Stream<T> replicaStream(TopicPartition partition) {
-      indexPartition();
-      return byPartition.getOrDefault(partition, List.of()).stream();
+      return byPartition.get().getOrDefault(partition, List.of()).stream();
     }
 
     @Override
     public Stream<T> replicaStream(TopicPartitionReplica replica) {
-      if (byReplica == null) {
-        synchronized (this) {
-          if (byReplica == null)
-            byReplica =
-                all.stream()
-                    .collect(
-                        Collectors.groupingBy(
-                            ReplicaInfo::topicPartitionReplica, Collectors.toUnmodifiableList()));
-        }
-      }
-      return byReplica.getOrDefault(replica, List.of()).stream();
+      return byReplica.get().getOrDefault(replica, List.of()).stream();
     }
 
     @Override
     public Stream<T> replicaStream(int broker) {
-      if (byBroker == null) {
-        synchronized (this) {
-          if (byBroker == null)
-            byBroker =
-                all.stream()
-                    .collect(
-                        Collectors.groupingBy(
-                            r -> r.nodeInfo().id(), Collectors.toUnmodifiableList()));
-        }
-      }
-      return byBroker.getOrDefault(broker, List.of()).stream();
+      return byBroker.get().getOrDefault(broker, List.of()).stream();
     }
 
     @Override
     public Stream<T> replicaStream(int broker, String topic) {
-      if (byBrokerTopic == null) {
-        synchronized (this) {
-          if (byBrokerTopic == null)
-            byBrokerTopic =
-                all.stream()
-                    .collect(
-                        Collectors.groupingBy(
-                            r -> Map.entry(r.nodeInfo().id(), r.topic()),
-                            Collectors.toUnmodifiableList()));
-        }
-      }
-      return byBrokerTopic.getOrDefault(Map.entry(broker, topic), List.of()).stream();
+      return byBrokerTopic.get().getOrDefault(Map.entry(broker, topic), List.of()).stream();
     }
 
     @Override
     public Set<TopicPartition> topicPartitions() {
-      indexPartition();
-      return byPartition.keySet();
+      return byPartition.get().keySet();
     }
 
     @Override
     public Set<String> topics() {
-      indexTopic();
-      return byTopic.keySet();
+      return byTopic.get().keySet();
     }
 
     @Override
@@ -509,31 +515,6 @@ public interface ClusterInfo<T extends ReplicaInfo> {
     @Override
     public Stream<T> replicaStream() {
       return all.stream();
-    }
-
-    private void indexTopic() {
-      if (byTopic == null) {
-        synchronized (this) {
-          if (byTopic == null)
-            byTopic =
-                all.stream()
-                    .collect(
-                        Collectors.groupingBy(ReplicaInfo::topic, Collectors.toUnmodifiableList()));
-        }
-      }
-    }
-
-    private void indexPartition() {
-      if (byPartition == null) {
-        synchronized (this) {
-          if (byPartition == null)
-            byPartition =
-                all.stream()
-                    .collect(
-                        Collectors.groupingBy(
-                            ReplicaInfo::topicPartition, Collectors.toUnmodifiableList()));
-        }
-      }
     }
   }
 }

--- a/common/src/test/java/org/astraea/common/LazyTest.java
+++ b/common/src/test/java/org/astraea/common/LazyTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class LazyTest {
+
+  @Test
+  void testCountOfGet() {
+    var count = new AtomicInteger();
+    Supplier<String> s =
+        () -> {
+          count.incrementAndGet();
+          return "ss";
+        };
+    var lazy = Lazy.of(s);
+    IntStream.range(0, 10)
+        .mapToObj(
+            ignored -> CompletableFuture.runAsync(() -> Assertions.assertEquals("ss", lazy.get())))
+        .forEach(CompletableFuture::join);
+    Assertions.assertEquals(1, count.get());
+  }
+}


### PR DESCRIPTION
`ClusterInfo`作為我們貫穿各地的物件，我們需要針對大量的replicas做各種索引，但該些索引的建立累積起來也相當費時，因此我們採用lazy手法只有當需要時才建立物件，這隻PR將lazy的手法抽出來成為一個獨立的行為，這樣其他需要的使用者也可以採用