### PR TITLE
Fix flaky `BalancerHandlerTest#testTopics`

### DIFF
--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -148,7 +148,8 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
     var topicNames = createAndProduceTopic(5);
     try (var admin = Admin.of(bootstrapServers())) {
       var handler = new BalancerHandler(admin);
-      // For all 5 topics, we only allow the first two topics can be altered
+      // For all 5 topics, we only allow the first two topics can be altered.
+      // We apply this limitation to test if the BalancerHandler.TOPICS_KEY works correctly.
       var allowedTopics = topicNames.subList(0, 2);
       var report =
           submitPlanGeneration(

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -145,9 +145,10 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
 
   @Test
   void testTopics() {
-    var topicNames = createAndProduceTopic(3);
+    var topicNames = createAndProduceTopic(5);
     try (var admin = Admin.of(bootstrapServers())) {
       var handler = new BalancerHandler(admin);
+      var allowedTopics = topicNames.subList(0, 2);
       var report =
           submitPlanGeneration(
                   handler,
@@ -155,15 +156,12 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                       BalancerHandler.LOOP_KEY,
                       "30",
                       BalancerHandler.TOPICS_KEY,
-                      topicNames.get(0) + "," + topicNames.get(1),
+                      String.join(",", allowedTopics),
                       BalancerHandler.COST_WEIGHT_KEY,
                       defaultDecreasing))
               .report;
-      var actual =
-          report.changes.stream().map(r -> r.topic).collect(Collectors.toUnmodifiableSet());
-      Assertions.assertEquals(2, actual.size());
-      Assertions.assertTrue(actual.contains(topicNames.get(0)));
-      Assertions.assertTrue(actual.contains(topicNames.get(1)));
+      Assertions.assertTrue(
+          report.changes.stream().map(x -> x.topic).allMatch(allowedTopics::contains));
       Assertions.assertTrue(report.cost >= report.newCost);
       var sizeMigration =
           report.migrationCosts.stream().filter(x -> x.function.equals("size")).findFirst().get();


### PR DESCRIPTION
resolve #1047.

原先測試是建 3 個 topics，參數允許特定 2 個 topics 能夠被 Balance，然後測試預期他們兩個都有被搬移。
以現行 Generator 的機制，會隨機從 9 個 topic/partition 中抽 1 ~ 30 個做更動，且這個操作執行 30 次，取 Cost Function 最佳的分佈，由於現在都使用 `decreasing cost` 所以其實 30 次只有最後一次 matter。

由於隨機的關係我們可能會 1 ~ 30 個更動全部都抽到同一個 topic/partition。使最後 `POST /balancer` 得到的 Changes 只有 1 個。

實際上測試假設這兩個 topic/partition 都一定會抽到是不太合理的，隨機下有一定機率會全部更改都坐落在同一個 topic。雖然不確定具體機率是多少，但單看只做 1 個變更的情況，我們可以很肯定觸發這個情況的機率比 `1/30` 還要高(約 3.33%)。

這個 PR 修正測試的檢查條件，所有的 changes 都應該是針對允許的 topics。