### PR TITLE
Enable consumer builder to build stream directly

### DIFF
--- a/common/src/main/java/org/astraea/common/consumer/Consumer.java
+++ b/common/src/main/java/org/astraea/common/consumer/Consumer.java
@@ -17,7 +17,7 @@
 package org.astraea.common.consumer;
 
 import java.time.Duration;
-import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -25,8 +25,7 @@ import org.astraea.common.admin.TopicPartition;
 
 /** An interface for polling records. */
 public interface Consumer<Key, Value> extends AutoCloseable {
-
-  default Collection<Record<Key, Value>> poll(Duration timeout) {
+  default List<Record<Key, Value>> poll(Duration timeout) {
     return poll(1, timeout);
   }
 
@@ -37,7 +36,7 @@ public interface Consumer<Key, Value> extends AutoCloseable {
    * @param timeout max time to wait data
    * @return records
    */
-  Collection<Record<Key, Value>> poll(int recordCount, Duration timeout);
+  List<Record<Key, Value>> poll(int recordCount, Duration timeout);
 
   /**
    * Wakeup the consumer. This method is thread-safe and is useful in particular to abort a long


### PR DESCRIPTION
這隻PR是 #1093 的第一步，我們要將 consumer thread 從目前的執行緒中移出，這樣方便我們去銜接不同的 I/O (例如 file IO)