### PR TITLE
[GUI] apply StraightPlanExecutor to BalancerNode

### DIFF
--- a/common/src/main/java/org/astraea/common/balancer/executor/StraightPlanExecutor.java
+++ b/common/src/main/java/org/astraea/common/balancer/executor/StraightPlanExecutor.java
@@ -22,13 +22,9 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 import org.astraea.common.admin.Admin;
-import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.Replica;
 import org.astraea.common.admin.ReplicaInfo;
 import org.astraea.common.admin.TopicPartition;
@@ -47,67 +43,84 @@ public class StraightPlanExecutor implements RebalancePlanExecutor {
         .thenCompose(admin::clusterInfo)
         .thenApply(clusterInfo -> findNonFulfilledAllocation(clusterInfo, logAllocation))
         .thenApply(
+            tps ->
+                tps.stream()
+                    .flatMap(tp -> logAllocation.replicas(tp).stream())
+                    .sorted(Comparator.comparing(Replica::isPreferredLeader))
+                    .collect(Collectors.toList()))
+
+        // step.1 move replica to specify brokers/folders
+        .thenCompose(
+            replicas ->
+                run(admin, replicas)
+                    .thenApply(
+                        ignored ->
+                            replicas.stream()
+                                .map(Replica::topicPartitionReplica)
+                                .collect(Collectors.toSet())))
+
+        // step.2 wait all replicas to be synced
+        .thenCompose(
+            replicas ->
+                admin
+                    .waitReplicasSynced(replicas, ChronoUnit.DECADES.getDuration())
+                    .thenApply(
+                        ignored ->
+                            replicas.stream()
+                                .map(TopicPartitionReplica::topicPartition)
+                                .collect(Collectors.toSet())))
+        // step.3 re-elect leaders
+        .thenCompose(
             topicPartitions ->
-                topicPartitions.stream()
-                    .map(
-                        tp ->
-                            logAllocation.replicas(tp).stream()
-                                .sorted(Comparator.comparing(Replica::isPreferredLeader).reversed())
-                                .collect(Collectors.toUnmodifiableList()))
-                    .map(
-                        replicaList ->
-                            admin
-                                .moveToBrokers(toReplicaMap(replicaList))
-                                .thenCompose(i -> waitStart(admin, replicaList))
-                                .thenCompose(i -> admin.moveToFolders(toPathMap(replicaList)))
-                                .thenCompose(
-                                    i ->
-                                        admin.waitReplicasSynced(
-                                            replicaList.stream()
-                                                .map(ReplicaInfo::topicPartitionReplica)
-                                                .collect(Collectors.toSet()),
-                                            ChronoUnit.DECADES.getDuration()))
-                                .thenAccept(c -> assertion(c, "Failed to sync " + replicaList))
-                                .thenCompose(
-                                    i ->
-                                        admin.preferredLeaderElection(
-                                            Set.of(replicaList.get(0).topicPartition())))
-                                .thenCompose(
-                                    i ->
-                                        admin.waitPreferredLeaderSynced(
-                                            Set.of(replicaList.get(0).topicPartition()),
-                                            ChronoUnit.DECADES.getDuration()))
-                                .thenAccept(c -> assertion(c, "Failed to sync " + replicaList)))
-                    .map(CompletionStage::toCompletableFuture)
-                    .toArray(CompletableFuture[]::new))
-        .thenCompose(CompletableFuture::allOf);
+                admin
+                    .preferredLeaderElection(topicPartitions)
+                    .thenCompose(
+                        ignored ->
+                            admin.waitPreferredLeaderSynced(
+                                topicPartitions, ChronoUnit.DECADES.getDuration()))
+                    .thenAccept(c -> assertion(c, "Failed to sync " + topicPartitions)));
   }
 
-  private Map<TopicPartitionReplica, String> toPathMap(List<Replica> replicas) {
-    return replicas.stream()
-        .collect(Collectors.toMap(ReplicaInfo::topicPartitionReplica, Replica::path));
-  }
-
-  private Map<TopicPartition, List<Integer>> toReplicaMap(List<Replica> replicas) {
-    return Map.of(
-        replicas.get(0).topicPartition(),
-        replicas.stream().map(Replica::nodeInfo).map(NodeInfo::id).collect(Collectors.toList()));
+  public CompletionStage<Void> run(Admin admin, List<Replica> replicas) {
+    var moveBrokerRequest =
+        replicas.stream()
+            .sorted(Comparator.comparing(Replica::isPreferredLeader).reversed())
+            .collect(
+                Collectors.groupingBy(
+                    ReplicaInfo::topicPartition,
+                    Collectors.mapping(r -> r.nodeInfo().id(), Collectors.toList())));
+    var moveFolderRequest =
+        replicas.stream()
+            .collect(Collectors.toMap(ReplicaInfo::topicPartitionReplica, Replica::path));
+    return admin
+        // step.1 move replica to specify brokers
+        .moveToBrokers(moveBrokerRequest)
+        // step.2 wait assignment
+        .thenCompose(
+            ignored ->
+                admin.waitCluster(
+                    moveBrokerRequest.keySet().stream()
+                        .map(TopicPartition::topic)
+                        .collect(Collectors.toSet()),
+                    clusterInfo ->
+                        replicas.stream()
+                            .allMatch(
+                                r ->
+                                    clusterInfo
+                                        .replicaStream()
+                                        .anyMatch(
+                                            replica ->
+                                                replica
+                                                    .topicPartitionReplica()
+                                                    .equals(r.topicPartitionReplica()))),
+                    Duration.ofSeconds(15),
+                    2))
+        .thenAccept(done -> assertion(done, "Failed to sync " + moveFolderRequest.keySet()))
+        // step.3 move replica to specify folder
+        .thenCompose(ignored -> admin.moveToFolders(moveFolderRequest));
   }
 
   private void assertion(boolean condition, String info) {
     if (!condition) throw new IllegalStateException(info);
-  }
-
-  private CompletionStage<Boolean> waitStart(Admin admin, List<Replica> replicas) {
-    return admin.waitCluster(
-        Set.of(replicas.get(0).topic()),
-        (cluster) ->
-            replicas.stream()
-                .allMatch(
-                    r ->
-                        cluster.replicas(r.topicPartition()).stream()
-                            .anyMatch(rr -> rr.nodeInfo().id() == r.nodeInfo().id())),
-        Duration.ofSeconds(5),
-        3);
   }
 }

--- a/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
@@ -22,24 +22,31 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javafx.scene.Node;
 import org.astraea.common.DataSize;
+import org.astraea.common.MapUtils;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.admin.Replica;
 import org.astraea.common.admin.ReplicaInfo;
-import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.admin.TopicPartitionReplica;
 import org.astraea.common.balancer.Balancer;
 import org.astraea.common.balancer.algorithms.AlgorithmConfig;
 import org.astraea.common.balancer.algorithms.GreedyBalancer;
+import org.astraea.common.balancer.executor.StraightPlanExecutor;
 import org.astraea.common.cost.HasClusterCost;
+import org.astraea.common.cost.MoveCost;
 import org.astraea.common.cost.ReplicaLeaderCost;
 import org.astraea.common.cost.ReplicaNumberCost;
 import org.astraea.common.cost.ReplicaSizeCost;
+import org.astraea.common.function.Bi3Function;
 import org.astraea.gui.Context;
 import org.astraea.gui.Logger;
 import org.astraea.gui.button.SelectBox;
@@ -51,17 +58,18 @@ import org.astraea.gui.text.TextInput;
 
 public class BalancerNode {
 
+  static final AtomicReference<Balancer.Plan> LAST_PLAN = new AtomicReference<>();
   static final String TOPIC_NAME_KEY = "topic";
   private static final String PARTITION_KEY = "partition";
   private static final String MAX_MIGRATE_LOG_SIZE = "total max migrate log size";
-  private static final String MAX_MIGRATE_LEADER_NUM = "maximum leader number to migrate";
+  static final String MAX_MIGRATE_LEADER_NUM = "maximum leader number to migrate";
   private static final String PREVIOUS_LEADER_KEY = "previous leader";
   private static final String NEW_LEADER_KEY = "new leader";
   private static final String PREVIOUS_FOLLOWER_KEY = "previous follower";
   private static final String NEW_FOLLOWER_KEY = "new follower";
   private static final String NEW_ASSIGNMENT_KEY = "new assignments";
 
-  private enum Cost {
+  enum Cost {
     REPLICA("replica", new ReplicaNumberCost()),
     LEADER("leader", new ReplicaLeaderCost()),
     SIZE("size", new ReplicaSizeCost());
@@ -117,103 +125,136 @@ public class BalancerNode {
         .collect(Collectors.toList());
   }
 
-  static CompletionStage<List<Map<String, Object>>> generator(
-      Context context, Input input, Logger logger) {
-    return context
-        .admin()
-        .topicNames(false)
-        .thenCompose(context.admin()::clusterInfo)
-        .thenCompose(
-            clusterInfo ->
-                context
-                    .admin()
-                    .brokerFolders()
-                    .thenApply(
-                        brokerFolders -> {
-                          var patterns =
-                              input
-                                  .texts()
-                                  .get(TOPIC_NAME_KEY)
-                                  .map(
-                                      ss ->
-                                          Arrays.stream(ss.split(","))
-                                              .map(Utils::wildcardToPattern)
-                                              .collect(Collectors.toList()))
-                                  .orElse(List.of());
-                          logger.log("searching better assignments ... ");
-                          var converter = new DataSize.Field();
-                          var replicaSizeLimit =
-                              Optional.ofNullable(input.nonEmptyTexts().get(MAX_MIGRATE_LOG_SIZE))
-                                  .map(x -> converter.convert(x).bytes());
-                          var leaderNumLimit =
-                              Optional.ofNullable(input.nonEmptyTexts().get(MAX_MIGRATE_LEADER_NUM))
-                                  .map(Integer::parseInt);
-                          return Map.entry(
-                              clusterInfo,
-                              Balancer.create(
-                                      GreedyBalancer.class,
-                                      AlgorithmConfig.builder()
-                                          .clusterCost(
-                                              HasClusterCost.of(
-                                                  input.selectedKeys().stream()
-                                                      .flatMap(
-                                                          name ->
-                                                              Arrays.stream(Cost.values())
-                                                                  .filter(
-                                                                      c ->
-                                                                          c.toString()
-                                                                              .equals(name)))
-                                                      .map(
-                                                          cost -> Map.entry(cost.costFunction, 1.0))
-                                                      .collect(
-                                                          Collectors.toMap(
-                                                              Map.Entry::getKey,
-                                                              Map.Entry::getValue))))
-                                          .moveCost(
-                                              List.of(
-                                                  new ReplicaSizeCost(), new ReplicaLeaderCost()))
-                                          .movementConstraint(
-                                              moveCosts ->
-                                                  moveCosts.stream()
-                                                      .allMatch(
-                                                          mc -> {
-                                                            switch (mc.name()) {
-                                                              case ReplicaSizeCost.COST_NAME:
-                                                                if (replicaSizeLimit.isEmpty()
-                                                                    || mc.totalCost()
-                                                                        <= replicaSizeLimit.get())
-                                                                  return true;
-                                                                break;
-                                                              case ReplicaLeaderCost.COST_NAME:
-                                                                if (leaderNumLimit.isEmpty()
-                                                                    || mc.totalCost()
-                                                                        <= leaderNumLimit.get())
-                                                                  return true;
-                                                                break;
-                                                            }
-                                                            return false;
-                                                          }))
-                                          .limit(Duration.ofSeconds(10))
-                                          .topicFilter(
-                                              topic ->
-                                                  patterns.isEmpty()
-                                                      || patterns.stream()
-                                                          .anyMatch(
-                                                              p -> p.matcher(topic).matches()))
-                                          .limit(10000)
-                                          .build())
-                                  .offer(clusterInfo, brokerFolders));
-                        }))
-        .thenApply(
-            entry -> {
-              var result =
-                  entry.getValue().map(plan -> result(entry.getKey(), plan)).orElse(List.of());
-              if (result.isEmpty()) logger.log("there is no better assignments");
-              else
-                logger.log(
-                    "find a better assignments. Total number of reassignments is " + result.size());
-              return result;
-            });
+  static Map<HasClusterCost, Double> clusterCosts(List<String> keys) {
+    return keys.stream()
+        .flatMap(
+            name -> Arrays.stream(Cost.values()).filter(c -> c.toString().equalsIgnoreCase(name)))
+        .map(cost -> Map.entry(cost.costFunction, 1.0))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  static Predicate<List<MoveCost>> movementConstraint(Map<String, String> input) {
+    var converter = new DataSize.Field();
+    var replicaSizeLimit =
+        Optional.ofNullable(input.get(MAX_MIGRATE_LOG_SIZE)).map(x -> converter.convert(x).bytes());
+    var leaderNumLimit =
+        Optional.ofNullable(input.get(MAX_MIGRATE_LEADER_NUM)).map(Integer::parseInt);
+    return moveCosts ->
+        moveCosts.stream()
+            .allMatch(
+                mc -> {
+                  switch (mc.name()) {
+                    case ReplicaSizeCost.COST_NAME:
+                      return replicaSizeLimit.filter(limit -> limit <= mc.totalCost()).isEmpty();
+                    case ReplicaLeaderCost.COST_NAME:
+                      return leaderNumLimit.filter(limit -> limit <= mc.totalCost()).isEmpty();
+                    default:
+                      return true;
+                  }
+                });
+  }
+
+  static BiFunction<Input, Logger, CompletionStage<List<Map<String, Object>>>> refresher(
+      Context context) {
+    return (input, logger) ->
+        context
+            .admin()
+            .topicNames(false)
+            .thenCompose(context.admin()::clusterInfo)
+            .thenCompose(
+                clusterInfo ->
+                    context
+                        .admin()
+                        .brokerFolders()
+                        .thenApply(
+                            brokerFolders -> {
+                              var patterns =
+                                  input
+                                      .texts()
+                                      .get(TOPIC_NAME_KEY)
+                                      .map(
+                                          ss ->
+                                              Arrays.stream(ss.split(","))
+                                                  .map(Utils::wildcardToPattern)
+                                                  .collect(Collectors.toList()))
+                                      .orElse(List.of());
+                              logger.log("searching better assignments ... ");
+                              return Map.entry(
+                                  clusterInfo,
+                                  Balancer.create(
+                                          GreedyBalancer.class,
+                                          AlgorithmConfig.builder()
+                                              .clusterCost(
+                                                  HasClusterCost.of(
+                                                      clusterCosts(input.selectedKeys())))
+                                              .moveCost(
+                                                  List.of(
+                                                      new ReplicaSizeCost(),
+                                                      new ReplicaLeaderCost()))
+                                              .movementConstraint(
+                                                  movementConstraint(input.nonEmptyTexts()))
+                                              .limit(Duration.ofSeconds(10))
+                                              .topicFilter(
+                                                  topic ->
+                                                      patterns.isEmpty()
+                                                          || patterns.stream()
+                                                              .anyMatch(
+                                                                  p -> p.matcher(topic).matches()))
+                                              .limit(10000)
+                                              .build())
+                                      .offer(clusterInfo, brokerFolders));
+                            }))
+            .thenApply(
+                entry -> {
+                  entry.getValue().ifPresent(LAST_PLAN::set);
+                  var result =
+                      entry.getValue().map(plan -> result(entry.getKey(), plan)).orElse(List.of());
+                  if (result.isEmpty()) logger.log("there is no better assignments");
+                  else
+                    logger.log(
+                        "find a better assignments. Total number of reassignments is "
+                            + result.size());
+                  return result;
+                });
+  }
+
+  static Bi3Function<List<Map<String, Object>>, Input, Logger, CompletionStage<Void>>
+      tableViewAction(Context context) {
+    return (items, inputs, logger) -> {
+      logger.log("applying better assignments ... ");
+      var selectedReplicas =
+          items.stream()
+              .flatMap(
+                  item -> {
+                    var topic = item.get(TOPIC_NAME_KEY);
+                    var partition = item.get(PARTITION_KEY);
+                    var assignments = item.get(NEW_ASSIGNMENT_KEY);
+                    if (topic != null && partition != null && assignments != null)
+                      return Arrays.stream(assignments.toString().split(","))
+                          .map(
+                              assignment ->
+                                  Map.entry(
+                                      TopicPartitionReplica.of(
+                                          topic.toString(),
+                                          Integer.parseInt(partition.toString()),
+                                          Integer.parseInt(assignment.split(":")[0])),
+                                      assignment.split(":")[1]));
+                    return Stream.of();
+                  })
+              .collect(MapUtils.toLinkedHashMap(Map.Entry::getKey, Map.Entry::getValue));
+      // remove previous plan so users can't run it again
+      var plan = LAST_PLAN.getAndSet(null);
+      if (plan != null) {
+        var replicas =
+            plan.proposal().rebalancePlan().replicas().stream()
+                .filter(r -> selectedReplicas.containsKey(r.topicPartitionReplica()))
+                .collect(Collectors.toList());
+        return new StraightPlanExecutor()
+            .run(context.admin(), replicas)
+            .thenAccept(ignored -> logger.log("succeed to balance cluster"));
+      }
+      return CompletableFuture.completedFuture(null);
+    };
   }
 
   public static Node of(Context context) {
@@ -233,96 +274,8 @@ public class BalancerNode {
                     TextInput.of(
                         MAX_MIGRATE_LOG_SIZE,
                         EditableText.singleLine().hint("30KB,200MB,1GB").build()))))
-        .tableViewAction(
-            null,
-            "EXECUTE",
-            (items, inputs, logger) -> {
-              logger.log("applying better assignments ... ");
-              var reassignments =
-                  items.stream()
-                      .flatMap(
-                          item -> {
-                            var topic = item.get(TOPIC_NAME_KEY);
-                            var partition = item.get(PARTITION_KEY);
-                            var assignments = item.get(NEW_ASSIGNMENT_KEY);
-                            if (topic != null && partition != null && assignments != null)
-                              return Stream.of(
-                                  Map.entry(
-                                      TopicPartition.of(
-                                          topic.toString(), Integer.parseInt(partition.toString())),
-                                      Arrays.stream(assignments.toString().split(","))
-                                          .map(
-                                              assignment ->
-                                                  Map.entry(
-                                                      Integer.parseInt(assignment.split(":")[0]),
-                                                      assignment.split(":")[1]))
-                                          .collect(Collectors.toList())));
-                            return Stream.of();
-                          })
-                      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-              var moveBrokerRequest =
-                  reassignments.entrySet().stream()
-                      .collect(
-                          Collectors.toMap(
-                              Map.Entry::getKey,
-                              e ->
-                                  e.getValue().stream()
-                                      .map(Map.Entry::getKey)
-                                      .collect(Collectors.toList())));
-              var moveFolderRequest =
-                  reassignments.entrySet().stream()
-                      .flatMap(
-                          e ->
-                              e.getValue().stream()
-                                  .map(
-                                      idAndPath ->
-                                          Map.entry(
-                                              TopicPartitionReplica.of(
-                                                  e.getKey().topic(),
-                                                  e.getKey().partition(),
-                                                  idAndPath.getKey()),
-                                              idAndPath.getValue())))
-                      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-              var expectedReplicas =
-                  moveBrokerRequest.entrySet().stream()
-                      .flatMap(
-                          e ->
-                              e.getValue().stream()
-                                  .map(
-                                      id ->
-                                          TopicPartitionReplica.of(
-                                              e.getKey().topic(), e.getKey().partition(), id)))
-                      .collect(Collectors.toList());
-              return context
-                  .admin()
-                  .moveToBrokers(moveBrokerRequest)
-                  // wait assignment
-                  .thenCompose(
-                      ignored ->
-                          context
-                              .admin()
-                              .waitCluster(
-                                  moveBrokerRequest.keySet().stream()
-                                      .map(TopicPartition::topic)
-                                      .collect(Collectors.toSet()),
-                                  clusterInfo ->
-                                      expectedReplicas.stream()
-                                          .allMatch(
-                                              r ->
-                                                  clusterInfo
-                                                      .replicaStream()
-                                                      .anyMatch(
-                                                          replica ->
-                                                              replica
-                                                                  .topicPartitionReplica()
-                                                                  .equals(r))),
-                                  Duration.ofSeconds(15),
-                                  2))
-                  .thenCompose(ignored -> context.admin().moveToFolders(moveFolderRequest))
-                  .thenAccept(ignored -> logger.log("succeed to balance cluster"));
-            })
-        .tableRefresher((input, logger) -> generator(context, input, logger))
+        .tableViewAction(null, "EXECUTE", tableViewAction(context))
+        .tableRefresher(refresher(context))
         .build();
   }
 }

--- a/gui/src/test/java/org/astraea/gui/tab/BalancerNodeTest.java
+++ b/gui/src/test/java/org/astraea/gui/tab/BalancerNodeTest.java
@@ -34,13 +34,42 @@ import org.astraea.common.balancer.RebalancePlanProposal;
 import org.astraea.common.balancer.log.ClusterLogAllocation;
 import org.astraea.common.cost.MoveCost;
 import org.astraea.common.cost.ReplicaLeaderCost;
+import org.astraea.common.cost.ReplicaSizeCost;
 import org.astraea.gui.Context;
 import org.astraea.gui.pane.Input;
 import org.astraea.it.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class BalancerTabTest extends RequireBrokerCluster {
+class BalancerNodeTest extends RequireBrokerCluster {
+
+  @Test
+  void testClusterCost() {
+    Assertions.assertEquals(0, BalancerNode.clusterCosts(List.of()).size());
+    Assertions.assertEquals(0, BalancerNode.clusterCosts(List.of(Utils.randomString())).size());
+
+    var costs = BalancerNode.clusterCosts(List.of(BalancerNode.Cost.SIZE.name()));
+    Assertions.assertEquals(1, costs.size());
+    Assertions.assertInstanceOf(ReplicaSizeCost.class, costs.entrySet().iterator().next().getKey());
+  }
+
+  @Test
+  void testMovementConstraint() {
+    Assertions.assertTrue(BalancerNode.movementConstraint(Map.of()).test(List.of()));
+    Assertions.assertTrue(
+        BalancerNode.movementConstraint(Map.of())
+            .test(List.of(MoveCost.builder().name("test").totalCost(100).build())));
+    Assertions.assertFalse(
+        BalancerNode.movementConstraint(Map.of(BalancerNode.MAX_MIGRATE_LEADER_NUM, "10"))
+            .test(
+                List.of(
+                    MoveCost.builder().name(ReplicaLeaderCost.COST_NAME).totalCost(100).build())));
+    Assertions.assertTrue(
+        BalancerNode.movementConstraint(Map.of(BalancerNode.MAX_MIGRATE_LEADER_NUM, "10"))
+            .test(
+                List.of(
+                    MoveCost.builder().name(ReplicaLeaderCost.COST_NAME).totalCost(5).build())));
+  }
 
   @Test
   void testGenerator() {
@@ -57,10 +86,11 @@ class BalancerTabTest extends RequireBrokerCluster {
       Utils.sleep(Duration.ofSeconds(2));
       var log = new AtomicReference<String>();
       var f =
-          BalancerNode.generator(
-              new Context(admin),
-              Input.of(List.of("leader"), Map.of(BalancerNode.TOPIC_NAME_KEY, Optional.empty())),
-              log::set);
+          BalancerNode.refresher(new Context(admin))
+              .apply(
+                  Input.of(
+                      List.of("leader"), Map.of(BalancerNode.TOPIC_NAME_KEY, Optional.empty())),
+                  log::set);
       f.toCompletableFuture().join();
       Assertions.assertTrue(f.toCompletableFuture().isDone());
       Assertions.assertEquals(log.get(), "there is no better assignments");
@@ -73,10 +103,11 @@ class BalancerTabTest extends RequireBrokerCluster {
       admin.moveToBrokers(tps).toCompletableFuture().join();
       Utils.sleep(Duration.ofSeconds(2));
       var s =
-          BalancerNode.generator(
-              new Context(admin),
-              Input.of(List.of("leader"), Map.of(BalancerNode.TOPIC_NAME_KEY, Optional.empty())),
-              log::set);
+          BalancerNode.refresher(new Context(admin))
+              .apply(
+                  Input.of(
+                      List.of("leader"), Map.of(BalancerNode.TOPIC_NAME_KEY, Optional.empty())),
+                  log::set);
       s.toCompletableFuture().join();
       Assertions.assertTrue(s.toCompletableFuture().isDone());
       Assertions.assertTrue(


### PR DESCRIPTION
如題，我們重複使用`StraightPlanExecutor`來達成搬移的效果

另外在 #1055 還沒結果之前，`StraightPlanExecutor`會保持等待資料都同步的邏輯，同時為了讓`GUI`不會卡在等待資料同步，`StraightPlanExecutor`提供兩個方法，一個只負責完成plan，一個則是完成plan和資料搬移

另外也替`BalancerNode`補上測試