### PR TITLE
Enhance `Balancer` with retry mechanism

### DIFF
--- a/app/src/main/java/org/astraea/app/balancer/BalanceProcessDemo.java
+++ b/app/src/main/java/org/astraea/app/balancer/BalanceProcessDemo.java
@@ -54,7 +54,7 @@ public class BalanceProcessDemo {
                       .dataFolders(brokerFolders)
                       .config("iteration", "1000")
                       .build())
-              .offer(clusterInfo);
+              .offer(clusterInfo, Duration.ofSeconds(3));
       plan.ifPresent(
           p ->
               new StraightPlanExecutor()

--- a/app/src/main/java/org/astraea/app/balancer/BalanceProcessDemo.java
+++ b/app/src/main/java/org/astraea/app/balancer/BalanceProcessDemo.java
@@ -51,9 +51,10 @@ public class BalanceProcessDemo {
                   AlgorithmConfig.builder()
                       .clusterCost(new ReplicaLeaderCost())
                       .topicFilter(filter)
+                      .dataFolders(brokerFolders)
                       .config("iteration", "1000")
                       .build())
-              .offer(clusterInfo, brokerFolders);
+              .offer(clusterInfo);
       plan.ifPresent(
           p ->
               new StraightPlanExecutor()

--- a/app/src/main/java/org/astraea/app/web/BalancerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BalancerHandler.java
@@ -147,7 +147,7 @@ class BalancerHandler implements Handler {
                           .value();
                   var bestPlan =
                       Balancer.create(request.balancerClasspath, request.algorithmConfig)
-                          .offer(currentClusterInfo);
+                          .offer(currentClusterInfo, request.executionTime);
                   var changes =
                       bestPlan
                           .map(

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -288,7 +288,8 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                   admin
                       .clusterInfo(admin.topicNames(false).toCompletableFuture().join())
                       .toCompletableFuture()
-                      .join());
+                      .join(),
+                  Duration.ofSeconds(3));
 
       Assertions.assertNotEquals(Optional.empty(), Best);
 
@@ -310,7 +311,8 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                       admin
                           .clusterInfo(admin.topicNames(false).toCompletableFuture().join())
                           .toCompletableFuture()
-                          .join()));
+                          .join(),
+                      Duration.ofSeconds(3)));
 
       // test cluster cost predicate
       Assertions.assertEquals(
@@ -328,7 +330,8 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                   admin
                       .clusterInfo(admin.topicNames(false).toCompletableFuture().join())
                       .toCompletableFuture()
-                      .join()));
+                      .join(),
+                  Duration.ofSeconds(3)));
 
       // test move cost predicate
       Assertions.assertEquals(
@@ -346,7 +349,8 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                   admin
                       .clusterInfo(admin.topicNames(false).toCompletableFuture().join())
                       .toCompletableFuture()
-                      .join()));
+                      .join(),
+                  Duration.ofSeconds(3)));
     }
   }
 
@@ -1123,10 +1127,10 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
     }
 
     @Override
-    public Optional<Plan> offer(ClusterInfo<Replica> currentClusterInfo) {
+    public Optional<Plan> offer(ClusterInfo<Replica> currentClusterInfo, Duration timeout) {
       offerCallbacks.forEach(Runnable::run);
       offerCallbacks.clear();
-      return super.offer(currentClusterInfo);
+      return super.offer(currentClusterInfo, timeout);
     }
   }
 }

--- a/common/src/main/java/org/astraea/common/balancer/Balancer.java
+++ b/common/src/main/java/org/astraea/common/balancer/Balancer.java
@@ -64,11 +64,6 @@ public interface Balancer {
     throw new RuntimeException("Execution time exceeded: " + timeoutMs);
   }
 
-  /** Invoke {@link Balancer#offer(ClusterInfo, Duration)} with a default timeout. */
-  default Optional<Plan> offer(ClusterInfo<Replica> currentClusterInfo) {
-    return offer(currentClusterInfo, Duration.ofSeconds(3));
-  }
-
   /**
    * @return a rebalance plan
    */

--- a/common/src/main/java/org/astraea/common/balancer/Balancer.java
+++ b/common/src/main/java/org/astraea/common/balancer/Balancer.java
@@ -17,9 +17,7 @@
 package org.astraea.common.balancer;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import org.astraea.common.EnumInfo;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.ClusterInfo;
@@ -36,8 +34,7 @@ public interface Balancer {
   /**
    * @return a rebalance plan
    */
-  Optional<Plan> offer(
-      ClusterInfo<Replica> currentClusterInfo, Map<Integer, Set<String>> brokerFolders);
+  Optional<Plan> offer(ClusterInfo<Replica> currentClusterInfo);
 
   @SuppressWarnings("unchecked")
   static Balancer create(String classpath, AlgorithmConfig config) {

--- a/common/src/main/java/org/astraea/common/balancer/Balancer.java
+++ b/common/src/main/java/org/astraea/common/balancer/Balancer.java
@@ -19,7 +19,6 @@ package org.astraea.common.balancer;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletionStage;
 import org.astraea.common.EnumInfo;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.ClusterInfo;
@@ -37,14 +36,6 @@ public interface Balancer {
   /**
    * Execute {@link Balancer#offer(ClusterInfo, Duration)}. Retry the plan generation if a {@link
    * NoSufficientMetricsException} exception occurred.
-   *
-   * <p>The returned {@link CompletionStage} finished if:
-   *
-   * <ul>
-   *   <li>The plan is generated.
-   *   <li>The plan didn't generated before the execution time exceeded.
-   *   <li>An exception occurred during the plan generation.
-   * </ul>
    */
   default Optional<Plan> retryOffer(ClusterInfo<Replica> currentClusterInfo, Duration timeout) {
     final var timeoutMs = System.currentTimeMillis() + timeout.toMillis();

--- a/common/src/main/java/org/astraea/common/balancer/Balancer.java
+++ b/common/src/main/java/org/astraea/common/balancer/Balancer.java
@@ -41,11 +41,11 @@ public interface Balancer {
     final var timeoutMs = System.currentTimeMillis() + timeout.toMillis();
     while (System.currentTimeMillis() < timeoutMs) {
       try {
-        return offer(currentClusterInfo, timeout);
+        return offer(currentClusterInfo, Duration.ofMillis(timeoutMs - System.currentTimeMillis()));
       } catch (NoSufficientMetricsException e) {
         e.printStackTrace();
-        long remainTimeout = timeoutMs - System.currentTimeMillis();
-        long waitMs = e.suggestedWait().toMillis();
+        var remainTimeout = timeoutMs - System.currentTimeMillis();
+        var waitMs = e.suggestedWait().toMillis();
         if (remainTimeout > waitMs) {
           Utils.sleep(Duration.ofMillis(waitMs));
         } else {

--- a/common/src/main/java/org/astraea/common/balancer/Balancer.java
+++ b/common/src/main/java/org/astraea/common/balancer/Balancer.java
@@ -16,6 +16,7 @@
  */
 package org.astraea.common.balancer;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import org.astraea.common.EnumInfo;
@@ -31,10 +32,15 @@ import org.astraea.common.cost.MoveCost;
 
 public interface Balancer {
 
+  /** Invoke {@link Balancer#offer(ClusterInfo, Duration)} with a default timeout. */
+  default Optional<Plan> offer(ClusterInfo<Replica> currentClusterInfo) {
+    return offer(currentClusterInfo, Duration.ofSeconds(3));
+  }
+
   /**
    * @return a rebalance plan
    */
-  Optional<Plan> offer(ClusterInfo<Replica> currentClusterInfo);
+  Optional<Plan> offer(ClusterInfo<Replica> currentClusterInfo, Duration timeout);
 
   @SuppressWarnings("unchecked")
   static Balancer create(String classpath, AlgorithmConfig config) {

--- a/common/src/main/java/org/astraea/common/balancer/algorithms/AlgorithmConfig.java
+++ b/common/src/main/java/org/astraea/common/balancer/algorithms/AlgorithmConfig.java
@@ -16,7 +16,6 @@
  */
 package org.astraea.common.balancer.algorithms;
 
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -73,11 +72,6 @@ public interface AlgorithmConfig {
   Predicate<List<MoveCost>> movementConstraint();
 
   /**
-   * @return the limit of algorithm execution time
-   */
-  Duration executionTime();
-
-  /**
    * @return a {@link Predicate} that can indicate which topic is eligible for rebalance.
    */
   Predicate<String> topicFilter();
@@ -101,7 +95,6 @@ public interface AlgorithmConfig {
     private BiPredicate<ClusterCost, ClusterCost> clusterConstraint =
         (before, after) -> after.value() < before.value();
     private Predicate<List<MoveCost>> movementConstraint = ignore -> true;
-    private Duration executionTime = Duration.ofSeconds(3);
     private Supplier<ClusterBean> metricSource = () -> ClusterBean.EMPTY;
     private Predicate<String> topicFilter = ignore -> true;
     private final Map<String, String> config = new HashMap<>();
@@ -175,15 +168,6 @@ public interface AlgorithmConfig {
      */
     public Builder movementConstraint(Predicate<List<MoveCost>> moveConstraint) {
       this.movementConstraint = Objects.requireNonNull(moveConstraint);
-      return this;
-    }
-
-    /**
-     * @param limit the execution time of searching best plan.
-     * @return this
-     */
-    public Builder limit(Duration limit) {
-      this.executionTime = limit;
       return this;
     }
 
@@ -266,11 +250,6 @@ public interface AlgorithmConfig {
         @Override
         public Predicate<List<MoveCost>> movementConstraint() {
           return movementConstraint;
-        }
-
-        @Override
-        public Duration executionTime() {
-          return executionTime;
         }
 
         @Override

--- a/common/src/main/java/org/astraea/common/balancer/algorithms/AlgorithmConfig.java
+++ b/common/src/main/java/org/astraea/common/balancer/algorithms/AlgorithmConfig.java
@@ -116,6 +116,8 @@ public interface AlgorithmConfig {
      * @return this.
      */
     public Builder dataFolders(Map<Integer, Set<String>> dataFolders) {
+      // TODO: Embedded these data folders information into ClusterInfo
+      //       see https://github.com/skiptests/astraea/issues/1106
       this.dataFolders = Objects.requireNonNull(dataFolders);
       return this;
     }

--- a/common/src/main/java/org/astraea/common/balancer/algorithms/AlgorithmConfig.java
+++ b/common/src/main/java/org/astraea/common/balancer/algorithms/AlgorithmConfig.java
@@ -111,7 +111,7 @@ public interface AlgorithmConfig {
     }
 
     /**
-     * Sepcify the data foldesr of all brokers
+     * Specify the data folders of all brokers
      *
      * @return this.
      */

--- a/common/src/main/java/org/astraea/common/balancer/algorithms/AlgorithmConfig.java
+++ b/common/src/main/java/org/astraea/common/balancer/algorithms/AlgorithmConfig.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
@@ -45,6 +46,11 @@ public interface AlgorithmConfig {
    *     logging usage.
    */
   String executionId();
+
+  /**
+   * @return the data folders of al brokers.
+   */
+  Map<Integer, Set<String>> dataFolders();
 
   /**
    * @return the cluster cost function for this problem.
@@ -90,6 +96,7 @@ public interface AlgorithmConfig {
 
     private String executionId = "noname-" + UUID.randomUUID();
     private HasClusterCost clusterCostFunction;
+    private Map<Integer, Set<String>> dataFolders;
     private List<HasMoveCost> moveCostFunction = List.of(HasMoveCost.EMPTY);
     private BiPredicate<ClusterCost, ClusterCost> clusterConstraint =
         (before, after) -> after.value() < before.value();
@@ -107,6 +114,16 @@ public interface AlgorithmConfig {
      */
     public Builder executionId(String id) {
       this.executionId = id;
+      return this;
+    }
+
+    /**
+     * Sepcify the data foldesr of all brokers
+     *
+     * @return this.
+     */
+    public Builder dataFolders(Map<Integer, Set<String>> dataFolders) {
+      this.dataFolders = Objects.requireNonNull(dataFolders);
       return this;
     }
 
@@ -217,10 +234,18 @@ public interface AlgorithmConfig {
     }
 
     public AlgorithmConfig build() {
+      Objects.requireNonNull(clusterCostFunction);
+      Objects.requireNonNull(dataFolders);
+
       return new AlgorithmConfig() {
         @Override
         public String executionId() {
           return executionId;
+        }
+
+        @Override
+        public Map<Integer, Set<String>> dataFolders() {
+          return dataFolders;
         }
 
         @Override

--- a/common/src/main/java/org/astraea/common/balancer/algorithms/GreedyBalancer.java
+++ b/common/src/main/java/org/astraea/common/balancer/algorithms/GreedyBalancer.java
@@ -16,6 +16,7 @@
  */
 package org.astraea.common.balancer.algorithms;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -81,7 +82,7 @@ public class GreedyBalancer implements Balancer {
   }
 
   @Override
-  public Optional<Plan> offer(ClusterInfo<Replica> currentClusterInfo) {
+  public Optional<Plan> offer(ClusterInfo<Replica> currentClusterInfo, Duration timeout) {
     Jmx jmx = new Jmx();
 
     final var allocationTweaker = new ShuffleTweaker(minStep, maxStep);
@@ -91,7 +92,7 @@ public class GreedyBalancer implements Balancer {
 
     final var loop = new AtomicInteger(iteration);
     final var start = System.currentTimeMillis();
-    final var executionTime = config.executionTime().toMillis();
+    final var executionTime = timeout.toMillis();
     Supplier<Boolean> moreRoom =
         () -> System.currentTimeMillis() - start < executionTime && loop.getAndDecrement() > 0;
     BiFunction<ClusterLogAllocation, ClusterCost, Optional<Balancer.Plan>> next =

--- a/common/src/main/java/org/astraea/common/balancer/algorithms/GreedyBalancer.java
+++ b/common/src/main/java/org/astraea/common/balancer/algorithms/GreedyBalancer.java
@@ -16,7 +16,6 @@
  */
 package org.astraea.common.balancer.algorithms;
 
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -82,8 +81,7 @@ public class GreedyBalancer implements Balancer {
   }
 
   @Override
-  public Optional<Plan> offer(
-      ClusterInfo<Replica> currentClusterInfo, Map<Integer, Set<String>> brokerFolders) {
+  public Optional<Plan> offer(ClusterInfo<Replica> currentClusterInfo) {
     Jmx jmx = new Jmx();
 
     final var allocationTweaker = new ShuffleTweaker(minStep, maxStep);
@@ -99,7 +97,7 @@ public class GreedyBalancer implements Balancer {
     BiFunction<ClusterLogAllocation, ClusterCost, Optional<Balancer.Plan>> next =
         (currentAllocation, currentCost) ->
             allocationTweaker
-                .generate(brokerFolders, currentAllocation)
+                .generate(config.dataFolders(), currentAllocation)
                 .takeWhile(ignored -> moreRoom.get())
                 .map(
                     newAllocation -> {

--- a/common/src/main/java/org/astraea/common/balancer/algorithms/SingleStepBalancer.java
+++ b/common/src/main/java/org/astraea/common/balancer/algorithms/SingleStepBalancer.java
@@ -17,7 +17,6 @@
 package org.astraea.common.balancer.algorithms;
 
 import java.util.Comparator;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -72,8 +71,7 @@ public class SingleStepBalancer implements Balancer {
   }
 
   @Override
-  public Optional<Balancer.Plan> offer(
-      ClusterInfo<Replica> currentClusterInfo, Map<Integer, Set<String>> brokerFolders) {
+  public Optional<Balancer.Plan> offer(ClusterInfo<Replica> currentClusterInfo) {
     final var allocationTweaker = new ShuffleTweaker(minStep, maxStep);
     final var currentClusterBean = config.metricSource().get();
     final var clusterCostFunction = config.clusterCostFunction();
@@ -85,7 +83,7 @@ public class SingleStepBalancer implements Balancer {
     var start = System.currentTimeMillis();
     var executionTime = config.executionTime().toMillis();
     return allocationTweaker
-        .generate(brokerFolders, ClusterLogAllocation.of(generatorClusterInfo))
+        .generate(config.dataFolders(), ClusterLogAllocation.of(generatorClusterInfo))
         .parallel()
         .limit(iteration)
         .takeWhile(ignored -> System.currentTimeMillis() - start <= executionTime)

--- a/common/src/main/java/org/astraea/common/cost/CostFunction.java
+++ b/common/src/main/java/org/astraea/common/cost/CostFunction.java
@@ -25,6 +25,13 @@ import org.astraea.common.metrics.collector.Fetcher;
  *
  * <p>Constructors in CostFunction can only take no or only one parameter {@link Configuration}, ex.
  * Constructor({@link Configuration} configuration) or Constructor()
+ *
+ * <p>A cost function might take advantage of some Mbean metrics to function. One can indicate such
+ * requirement in the {@link CostFunction#fetcher()} function. If the operation logic of
+ * CostFunction thinks the metrics on hand are insufficient or not ready to work. One can throw a
+ * {@link NoSufficientMetricsException} from the calculation logic of {@link HasBrokerCost} or
+ * {@link HasClusterCost}. This serves as a hint to the caller that it needs newer metrics and
+ * please retry later.
  */
 public interface CostFunction {
 

--- a/common/src/main/java/org/astraea/common/cost/NoSufficientMetricsException.java
+++ b/common/src/main/java/org/astraea/common/cost/NoSufficientMetricsException.java
@@ -31,12 +31,7 @@ public class NoSufficientMetricsException extends RuntimeException {
   private final Duration suggestedWait;
 
   public NoSufficientMetricsException(CostFunction source, Duration suggestedWait) {
-    super();
-    if (suggestedWait.isNegative() || suggestedWait.isZero())
-      throw new IllegalArgumentException(
-          "the wait time should be positive: " + suggestedWait.toMillis());
-    this.source = Objects.requireNonNull(source);
-    this.suggestedWait = Objects.requireNonNull(suggestedWait);
+    this(source, suggestedWait, "");
   }
 
   public NoSufficientMetricsException(CostFunction source, Duration suggestedWait, String message) {

--- a/common/src/main/java/org/astraea/common/cost/NoSufficientMetricsException.java
+++ b/common/src/main/java/org/astraea/common/cost/NoSufficientMetricsException.java
@@ -30,23 +30,30 @@ public class NoSufficientMetricsException extends RuntimeException {
   private final CostFunction source;
   private final Duration suggestedWait;
 
-  public NoSufficientMetricsException(CostFunction source, String message) {
-    this(source, Duration.ZERO, message);
-  }
-
-  public NoSufficientMetricsException(CostFunction source, Duration suggestedWait, String message) {
-    super(composedMessage(source, message));
+  public NoSufficientMetricsException(CostFunction source, Duration suggestedWait) {
+    super();
+    if (suggestedWait.isNegative() || suggestedWait.isZero())
+      throw new IllegalArgumentException(
+          "the wait time should be positive: " + suggestedWait.toMillis());
     this.source = Objects.requireNonNull(source);
     this.suggestedWait = Objects.requireNonNull(suggestedWait);
   }
 
-  public NoSufficientMetricsException(CostFunction source, String message, Throwable cause) {
-    this(source, Duration.ZERO, message, cause);
+  public NoSufficientMetricsException(CostFunction source, Duration suggestedWait, String message) {
+    super(composedMessage(source, message));
+    if (suggestedWait.isNegative() || suggestedWait.isZero())
+      throw new IllegalArgumentException(
+          "the wait time should be positive: " + suggestedWait.toMillis());
+    this.source = Objects.requireNonNull(source);
+    this.suggestedWait = Objects.requireNonNull(suggestedWait);
   }
 
   public NoSufficientMetricsException(
       CostFunction source, Duration suggestedWait, String message, Throwable cause) {
     super(composedMessage(source, message), cause);
+    if (suggestedWait.isNegative() || suggestedWait.isZero())
+      throw new IllegalArgumentException(
+          "the wait time should be positive: " + suggestedWait.toMillis());
     this.source = Objects.requireNonNull(source);
     this.suggestedWait = Objects.requireNonNull(suggestedWait);
   }

--- a/common/src/main/java/org/astraea/common/cost/NoSufficientMetricsException.java
+++ b/common/src/main/java/org/astraea/common/cost/NoSufficientMetricsException.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.cost;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Indicate that {@link CostFunction} thinks the metrics on hand cannot be processed. It probably is
+ * due to the insufficient amount of metrics or contradiction in the value of the metric. This
+ * exception serves as a hint to the caller that it needs more or newer metrics to function, please
+ * retry later.
+ */
+public class NoSufficientMetricsException extends RuntimeException {
+
+  private final CostFunction source;
+  private final Duration suggestedWait;
+
+  public NoSufficientMetricsException(CostFunction source, String message) {
+    this(source, Duration.ZERO, message);
+  }
+
+  public NoSufficientMetricsException(CostFunction source, Duration suggestedWait, String message) {
+    super(composedMessage(source, message));
+    this.source = Objects.requireNonNull(source);
+    this.suggestedWait = Objects.requireNonNull(suggestedWait);
+  }
+
+  public NoSufficientMetricsException(CostFunction source, String message, Throwable cause) {
+    this(source, Duration.ZERO, message, cause);
+  }
+
+  public NoSufficientMetricsException(
+      CostFunction source, Duration suggestedWait, String message, Throwable cause) {
+    super(composedMessage(source, message), cause);
+    this.source = Objects.requireNonNull(source);
+    this.suggestedWait = Objects.requireNonNull(suggestedWait);
+  }
+
+  /** Which cost function cause this exception. */
+  public CostFunction source() {
+    return source;
+  }
+
+  /**
+   * The suggested retry interval. This is just a suggestion so the implementation might wait longer
+   * than the specified duration.
+   */
+  public Duration suggestedWait() {
+    return suggestedWait;
+  }
+
+  private static String composedMessage(CostFunction source, String original) {
+    return "Not enough metrics for " + source.getClass().getName() + ": " + original;
+  }
+}

--- a/common/src/test/java/org/astraea/common/balancer/BalancerAlgorithmTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerAlgorithmTest.java
@@ -89,13 +89,13 @@ public class BalancerAlgorithmTest extends RequireBrokerCluster {
                   AlgorithmConfig.builder()
                       .clusterCost(new ReplicaNumberCost())
                       .dataFolders(admin.brokerFolders().toCompletableFuture().join())
-                      .limit(Duration.ofSeconds(5))
                       .build())
               .offer(
                   admin
                       .clusterInfo(admin.topicNames(false).toCompletableFuture().join())
                       .toCompletableFuture()
-                      .join())
+                      .join(),
+                  Duration.ofSeconds(5))
               .get();
 
       var plan =
@@ -104,13 +104,13 @@ public class BalancerAlgorithmTest extends RequireBrokerCluster {
                   AlgorithmConfig.builder()
                       .clusterCost(new ReplicaNumberCost())
                       .dataFolders(admin.brokerFolders().toCompletableFuture().join())
-                      .limit(Duration.ofSeconds(5))
                       .build())
               .offer(
                   admin
                       .clusterInfo(admin.topicNames(false).toCompletableFuture().join())
                       .toCompletableFuture()
-                      .join())
+                      .join(),
+                  Duration.ofSeconds(5))
               .get();
 
       Assertions.assertTrue(plan.clusterCost.value() > planOfGreedy.clusterCost.value());

--- a/common/src/test/java/org/astraea/common/balancer/BalancerAlgorithmTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerAlgorithmTest.java
@@ -88,14 +88,14 @@ public class BalancerAlgorithmTest extends RequireBrokerCluster {
                   GreedyBalancer.class,
                   AlgorithmConfig.builder()
                       .clusterCost(new ReplicaNumberCost())
+                      .dataFolders(admin.brokerFolders().toCompletableFuture().join())
                       .limit(Duration.ofSeconds(5))
                       .build())
               .offer(
                   admin
                       .clusterInfo(admin.topicNames(false).toCompletableFuture().join())
                       .toCompletableFuture()
-                      .join(),
-                  admin.brokerFolders().toCompletableFuture().join())
+                      .join())
               .get();
 
       var plan =
@@ -103,14 +103,14 @@ public class BalancerAlgorithmTest extends RequireBrokerCluster {
                   SingleStepBalancer.class,
                   AlgorithmConfig.builder()
                       .clusterCost(new ReplicaNumberCost())
+                      .dataFolders(admin.brokerFolders().toCompletableFuture().join())
                       .limit(Duration.ofSeconds(5))
                       .build())
               .offer(
                   admin
                       .clusterInfo(admin.topicNames(false).toCompletableFuture().join())
                       .toCompletableFuture()
-                      .join(),
-                  admin.brokerFolders().toCompletableFuture().join())
+                      .join())
               .get();
 
       Assertions.assertTrue(plan.clusterCost.value() > planOfGreedy.clusterCost.value());

--- a/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
@@ -160,7 +160,7 @@ class BalancerTest extends RequireBrokerCluster {
                       .clusterCost(randomScore)
                       .config("iteration", "500")
                       .build())
-              .offer(clusterInfo)
+              .offer(clusterInfo, Duration.ofSeconds(3))
               .get()
               .proposal();
 
@@ -258,7 +258,7 @@ class BalancerTest extends RequireBrokerCluster {
                       .metricSource(metricSource)
                       .config("iteration", "500")
                       .build())
-              .offer(ClusterInfo.empty());
+              .offer(ClusterInfo.empty(), Duration.ofSeconds(3));
           Assertions.assertTrue(called.get(), "The cost function has been invoked");
         };
 

--- a/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
@@ -93,13 +93,13 @@ class BalancerTest extends RequireBrokerCluster {
                       .clusterCost(new ReplicaLeaderCost())
                       .dataFolders(admin.brokerFolders().toCompletableFuture().join())
                       .topicFilter(topic -> topic.equals(topicName))
-                      .limit(Duration.ofSeconds(10))
                       .build())
               .offer(
                   admin
                       .clusterInfo(admin.topicNames(false).toCompletableFuture().join())
                       .toCompletableFuture()
-                      .join())
+                      .join(),
+                  Duration.ofSeconds(10))
               .orElseThrow();
       new StraightPlanExecutor()
           .run(admin, plan.proposal(), Duration.ofSeconds(10))
@@ -193,13 +193,13 @@ class BalancerTest extends RequireBrokerCluster {
                           AlgorithmConfig.builder()
                               .clusterCost((clusterInfo, bean) -> Math::random)
                               .dataFolders(admin.brokerFolders().toCompletableFuture().join())
-                              .limit(Duration.ofSeconds(3))
                               .build())
                       .offer(
                           admin
                               .clusterInfo(admin.topicNames(false).toCompletableFuture().join())
                               .toCompletableFuture()
-                              .join())
+                              .join(),
+                          Duration.ofSeconds(3))
                       .get()
                       .proposal());
       Utils.sleep(Duration.ofMillis(1000));

--- a/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
@@ -91,6 +91,7 @@ class BalancerTest extends RequireBrokerCluster {
                   theClass,
                   AlgorithmConfig.builder()
                       .clusterCost(new ReplicaLeaderCost())
+                      .dataFolders(admin.brokerFolders().toCompletableFuture().join())
                       .topicFilter(topic -> topic.equals(topicName))
                       .limit(Duration.ofSeconds(10))
                       .build())
@@ -98,8 +99,7 @@ class BalancerTest extends RequireBrokerCluster {
                   admin
                       .clusterInfo(admin.topicNames(false).toCompletableFuture().join())
                       .toCompletableFuture()
-                      .join(),
-                  admin.brokerFolders().toCompletableFuture().join())
+                      .join())
               .orElseThrow();
       new StraightPlanExecutor()
           .run(admin, plan.proposal(), Duration.ofSeconds(10))
@@ -150,10 +150,11 @@ class BalancerTest extends RequireBrokerCluster {
                   theClass,
                   AlgorithmConfig.builder()
                       .topicFilter(t -> t.equals(theTopic))
+                      .dataFolders(brokerFolders)
                       .clusterCost(randomScore)
                       .config("iteration", "500")
                       .build())
-              .offer(clusterInfo, brokerFolders)
+              .offer(clusterInfo)
               .get()
               .proposal();
 
@@ -191,14 +192,14 @@ class BalancerTest extends RequireBrokerCluster {
                           theClass,
                           AlgorithmConfig.builder()
                               .clusterCost((clusterInfo, bean) -> Math::random)
+                              .dataFolders(admin.brokerFolders().toCompletableFuture().join())
                               .limit(Duration.ofSeconds(3))
                               .build())
                       .offer(
                           admin
                               .clusterInfo(admin.topicNames(false).toCompletableFuture().join())
                               .toCompletableFuture()
-                              .join(),
-                          admin.brokerFolders().toCompletableFuture().join())
+                              .join())
                       .get()
                       .proposal());
       Utils.sleep(Duration.ofMillis(1000));
@@ -247,10 +248,11 @@ class BalancerTest extends RequireBrokerCluster {
                   theClass,
                   AlgorithmConfig.builder()
                       .clusterCost(theCostFunction)
+                      .dataFolders(Map.of())
                       .metricSource(metricSource)
                       .config("iteration", "500")
                       .build())
-              .offer(ClusterInfo.empty(), Map.of());
+              .offer(ClusterInfo.empty());
           Assertions.assertTrue(called.get(), "The cost function has been invoked");
         };
 

--- a/common/src/test/java/org/astraea/common/balancer/algorithms/GreedyBalancerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/algorithms/GreedyBalancerTest.java
@@ -54,22 +54,23 @@ class GreedyBalancerTest {
   void testJmx() {
     var cost = new DecreasingCost(Configuration.of(Map.of()));
     var id = "TestJmx-" + UUID.randomUUID();
+    var clusterInfo = FakeClusterInfo.of(5, 5, 5, 2);
     var balancer =
         Balancer.create(
             GreedyBalancer.class,
             AlgorithmConfig.builder()
                 .executionId(id)
+                .dataFolders(clusterInfo.dataDirectories())
                 .clusterCost(cost)
                 .limit(Duration.ofMillis(300))
                 .config(GreedyBalancer.ITERATION_CONFIG, "100")
                 .build());
-    var clusterInfo = FakeClusterInfo.of(5, 5, 5, 2);
 
     try (MBeanClient client = MBeanClient.local()) {
       IntStream.range(0, 10)
           .forEach(
               run -> {
-                var plan = balancer.offer(clusterInfo, clusterInfo.dataDirectories());
+                var plan = balancer.offer(clusterInfo);
                 Assertions.assertTrue(plan.isPresent());
                 var bean =
                     Assertions.assertDoesNotThrow(

--- a/common/src/test/java/org/astraea/common/balancer/algorithms/GreedyBalancerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/algorithms/GreedyBalancerTest.java
@@ -62,7 +62,6 @@ class GreedyBalancerTest {
                 .executionId(id)
                 .dataFolders(clusterInfo.dataDirectories())
                 .clusterCost(cost)
-                .limit(Duration.ofMillis(300))
                 .config(GreedyBalancer.ITERATION_CONFIG, "100")
                 .build());
 
@@ -70,7 +69,7 @@ class GreedyBalancerTest {
       IntStream.range(0, 10)
           .forEach(
               run -> {
-                var plan = balancer.offer(clusterInfo);
+                var plan = balancer.offer(clusterInfo, Duration.ofMillis(300));
                 Assertions.assertTrue(plan.isPresent());
                 var bean =
                     Assertions.assertDoesNotThrow(

--- a/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
@@ -208,6 +208,7 @@ public class BalancerNode {
                                               .clusterCost(
                                                   HasClusterCost.of(
                                                       clusterCosts(argument.selectedKeys())))
+                                              .dataFolders(brokerFolders)
                                               .moveCost(
                                                   List.of(
                                                       new ReplicaSizeCost(),
@@ -223,7 +224,7 @@ public class BalancerNode {
                                                                   p -> p.matcher(topic).matches()))
                                               .config("iteration", "10000")
                                               .build())
-                                      .offer(clusterInfo, brokerFolders));
+                                      .offer(clusterInfo));
                             }))
             .thenApply(
                 entry -> {

--- a/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
@@ -215,7 +215,6 @@ public class BalancerNode {
                                                       new ReplicaLeaderCost()))
                                               .movementConstraint(
                                                   movementConstraint(argument.nonEmptyTexts()))
-                                              .limit(Duration.ofSeconds(10))
                                               .topicFilter(
                                                   topic ->
                                                       patterns.isEmpty()
@@ -224,7 +223,7 @@ public class BalancerNode {
                                                                   p -> p.matcher(topic).matches()))
                                               .config("iteration", "10000")
                                               .build())
-                                      .offer(clusterInfo));
+                                      .offer(clusterInfo, Duration.ofSeconds(10)));
                             }))
             .thenApply(
                 entry -> {


### PR DESCRIPTION
resolve #1008.

* 把 `Balancer#offer()` 的 `brokerFolders` 參數移動到 `AlgorithmConfig` 裡面。
* 把 `executionTime` 參數從 `AlgorithmConfig` 移動到 `Balancer#offer` 函數簽名上。
* 實作 default interface method `Balancer#retryOffer()`,裡面會重複呼叫 `Balancer#offer`，如果遇到 `NoSufficientMetricsException` 時，在等一段時間後主動重試這個產生

這個 PR 在做 #955 在做的事情，只是從 `Balancer` 做起而非從 `BalancerHandler` 做起。這裡面還有很多要克服的問題

* 使 `BalancerHandler` 使用 `retryOffer`
* 使 `BalancerHandler` 內計算原本 cluster cost 的邏輯移動到 balancer 內部。

上述問題會在 #955 處理掉。