### PR TITLE
Enable RebalancePlanExecutor to execute plan with/without sycn waiting

### DIFF
--- a/app/src/main/java/org/astraea/app/balancer/BalanceProcessDemo.java
+++ b/app/src/main/java/org/astraea/app/balancer/BalanceProcessDemo.java
@@ -17,6 +17,7 @@
 package org.astraea.app.balancer;
 
 import com.beust.jcommander.Parameter;
+import java.time.Duration;
 import java.util.Set;
 import java.util.function.Predicate;
 import org.astraea.common.admin.Admin;
@@ -56,7 +57,7 @@ public class BalanceProcessDemo {
       plan.ifPresent(
           p ->
               new StraightPlanExecutor()
-                  .submit(admin, p.proposal().rebalancePlan())
+                  .execute(admin, p.proposal().rebalancePlan(), Duration.ofHours(1))
                   .toCompletableFuture()
                   .join());
     }

--- a/app/src/main/java/org/astraea/app/balancer/BalanceProcessDemo.java
+++ b/app/src/main/java/org/astraea/app/balancer/BalanceProcessDemo.java
@@ -56,7 +56,7 @@ public class BalanceProcessDemo {
       plan.ifPresent(
           p ->
               new StraightPlanExecutor()
-                  .run(admin, p.proposal().rebalancePlan())
+                  .submit(admin, p.proposal().rebalancePlan())
                   .toCompletableFuture()
                   .join());
     }

--- a/app/src/main/java/org/astraea/app/balancer/BalanceProcessDemo.java
+++ b/app/src/main/java/org/astraea/app/balancer/BalanceProcessDemo.java
@@ -57,7 +57,7 @@ public class BalanceProcessDemo {
       plan.ifPresent(
           p ->
               new StraightPlanExecutor()
-                  .execute(admin, p.proposal().rebalancePlan(), Duration.ofHours(1))
+                  .run(admin, p.proposal().rebalancePlan(), Duration.ofHours(1))
                   .toCompletableFuture()
                   .join());
     }

--- a/app/src/main/java/org/astraea/app/web/BalancerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BalancerHandler.java
@@ -277,7 +277,7 @@ class BalancerHandler implements Handler {
                       executedPlans.put(
                           thePlanId,
                           CompletableFuture.runAsync(
-                              () -> executor.run(admin, p.proposal().rebalancePlan())));
+                              () -> executor.submit(admin, p.proposal().rebalancePlan())));
                       lastExecutionId.set(thePlanId);
                     });
                 return new PutPlanResponse(thePlanId);

--- a/app/src/main/java/org/astraea/app/web/BalancerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BalancerHandler.java
@@ -277,7 +277,9 @@ class BalancerHandler implements Handler {
                       executedPlans.put(
                           thePlanId,
                           CompletableFuture.runAsync(
-                              () -> executor.submit(admin, p.proposal().rebalancePlan())));
+                              () ->
+                                  executor.execute(
+                                      admin, p.proposal().rebalancePlan(), Duration.ofHours(1))));
                       lastExecutionId.set(thePlanId);
                     });
                 return new PutPlanResponse(thePlanId);

--- a/app/src/main/java/org/astraea/app/web/BalancerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BalancerHandler.java
@@ -276,10 +276,9 @@ class BalancerHandler implements Handler {
                     p -> {
                       executedPlans.put(
                           thePlanId,
-                          CompletableFuture.runAsync(
-                              () ->
-                                  executor.execute(
-                                      admin, p.proposal().rebalancePlan(), Duration.ofHours(1))));
+                          executor
+                              .run(admin, p.proposal().rebalancePlan(), Duration.ofHours(1))
+                              .toCompletableFuture());
                       lastExecutionId.set(thePlanId);
                     });
                 return new PutPlanResponse(thePlanId);

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -476,8 +476,9 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
       var theExecutor =
           new NoOpExecutor() {
             @Override
-            public CompletionStage<Void> run(Admin admin, ClusterLogAllocation targetAllocation) {
-              super.run(admin, targetAllocation);
+            public CompletionStage<Void> submit(
+                Admin admin, ClusterInfo<Replica> targetAllocation, Duration timeout) {
+              super.submit(admin, targetAllocation);
               Utils.sleep(Duration.ofSeconds(10));
               return null;
             }
@@ -602,8 +603,9 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
             final CountDownLatch latch = new CountDownLatch(1);
 
             @Override
-            public CompletionStage<Void> run(Admin admin, ClusterLogAllocation targetAllocation) {
-              super.run(admin, targetAllocation);
+            public CompletionStage<Void> submit(
+                Admin admin, ClusterInfo<Replica> targetAllocation, Duration timeout) {
+              super.submit(admin, targetAllocation);
               Utils.packException(() -> latch.await());
               return null;
             }
@@ -668,8 +670,9 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
       var theExecutor =
           new NoOpExecutor() {
             @Override
-            public CompletionStage<Void> run(Admin admin, ClusterLogAllocation targetAllocation) {
-              super.run(admin, targetAllocation);
+            public CompletionStage<Void> submit(
+                Admin admin, ClusterInfo<Replica> targetAllocation, Duration timeout) {
+              super.submit(admin, targetAllocation);
               throw new RuntimeException("Boom");
             }
           };
@@ -802,7 +805,8 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
     private final LongAdder executionCounter = new LongAdder();
 
     @Override
-    public CompletionStage<Void> run(Admin admin, ClusterLogAllocation targetAllocation) {
+    public CompletionStage<Void> submit(
+        Admin admin, ClusterInfo<Replica> targetAllocation, Duration timeout) {
       executionCounter.increment();
       return null;
     }

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -478,7 +478,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
             @Override
             public CompletionStage<Void> submit(
                 Admin admin, ClusterInfo<Replica> targetAllocation, Duration timeout) {
-              super.submit(admin, targetAllocation);
+              super.submit(admin, targetAllocation, Duration.ofSeconds(5));
               Utils.sleep(Duration.ofSeconds(10));
               return null;
             }
@@ -605,7 +605,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
             @Override
             public CompletionStage<Void> submit(
                 Admin admin, ClusterInfo<Replica> targetAllocation, Duration timeout) {
-              super.submit(admin, targetAllocation);
+              super.submit(admin, targetAllocation, Duration.ofSeconds(5));
               Utils.packException(() -> latch.await());
               return null;
             }
@@ -672,7 +672,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
             @Override
             public CompletionStage<Void> submit(
                 Admin admin, ClusterInfo<Replica> targetAllocation, Duration timeout) {
-              super.submit(admin, targetAllocation);
+              super.submit(admin, targetAllocation, Duration.ofSeconds(5));
               throw new RuntimeException("Boom");
             }
           };

--- a/common/src/main/java/org/astraea/common/admin/ClusterInfo.java
+++ b/common/src/main/java/org/astraea/common/admin/ClusterInfo.java
@@ -350,11 +350,13 @@ public interface ClusterInfo<T extends ReplicaInfo> {
   }
 
   /**
+   * find the synced replica. Noted that the future replica is excluded
+   *
    * @param replica to search
    * @return the replica matched to input replica
    */
   default Optional<T> replica(TopicPartitionReplica replica) {
-    return replicaStream(replica).findFirst();
+    return replicaStream(replica).filter(ReplicaInfo::inSync).findFirst();
   }
 
   // ---------------------[others]---------------------//
@@ -370,6 +372,12 @@ public interface ClusterInfo<T extends ReplicaInfo> {
 
   default Set<TopicPartition> topicPartitions() {
     return replicaStream().map(ReplicaInfo::topicPartition).collect(Collectors.toUnmodifiableSet());
+  }
+
+  default Set<TopicPartitionReplica> topicPartitionReplicas() {
+    return replicaStream()
+        .map(ReplicaInfo::topicPartitionReplica)
+        .collect(Collectors.toUnmodifiableSet());
   }
 
   /**
@@ -506,6 +514,11 @@ public interface ClusterInfo<T extends ReplicaInfo> {
     @Override
     public Set<TopicPartition> topicPartitions() {
       return byPartition.get().keySet();
+    }
+
+    @Override
+    public Set<TopicPartitionReplica> topicPartitionReplicas() {
+      return byReplica.get().keySet();
     }
 
     @Override

--- a/common/src/main/java/org/astraea/common/admin/ClusterInfo.java
+++ b/common/src/main/java/org/astraea/common/admin/ClusterInfo.java
@@ -350,13 +350,11 @@ public interface ClusterInfo<T extends ReplicaInfo> {
   }
 
   /**
-   * find the synced replica. Noted that the future replica is excluded
-   *
    * @param replica to search
    * @return the replica matched to input replica
    */
   default Optional<T> replica(TopicPartitionReplica replica) {
-    return replicaStream(replica).filter(ReplicaInfo::inSync).findFirst();
+    return replicaStream(replica).findFirst();
   }
 
   // ---------------------[others]---------------------//

--- a/common/src/main/java/org/astraea/common/balancer/executor/RebalancePlanExecutor.java
+++ b/common/src/main/java/org/astraea/common/balancer/executor/RebalancePlanExecutor.java
@@ -24,11 +24,6 @@ import org.astraea.common.admin.Replica;
 
 /** This class associate with the logic of fulfill given rebalance plan. */
 public interface RebalancePlanExecutor {
-
-  default CompletionStage<Void> submit(Admin admin, ClusterInfo<Replica> targetAllocation) {
-    return submit(admin, targetAllocation, Duration.ofSeconds(15));
-  }
-
   /**
    * submit the migration request to servers. Noted that this method get completed when all requests
    * are accepted. The data syncing will keep running on the server side. Hence, there is no

--- a/common/src/main/java/org/astraea/common/balancer/executor/RebalancePlanExecutor.java
+++ b/common/src/main/java/org/astraea/common/balancer/executor/RebalancePlanExecutor.java
@@ -16,13 +16,68 @@
  */
 package org.astraea.common.balancer.executor;
 
+import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 import org.astraea.common.admin.Admin;
-import org.astraea.common.balancer.log.ClusterLogAllocation;
+import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.admin.Replica;
 
 /** This class associate with the logic of fulfill given rebalance plan. */
 public interface RebalancePlanExecutor {
 
-  /** This method responsible for fulfill a rebalance plan. */
-  CompletionStage<Void> run(Admin admin, ClusterLogAllocation targetAllocation);
+  default CompletionStage<Void> submit(Admin admin, ClusterInfo<Replica> targetAllocation) {
+    return submit(admin, targetAllocation, Duration.ofSeconds(15));
+  }
+
+  /**
+   * submit the migration request to servers. Noted that this method get completed when all requests
+   * are accepted. The data syncing will keep running on the server side. Hence, there is no
+   * guarantee that the leader re-election is invoked ( Kafka requires re-election can happen only
+   * if related replicas are get synced). Please call {@link RebalancePlanExecutor#execute(Admin,
+   * ClusterInfo, Duration)} to add extra check/wait for data sync and re-election
+   *
+   * @param admin to process request
+   * @param targetAllocation the expected assignments
+   * @param timeout to wait metadata sync for each phase. The plan could be divided into many
+   *     requests. This timeout could stop the infinite waiting for Kafka metadata. It causes
+   *     IllegalStateException if the metadata can't get synced and timeout is expired.
+   * @return a background running thread
+   */
+  CompletionStage<Void> submit(
+      Admin admin, ClusterInfo<Replica> targetAllocation, Duration timeout);
+
+  /**
+   * this method compose of {@link RebalancePlanExecutor#submit(Admin, ClusterInfo, Duration)} and
+   * data sync waiting. It makes sure all migrated replicas get synced and all new leaders get
+   * ready. The timeout to wait sync and re-election can be "large" and "unpredictable", so it is up
+   * to caller to give a "suitable" timeout.
+   *
+   * @param admin to process request
+   * @param targetAllocation the expected assignments
+   * @param timeout to wait metadata sync for each phase. The plan could be divided into many
+   *     requests. This timeout could stop the infinite waiting for Kafka metadata. It causes
+   *     IllegalStateException if the metadata can't get synced and timeout is expired.
+   * @return a background running thread
+   */
+  default CompletionStage<Void> execute(
+      Admin admin, ClusterInfo<Replica> targetAllocation, Duration timeout) {
+    return submit(admin, targetAllocation, timeout)
+        .thenCompose(
+            replicas ->
+                admin.waitReplicasSynced(targetAllocation.topicPartitionReplicas(), timeout))
+        // step.3 re-elect leaders
+        .thenCompose(
+            topicPartitions ->
+                admin
+                    .preferredLeaderElection(targetAllocation.topicPartitions())
+                    .thenCompose(
+                        ignored ->
+                            admin.waitPreferredLeaderSynced(
+                                targetAllocation.topicPartitions(), timeout))
+                    .thenAccept(c -> assertion(c, "Failed to re-election for " + topicPartitions)));
+  }
+
+  static void assertion(boolean condition, String info) {
+    if (!condition) throw new IllegalStateException(info);
+  }
 }

--- a/common/src/main/java/org/astraea/common/balancer/executor/RebalancePlanExecutor.java
+++ b/common/src/main/java/org/astraea/common/balancer/executor/RebalancePlanExecutor.java
@@ -24,6 +24,11 @@ import org.astraea.common.admin.Replica;
 
 /** This class associate with the logic of fulfill given rebalance plan. */
 public interface RebalancePlanExecutor {
+
+  static RebalancePlanExecutor of() {
+    return new StraightPlanExecutor();
+  }
+
   /**
    * submit the migration request to servers. Noted that this method get completed when all requests
    * are accepted. The data syncing will keep running on the server side. Hence, there is no

--- a/common/src/main/java/org/astraea/common/balancer/executor/StraightPlanExecutor.java
+++ b/common/src/main/java/org/astraea/common/balancer/executor/StraightPlanExecutor.java
@@ -19,17 +19,14 @@ package org.astraea.common.balancer.executor;
 import static org.astraea.common.admin.ClusterInfo.findNonFulfilledAllocation;
 
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
-import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 import org.astraea.common.admin.Admin;
+import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.admin.Replica;
 import org.astraea.common.admin.ReplicaInfo;
 import org.astraea.common.admin.TopicPartition;
-import org.astraea.common.admin.TopicPartitionReplica;
-import org.astraea.common.balancer.log.ClusterLogAllocation;
 
 /** Execute every possible migration immediately. */
 public class StraightPlanExecutor implements RebalancePlanExecutor {
@@ -37,7 +34,8 @@ public class StraightPlanExecutor implements RebalancePlanExecutor {
   public StraightPlanExecutor() {}
 
   @Override
-  public CompletionStage<Void> run(Admin admin, ClusterLogAllocation logAllocation) {
+  public CompletionStage<Void> submit(
+      Admin admin, ClusterInfo<Replica> logAllocation, Duration timeout) {
     return admin
         .topicNames(true)
         .thenCompose(admin::clusterInfo)
@@ -51,76 +49,46 @@ public class StraightPlanExecutor implements RebalancePlanExecutor {
 
         // step.1 move replica to specify brokers/folders
         .thenCompose(
-            replicas ->
-                run(admin, replicas)
-                    .thenApply(
-                        ignored ->
-                            replicas.stream()
-                                .map(Replica::topicPartitionReplica)
-                                .collect(Collectors.toSet())))
-
-        // step.2 wait all replicas to be synced
-        .thenCompose(
-            replicas ->
-                admin
-                    .waitReplicasSynced(replicas, ChronoUnit.DECADES.getDuration())
-                    .thenApply(
-                        ignored ->
-                            replicas.stream()
-                                .map(TopicPartitionReplica::topicPartition)
-                                .collect(Collectors.toSet())))
-        // step.3 re-elect leaders
-        .thenCompose(
-            topicPartitions ->
-                admin
-                    .preferredLeaderElection(topicPartitions)
-                    .thenCompose(
-                        ignored ->
-                            admin.waitPreferredLeaderSynced(
-                                topicPartitions, ChronoUnit.DECADES.getDuration()))
-                    .thenAccept(c -> assertion(c, "Failed to sync " + topicPartitions)));
-  }
-
-  public CompletionStage<Void> run(Admin admin, List<Replica> replicas) {
-    var moveBrokerRequest =
-        replicas.stream()
-            .sorted(Comparator.comparing(Replica::isPreferredLeader).reversed())
-            .collect(
-                Collectors.groupingBy(
-                    ReplicaInfo::topicPartition,
-                    Collectors.mapping(r -> r.nodeInfo().id(), Collectors.toList())));
-    var moveFolderRequest =
-        replicas.stream()
-            .collect(Collectors.toMap(ReplicaInfo::topicPartitionReplica, Replica::path));
-    return admin
-        // step.1 move replica to specify brokers
-        .moveToBrokers(moveBrokerRequest)
-        // step.2 wait assignment
-        .thenCompose(
-            ignored ->
-                admin.waitCluster(
-                    moveBrokerRequest.keySet().stream()
-                        .map(TopicPartition::topic)
-                        .collect(Collectors.toSet()),
-                    clusterInfo ->
-                        replicas.stream()
-                            .allMatch(
-                                r ->
-                                    clusterInfo
-                                        .replicaStream()
-                                        .anyMatch(
-                                            replica ->
-                                                replica
-                                                    .topicPartitionReplica()
-                                                    .equals(r.topicPartitionReplica()))),
-                    Duration.ofSeconds(15),
-                    2))
-        .thenAccept(done -> assertion(done, "Failed to sync " + moveFolderRequest.keySet()))
-        // step.3 move replica to specify folder
-        .thenCompose(ignored -> admin.moveToFolders(moveFolderRequest));
-  }
-
-  private void assertion(boolean condition, String info) {
-    if (!condition) throw new IllegalStateException(info);
+            replicas -> {
+              var moveBrokerRequest =
+                  replicas.stream()
+                      .sorted(Comparator.comparing(Replica::isPreferredLeader).reversed())
+                      .collect(
+                          Collectors.groupingBy(
+                              ReplicaInfo::topicPartition,
+                              Collectors.mapping(r -> r.nodeInfo().id(), Collectors.toList())));
+              var moveFolderRequest =
+                  replicas.stream()
+                      .collect(Collectors.toMap(ReplicaInfo::topicPartitionReplica, Replica::path));
+              return admin
+                  // step.1 move replica to specify brokers
+                  .moveToBrokers(moveBrokerRequest)
+                  // step.2 wait assignment
+                  .thenCompose(
+                      ignored ->
+                          admin.waitCluster(
+                              moveBrokerRequest.keySet().stream()
+                                  .map(TopicPartition::topic)
+                                  .collect(Collectors.toSet()),
+                              clusterInfo ->
+                                  replicas.stream()
+                                      .allMatch(
+                                          r ->
+                                              clusterInfo
+                                                  .replicaStream()
+                                                  .anyMatch(
+                                                      replica ->
+                                                          replica
+                                                              .topicPartitionReplica()
+                                                              .equals(r.topicPartitionReplica()))),
+                              timeout,
+                              1))
+                  .thenAccept(
+                      done ->
+                          RebalancePlanExecutor.assertion(
+                              done, "Failed to move " + moveFolderRequest.keySet()))
+                  // step.3 move replica to specify folder
+                  .thenCompose(ignored -> admin.moveToFolders(moveFolderRequest));
+            });
   }
 }

--- a/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
@@ -102,7 +102,7 @@ class BalancerTest extends RequireBrokerCluster {
                   admin.brokerFolders().toCompletableFuture().join())
               .orElseThrow();
       new StraightPlanExecutor()
-          .submit(admin, plan.proposal().rebalancePlan())
+          .execute(admin, plan.proposal().rebalancePlan(), Duration.ofSeconds(10))
           .toCompletableFuture()
           .join();
 

--- a/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
@@ -102,7 +102,7 @@ class BalancerTest extends RequireBrokerCluster {
                   admin.brokerFolders().toCompletableFuture().join())
               .orElseThrow();
       new StraightPlanExecutor()
-          .run(admin, plan.proposal().rebalancePlan())
+          .submit(admin, plan.proposal().rebalancePlan())
           .toCompletableFuture()
           .join();
 

--- a/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
@@ -102,7 +102,7 @@ class BalancerTest extends RequireBrokerCluster {
                   admin.brokerFolders().toCompletableFuture().join())
               .orElseThrow();
       new StraightPlanExecutor()
-          .execute(admin, plan.proposal().rebalancePlan(), Duration.ofSeconds(10))
+          .run(admin, plan.proposal().rebalancePlan(), Duration.ofSeconds(10))
           .toCompletableFuture()
           .join();
 

--- a/common/src/test/java/org/astraea/common/balancer/executor/StraightPlanExecutorTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/executor/StraightPlanExecutorTest.java
@@ -105,7 +105,7 @@ class StraightPlanExecutorTest extends RequireBrokerCluster {
       final var expectedTopicPartition = expectedAllocation.topicPartitions();
 
       var execute =
-          new StraightPlanExecutor().execute(admin, expectedAllocation, Duration.ofSeconds(10));
+          new StraightPlanExecutor().run(admin, expectedAllocation, Duration.ofSeconds(10));
 
       execute.toCompletableFuture().join();
 

--- a/common/src/test/java/org/astraea/common/balancer/executor/StraightPlanExecutorTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/executor/StraightPlanExecutorTest.java
@@ -104,7 +104,8 @@ class StraightPlanExecutorTest extends RequireBrokerCluster {
       final var expectedAllocation = ClusterLogAllocation.of(ClusterInfo.of(allocation));
       final var expectedTopicPartition = expectedAllocation.topicPartitions();
 
-      var execute = new StraightPlanExecutor().submit(admin, expectedAllocation);
+      var execute =
+          new StraightPlanExecutor().execute(admin, expectedAllocation, Duration.ofSeconds(10));
 
       execute.toCompletableFuture().join();
 

--- a/common/src/test/java/org/astraea/common/balancer/executor/StraightPlanExecutorTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/executor/StraightPlanExecutorTest.java
@@ -104,7 +104,7 @@ class StraightPlanExecutorTest extends RequireBrokerCluster {
       final var expectedAllocation = ClusterLogAllocation.of(ClusterInfo.of(allocation));
       final var expectedTopicPartition = expectedAllocation.topicPartitions();
 
-      var execute = new StraightPlanExecutor().run(admin, expectedAllocation);
+      var execute = new StraightPlanExecutor().submit(admin, expectedAllocation);
 
       execute.toCompletableFuture().join();
 

--- a/gui/src/main/java/org/astraea/gui/pane/PaneBuilder.java
+++ b/gui/src/main/java/org/astraea/gui/pane/PaneBuilder.java
@@ -139,9 +139,10 @@ public class PaneBuilder {
                     ? Map.<String, Optional<String>>of()
                     : secondLattice.contents();
             var input = Input.of(List.of(), text);
-            try {
-              checkbox.setSelected(false);
 
+            checkbox.setDisable(true);
+            checkbox.setSelected(false);
+            try {
               var invalidKeys = secondLattice == null ? Set.of() : secondLattice.invalidKeys();
               if (!invalidKeys.isEmpty()) {
                 console.text("please check fields: " + invalidKeys);
@@ -149,8 +150,13 @@ public class PaneBuilder {
               }
               tableViewAction
                   .apply(items, input, console::append)
-                  .whenComplete((data, e) -> console.text(e));
+                  .whenComplete(
+                      (data, e) -> {
+                        checkbox.setDisable(false);
+                        console.text(e);
+                      });
             } catch (Exception e) {
+              checkbox.setDisable(false);
               console.text(e);
             }
           });

--- a/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
@@ -241,7 +241,7 @@ public class BalancerNode {
                 .filter(r -> selectedPartitions.contains(r.topicPartition()))
                 .collect(Collectors.toList());
         return new StraightPlanExecutor()
-            .submit(context.admin(), ClusterInfo.of(replicas))
+            .submit(context.admin(), ClusterInfo.of(replicas), Duration.ofSeconds(15))
             .thenAccept(
                 ignored ->
                     logger.log(

--- a/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
@@ -241,7 +241,7 @@ public class BalancerNode {
                 .filter(r -> selectedPartitions.contains(r.topicPartition()))
                 .collect(Collectors.toList());
         return new StraightPlanExecutor()
-            .run(context.admin(), replicas)
+            .submit(context.admin(), ClusterInfo.of(replicas))
             .thenAccept(
                 ignored ->
                     logger.log(

--- a/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
@@ -248,7 +248,7 @@ public class BalancerNode {
                 addingReplicas -> {
                   if (addingReplicas.isEmpty())
                     return RebalancePlanExecutor.of()
-                        .execute(context.admin(), ClusterInfo.of(replicas), Duration.ofHours(1))
+                        .run(context.admin(), ClusterInfo.of(replicas), Duration.ofHours(1))
                         .thenAccept(
                             ignored ->
                                 logger.log(

--- a/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
@@ -39,7 +39,7 @@ import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.balancer.Balancer;
 import org.astraea.common.balancer.algorithms.AlgorithmConfig;
 import org.astraea.common.balancer.algorithms.GreedyBalancer;
-import org.astraea.common.balancer.executor.StraightPlanExecutor;
+import org.astraea.common.balancer.executor.RebalancePlanExecutor;
 import org.astraea.common.cost.HasClusterCost;
 import org.astraea.common.cost.MoveCost;
 import org.astraea.common.cost.ReplicaLeaderCost;
@@ -240,8 +240,8 @@ public class BalancerNode {
             plan.proposal().rebalancePlan().replicas().stream()
                 .filter(r -> selectedPartitions.contains(r.topicPartition()))
                 .collect(Collectors.toList());
-        return new StraightPlanExecutor()
-            .submit(context.admin(), ClusterInfo.of(replicas), Duration.ofSeconds(15))
+        return RebalancePlanExecutor.of()
+            .execute(context.admin(), ClusterInfo.of(replicas), Duration.ofHours(1))
             .thenAccept(
                 ignored ->
                     logger.log(

--- a/gui/src/main/java/org/astraea/gui/tab/topic/ReplicaNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/topic/ReplicaNode.java
@@ -70,6 +70,7 @@ public class ReplicaNode {
               result.put("isPreferredLeader", replica.isPreferredLeader());
               result.put("isOffline", replica.isOffline());
               result.put("isFuture", replica.isFuture());
+              result.put("inSync", replica.inSync());
               result.put("lag", replica.lag());
               result.put("size", DataSize.Byte.of(replica.size()));
               if (leaderSize > replica.size()) {

--- a/gui/src/test/java/org/astraea/gui/tab/topic/ReplicaNodeTest.java
+++ b/gui/src/test/java/org/astraea/gui/tab/topic/ReplicaNodeTest.java
@@ -33,7 +33,7 @@ import org.astraea.it.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class ReplicaTabTest extends RequireBrokerCluster {
+public class ReplicaNodeTest extends RequireBrokerCluster {
 
   @Test
   void testTableAction() {


### PR DESCRIPTION
fix #1055 

現在`RebalancePlanExecutor`預設需要實作的部分只要完成搬移就好，最後集體的資料同步和re-election將會由預設實作完成。同時使用者可以選擇是否要等待最後的同步