### PR TITLE
Use `FifteenMinuteRate` in `BrokerInputCost` and `BrokerOutputCost`

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/BrokerInputCost.java
+++ b/common/src/main/java/org/astraea/common/cost/BrokerInputCost.java
@@ -40,7 +40,7 @@ public class BrokerInputCost implements HasBrokerCost, HasClusterCost {
                     Map.Entry::getKey,
                     entry ->
                         ServerMetrics.BrokerTopic.BYTES_IN_PER_SEC.of(entry.getValue()).stream()
-                            .mapToDouble(ServerMetrics.BrokerTopic.Meter::oneMinuteRate)
+                            .mapToDouble(ServerMetrics.BrokerTopic.Meter::fifteenMinuteRate)
                             .sum()));
     return () -> brokerCost;
   }

--- a/common/src/main/java/org/astraea/common/cost/BrokerOutputCost.java
+++ b/common/src/main/java/org/astraea/common/cost/BrokerOutputCost.java
@@ -40,7 +40,7 @@ public class BrokerOutputCost implements HasBrokerCost, HasClusterCost {
                     Map.Entry::getKey,
                     entry ->
                         ServerMetrics.BrokerTopic.BYTES_OUT_PER_SEC.of(entry.getValue()).stream()
-                            .mapToDouble(ServerMetrics.BrokerTopic.Meter::oneMinuteRate)
+                            .mapToDouble(ServerMetrics.BrokerTopic.Meter::fifteenMinuteRate)
                             .sum()));
     return () -> brokerCost;
   }

--- a/common/src/test/java/org/astraea/common/cost/BrokerInputCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/BrokerInputCostTest.java
@@ -87,6 +87,6 @@ public class BrokerInputCostTest extends RequireBrokerCluster {
         new BeanObject(
             "object",
             Map.of("name", ServerMetrics.BrokerTopic.BYTES_IN_PER_SEC.metricName()),
-            Map.of("OneMinuteRate", value)));
+            Map.of("FifteenMinuteRate", value)));
   }
 }

--- a/common/src/test/java/org/astraea/common/cost/BrokerOutputCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/BrokerOutputCostTest.java
@@ -80,6 +80,6 @@ public class BrokerOutputCostTest extends RequireBrokerCluster {
         new BeanObject(
             "object",
             Map.of("name", ServerMetrics.BrokerTopic.BYTES_OUT_PER_SEC.metricName()),
-            Map.of("OneMinuteRate", value)));
+            Map.of("FifteenMinuteRate", value)));
   }
 }


### PR DESCRIPTION
Context: https://github.com/skiptests/astraea/pull/1103#discussion_r1019054271

原先 `BrokerInputCost` 和 `BrokerOutputCost` 使用 `OneMinuteRate` 來判斷各節點的輸入輸出負載重量。這個 PR 改用 `FifteenMinuteRate` 來衡量。這個指標看的時間比較長遠，較能反映出長遠下來的結果。