### PR TITLE
[GUI] add read/write records tab

### DIFF
--- a/common/src/main/java/org/astraea/common/admin/Admin.java
+++ b/common/src/main/java/org/astraea/common/admin/Admin.java
@@ -94,6 +94,23 @@ public interface Admin extends AutoCloseable {
    */
   default CompletionStage<Map<TopicPartition, Long>> timestampOfLatestRecords(
       Set<TopicPartition> topicPartitions, Duration timeout) {
+    return latestRecords(topicPartitions, 1, timeout)
+        .thenApply(
+            records ->
+                records.entrySet().stream()
+                    .collect(
+                        Collectors.toMap(
+                            Map.Entry::getKey,
+                            e ->
+                                e.getValue().stream()
+                                    .mapToLong(Record::timestamp)
+                                    .max()
+                                    // the value CANNOT be empty
+                                    .getAsLong())));
+  }
+
+  default CompletionStage<Map<TopicPartition, List<Record<byte[], byte[]>>>> latestRecords(
+      Set<TopicPartition> topicPartitions, int records, Duration timeout) {
     return brokers()
         .thenApply(
             bs -> bs.stream().map(b -> b.host() + ":" + b.port()).collect(Collectors.joining(",")))
@@ -102,22 +119,12 @@ public interface Admin extends AutoCloseable {
               try (var consumer =
                   Consumer.forPartitions(topicPartitions)
                       .bootstrapServers(bootstrap)
-                      .seek(SeekStrategy.DISTANCE_FROM_LATEST, 1)
+                      .seek(SeekStrategy.DISTANCE_FROM_LATEST, records)
                       .build()) {
                 // TODO: how many records we should take ?
                 return consumer.poll(Integer.MAX_VALUE, timeout).stream()
                     .collect(
-                        Collectors.groupingBy(r -> TopicPartition.of(r.topic(), r.partition())))
-                    .entrySet()
-                    .stream()
-                    .collect(
-                        Collectors.toMap(
-                            Map.Entry::getKey,
-                            e ->
-                                e.getValue().stream()
-                                    .mapToLong(Record::timestamp)
-                                    .max()
-                                    .orElse(-1L)));
+                        Collectors.groupingBy(r -> TopicPartition.of(r.topic(), r.partition())));
               }
             });
   }

--- a/common/src/main/java/org/astraea/common/consumer/Deserializer.java
+++ b/common/src/main/java/org/astraea/common/consumer/Deserializer.java
@@ -16,6 +16,7 @@
  */
 package org.astraea.common.consumer;
 
+import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 import org.apache.kafka.common.header.Headers;
@@ -61,6 +62,8 @@ public interface Deserializer<T> {
     return (topic, headers, data) -> deserializer.deserialize(topic, Header.of(headers), data);
   }
 
+  Deserializer<String> BASE64 =
+      (topic, headers, data) -> data == null ? null : Base64.getEncoder().encodeToString(data);
   Deserializer<byte[]> BYTE_ARRAY = of(new ByteArrayDeserializer());
   Deserializer<String> STRING = of(new StringDeserializer());
   Deserializer<Integer> INTEGER = of(new IntegerDeserializer());

--- a/common/src/main/java/org/astraea/common/producer/Builder.java
+++ b/common/src/main/java/org/astraea/common/producer/Builder.java
@@ -82,7 +82,7 @@ public class Builder<Key, Value> {
     producer.send(
         record,
         (metadata, exception) -> {
-          if (exception == null) completableFuture.complete(Metadata.of(metadata));
+          if (exception == null) completableFuture.completeAsync(() -> Metadata.of(metadata));
           else completableFuture.completeExceptionally(exception);
         });
     return completableFuture;

--- a/gui/src/main/java/org/astraea/gui/tab/AboutNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/AboutNode.java
@@ -131,7 +131,8 @@ public class AboutNode {
             SelectBox.single(
                 Arrays.stream(Info.values()).map(Info::toString).collect(Collectors.toList()),
                 Info.values().length))
-        .tableRefresher(
+        .clickFunction(
+            "DISPLAY",
             (input, logger) ->
                 CompletableFuture.completedFuture(
                     input.selectedKeys().stream()

--- a/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
@@ -280,7 +280,6 @@ public class BalancerNode {
             SelectBox.multi(
                 Arrays.stream(Cost.values()).map(Cost::toString).collect(Collectors.toList()),
                 Cost.values().length))
-        .clickName("PLAN")
         .lattice(
             Lattice.of(
                 List.of(
@@ -292,7 +291,7 @@ public class BalancerNode {
                         MAX_MIGRATE_LOG_SIZE,
                         EditableText.singleLine().hint("30KB,200MB,1GB").build()))))
         .tableViewAction(null, "EXECUTE", tableViewAction(context))
-        .tableRefresher(refresher(context))
+        .clickFunction("PLAN", refresher(context))
         .build();
   }
 }

--- a/gui/src/main/java/org/astraea/gui/tab/BrokerNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/BrokerNode.java
@@ -201,7 +201,8 @@ public class BrokerNode {
             SelectBox.multi(
                 Arrays.stream(MetricType.values()).map(Enum::toString).collect(Collectors.toList()),
                 MetricType.values().length / 2))
-        .tableRefresher(
+        .clickFunction(
+            "REFRESH",
             (input, logger) ->
                 context
                     .admin()
@@ -290,14 +291,16 @@ public class BrokerNode {
 
   private static Node basicNode(Context context) {
     return PaneBuilder.of()
-        .tableRefresher(
+        .clickFunction(
+            "REFRESH",
             (input, logger) -> context.admin().brokers().thenApply(BrokerNode::basicResult))
         .build();
   }
 
   private static Node configNode(Context context) {
     return PaneBuilder.of()
-        .tableRefresher(
+        .clickFunction(
+            "REFRESH",
             (input, logger) ->
                 context
                     .admin()
@@ -399,7 +402,8 @@ public class BrokerNode {
                     .orElse(Map.of())
                 : Map.of();
     return PaneBuilder.of()
-        .tableRefresher(
+        .clickFunction(
+            "REFRESH",
             (input, logger) ->
                 context
                     .admin()

--- a/gui/src/main/java/org/astraea/gui/tab/ClientNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/ClientNode.java
@@ -16,6 +16,7 @@
  */
 package org.astraea.gui.tab;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -29,6 +30,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javafx.geometry.Side;
 import javafx.scene.Node;
+import org.astraea.common.DataSize;
 import org.astraea.common.FutureUtils;
 import org.astraea.common.MapUtils;
 import org.astraea.common.admin.ConsumerGroup;
@@ -36,9 +38,17 @@ import org.astraea.common.admin.Partition;
 import org.astraea.common.admin.ProducerState;
 import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.admin.Transaction;
+import org.astraea.common.argument.DurationField;
+import org.astraea.common.consumer.Deserializer;
+import org.astraea.common.producer.Producer;
+import org.astraea.common.producer.Serializer;
 import org.astraea.gui.Context;
+import org.astraea.gui.button.SelectBox;
+import org.astraea.gui.pane.Lattice;
 import org.astraea.gui.pane.PaneBuilder;
 import org.astraea.gui.pane.Slide;
+import org.astraea.gui.text.EditableText;
+import org.astraea.gui.text.TextInput;
 
 public class ClientNode {
 
@@ -85,7 +95,8 @@ public class ClientNode {
 
   private static Node consumerNode(Context context) {
     return PaneBuilder.of()
-        .tableRefresher(
+        .clickFunction(
+            "REFRESH",
             (input, logger) ->
                 FutureUtils.combine(
                     context.admin().consumerGroupIds().thenCompose(context.admin()::consumerGroups),
@@ -117,7 +128,8 @@ public class ClientNode {
 
   public static Node transactionNode(Context context) {
     return PaneBuilder.of()
-        .tableRefresher(
+        .clickFunction(
+            "REFRESH",
             (input, logger) ->
                 context
                     .admin()
@@ -150,7 +162,8 @@ public class ClientNode {
 
   public static Node producerNode(Context context) {
     return PaneBuilder.of()
-        .tableRefresher(
+        .clickFunction(
+            "REFRESH",
             (input, logger) ->
                 context
                     .admin()
@@ -167,14 +180,157 @@ public class ClientNode {
         .build();
   }
 
+  private static Node readNode(Context context) {
+    var timeoutKey = "timeout";
+    var stringKey = "string";
+    var base64Key = "base64";
+    var recordsKey = "records";
+    return PaneBuilder.of()
+        .selectBox(SelectBox.single(List.of(base64Key, stringKey), 2))
+        .lattice(
+            Lattice.of(
+                List.of(
+                    TextInput.of(recordsKey, EditableText.singleLine().defaultValue("1").build()),
+                    TextInput.of(
+                        timeoutKey, EditableText.singleLine().defaultValue("3s").build()))))
+        .clickFunction(
+            "READ",
+            (input, logger) ->
+                context
+                    .admin()
+                    .topicNames(false)
+                    .thenCompose(context.admin()::topicPartitions)
+                    .thenCompose(
+                        tps ->
+                            context
+                                .admin()
+                                .latestRecords(
+                                    tps,
+                                    input.get(recordsKey).map(Integer::parseInt).orElse(1),
+                                    input
+                                        .get(timeoutKey)
+                                        .map(DurationField::toDuration)
+                                        .orElse(Duration.ofSeconds(3))))
+                    .thenApply(
+                        data ->
+                            data.entrySet().stream()
+                                .flatMap(
+                                    tpRecords ->
+                                        tpRecords.getValue().stream()
+                                            .map(
+                                                record -> {
+                                                  var deser =
+                                                      input.selectedKeys().contains(base64Key)
+                                                          ? Deserializer.BASE64
+                                                          : Deserializer.STRING;
+                                                  var result = new LinkedHashMap<String, Object>();
+                                                  result.put("topic", record.topic());
+                                                  result.put("partition", record.partition());
+                                                  result.put("offset", record.offset());
+                                                  result.put(
+                                                      "timestamp",
+                                                      LocalDateTime.ofInstant(
+                                                          Instant.ofEpochMilli(record.timestamp()),
+                                                          ZoneId.systemDefault()));
+                                                  if (record.key() != null)
+                                                    result.put(
+                                                        "key",
+                                                        deser.deserialize(
+                                                            record.topic(),
+                                                            record.headers(),
+                                                            record.key()));
+                                                  if (record.value() != null)
+                                                    result.put(
+                                                        "value",
+                                                        deser.deserialize(
+                                                            record.topic(),
+                                                            record.headers(),
+                                                            record.value()));
+                                                  return result;
+                                                }))
+                                .collect(Collectors.toList())))
+        .build();
+  }
+
+  private static Node writeNode(Context context) {
+    var topicKey = "topic";
+    var partitionKey = "partition";
+    var keyKey = "key";
+    var valueKey = "value";
+    return PaneBuilder.of()
+        .lattice(
+            Lattice.of(
+                List.of(
+                    TextInput.required(topicKey, EditableText.singleLine().build()),
+                    TextInput.of(partitionKey, EditableText.singleLine().build()),
+                    TextInput.of(keyKey, EditableText.multiline().build()),
+                    TextInput.of(valueKey, EditableText.multiline().build()))))
+        .clickFunction(
+            "WRITE",
+            (input, logger) ->
+                context
+                    .admin()
+                    .brokers()
+                    .thenApply(
+                        bs ->
+                            bs.stream()
+                                .map(b -> b.host() + ":" + b.port())
+                                .collect(Collectors.joining(",")))
+                    .thenCompose(
+                        bs -> {
+                          try (var producer = Producer.of(bs)) {
+                            var topic = input.nonEmptyTexts().get(topicKey);
+                            var sender = producer.sender().topic(topic);
+                            input
+                                .get(partitionKey)
+                                .map(Integer::parseInt)
+                                .ifPresent(sender::partition);
+                            input
+                                .get(keyKey)
+                                .map(b -> Serializer.STRING.serialize(topic, List.of(), b))
+                                .ifPresent(sender::key);
+                            input
+                                .get(valueKey)
+                                .map(b -> Serializer.STRING.serialize(topic, List.of(), b))
+                                .ifPresent(sender::value);
+                            return sender
+                                .run()
+                                .thenApply(
+                                    metadata -> {
+                                      var result = new LinkedHashMap<String, Object>();
+                                      result.put("topic", metadata.topic());
+                                      result.put("partition", metadata.partition());
+                                      result.put("offset", metadata.offset());
+                                      result.put(
+                                          "timestamp",
+                                          LocalDateTime.ofInstant(
+                                              Instant.ofEpochMilli(metadata.timestamp()),
+                                              ZoneId.systemDefault()));
+                                      result.put(
+                                          "serializedKeySize",
+                                          DataSize.Byte.of(metadata.serializedKeySize()));
+                                      result.put(
+                                          "serializedValueSize",
+                                          DataSize.Byte.of(metadata.serializedValueSize()));
+                                      return List.of(result);
+                                    });
+                          }
+                        }))
+        .build();
+  }
+
   public static Node of(Context context) {
     return Slide.of(
             Side.TOP,
             MapUtils.of(
                 "consumer",
                 consumerNode(context),
+                "read",
+                readNode(context),
                 "producer",
                 producerNode(context),
+                "write",
+                writeNode(context),
                 "transaction",
                 transactionNode(context)))
         .node();

--- a/gui/src/main/java/org/astraea/gui/tab/QuotaNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/QuotaNode.java
@@ -44,14 +44,14 @@ public class QuotaNode {
     var ipLabelKey = "ip address";
     var rateKey = "connections/second";
     return PaneBuilder.of()
-        .clickName("ALTER")
         .lattice(
             Lattice.of(
                 List.of(
                     TextInput.required(
                         ipLabelKey, EditableText.singleLine().disallowEmpty().build()),
                     TextInput.of(rateKey, EditableText.singleLine().onlyNumber().build()))))
-        .tableRefresher(
+        .clickListener(
+            "ALTER",
             (input, logger) ->
                 Optional.ofNullable(input.nonEmptyTexts().get(rateKey))
                     .map(
@@ -68,16 +68,11 @@ public class QuotaNode {
                                 .admin()
                                 .unsetConnectionQuotas(
                                     Set.of(input.nonEmptyTexts().get(ipLabelKey))))
-                    .thenCompose(
+                    .thenAccept(
                         ignored ->
-                            context
-                                .admin()
-                                .quotas(Set.of(QuotaConfigs.IP))
-                                .thenApply(
-                                    quotas ->
-                                        quotas.stream()
-                                            .map(QuotaNode::basicResult)
-                                            .collect(Collectors.toList()))))
+                            logger.log(
+                                "succeed to alter rate for "
+                                    + input.nonEmptyTexts().get(ipLabelKey))))
         .build();
   }
 
@@ -85,14 +80,14 @@ public class QuotaNode {
     var clientIdLabelKey = "kafka client id";
     var byteRateKey = "MB/second";
     return PaneBuilder.of()
-        .clickName("ALTER")
         .lattice(
             Lattice.of(
                 List.of(
                     TextInput.required(
                         clientIdLabelKey, EditableText.singleLine().disallowEmpty().build()),
                     TextInput.of(byteRateKey, EditableText.singleLine().onlyNumber().build()))))
-        .tableRefresher(
+        .clickListener(
+            "ALTER",
             (input, logger) ->
                 Optional.ofNullable(input.nonEmptyTexts().get(byteRateKey))
                     .map(
@@ -109,16 +104,11 @@ public class QuotaNode {
                                 .admin()
                                 .unsetProducerQuotas(
                                     Set.of(input.nonEmptyTexts().get(clientIdLabelKey))))
-                    .thenCompose(
+                    .thenAccept(
                         ignored ->
-                            context
-                                .admin()
-                                .quotas(Set.of(QuotaConfigs.CLIENT_ID))
-                                .thenApply(
-                                    quotas ->
-                                        quotas.stream()
-                                            .map(QuotaNode::basicResult)
-                                            .collect(Collectors.toList()))))
+                            logger.log(
+                                "succeed to alter rate for "
+                                    + input.nonEmptyTexts().get(clientIdLabelKey))))
         .build();
   }
 
@@ -126,14 +116,14 @@ public class QuotaNode {
     var clientIdLabelKey = "kafka client id";
     var byteRateKey = "MB/second";
     return PaneBuilder.of()
-        .clickName("ALTER")
         .lattice(
             Lattice.of(
                 List.of(
                     TextInput.required(
                         clientIdLabelKey, EditableText.singleLine().disallowEmpty().build()),
                     TextInput.of(byteRateKey, EditableText.singleLine().onlyNumber().build()))))
-        .tableRefresher(
+        .clickListener(
+            "ALTER",
             (input, logger) ->
                 Optional.ofNullable(input.nonEmptyTexts().get(byteRateKey))
                     .map(
@@ -150,16 +140,11 @@ public class QuotaNode {
                                 .admin()
                                 .unsetConsumerQuotas(
                                     Set.of(input.nonEmptyTexts().get(clientIdLabelKey))))
-                    .thenCompose(
+                    .thenAccept(
                         ignored ->
-                            context
-                                .admin()
-                                .quotas(Set.of(QuotaConfigs.CLIENT_ID))
-                                .thenApply(
-                                    quotas ->
-                                        quotas.stream()
-                                            .map(QuotaNode::basicResult)
-                                            .collect(Collectors.toList()))))
+                            logger.log(
+                                "succeed to alter rate for "
+                                    + input.nonEmptyTexts().get(clientIdLabelKey))))
         .build();
   }
 
@@ -176,7 +161,8 @@ public class QuotaNode {
 
   private static Node basicNode(Context context) {
     return PaneBuilder.of()
-        .tableRefresher(
+        .clickFunction(
+            "REFRESH",
             (input, logger) ->
                 FutureUtils.combine(
                     context.admin().quotas(Set.of(QuotaConfigs.IP)),

--- a/gui/src/main/java/org/astraea/gui/tab/SettingNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/SettingNode.java
@@ -103,8 +103,8 @@ public class SettingNode {
                             .onlyNumber()
                             .defaultValue(properties.get(jmxPortKey))
                             .build()))))
-        .clickName("CHECK")
         .clickListener(
+            "CHECK",
             (input, logger) -> {
               var bootstrapServers = input.nonEmptyTexts().get(BOOTSTRAP_SERVERS);
               Objects.requireNonNull(bootstrapServers);

--- a/gui/src/main/java/org/astraea/gui/tab/topic/PartitionNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/topic/PartitionNode.java
@@ -170,7 +170,8 @@ public class PartitionNode {
                         TRUNCATE_OFFSET_KEY, EditableText.singleLine().disable().build()))),
             "ALTER",
             tableViewAction(context))
-        .tableRefresher(
+        .clickFunction(
+            "REFRESH",
             (input, logger) ->
                 context
                     .admin()

--- a/gui/src/main/java/org/astraea/gui/tab/topic/ReplicaNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/topic/ReplicaNode.java
@@ -212,7 +212,8 @@ public class ReplicaNode {
 
   static Node of(Context context) {
     return PaneBuilder.of()
-        .tableRefresher(
+        .clickFunction(
+            "REFRESH",
             (input, logger) ->
                 context
                     .admin()

--- a/gui/src/main/java/org/astraea/gui/text/TextInput.java
+++ b/gui/src/main/java/org/astraea/gui/text/TextInput.java
@@ -22,9 +22,12 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
+import javafx.scene.control.ListCell;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
 
@@ -44,6 +47,19 @@ public interface TextInput {
     var box = new ComboBox<>(FXCollections.observableArrayList(keys.toArray(String[]::new)));
     box.getSelectionModel().selectFirst();
     box.setValue(selected);
+    // TODO: fix this hardcode
+    box.setButtonCell(
+        new ListCell<>() {
+          @Override
+          public void updateItem(String item, boolean empty) {
+            super.updateItem(item, empty);
+            if (item != null) {
+              setText(item);
+              setAlignment(Pos.BASELINE_RIGHT);
+              setPadding(new Insets(5, 0, 5, 0));
+            }
+          }
+        });
     var current = new AtomicReference<>(box.getValue());
     box.valueProperty().addListener((o, previous, now) -> current.set(now));
     return of(box, current::get, text.node(), text::text, false);


### PR DESCRIPTION
新增兩個頁面，第一個是可以讀取 topic

<img width="1197" alt="截圖 2022-11-02 下午6 13 49" src="https://user-images.githubusercontent.com/6234750/199463679-d07560bf-9ec1-498b-94eb-64f9779a4b0a.png">

第二個頁面則是可以寫入資料

<img width="1201" alt="截圖 2022-11-02 下午6 14 03" src="https://user-images.githubusercontent.com/6234750/199463756-59066304-1ea2-4f9c-b2e5-4cf3e183a3d9.png">

另外也將讀取 record timestamp的功能從`topic`頁面移除