### PR TITLE
[GUI] wildcard should exclude empty/blank string

### DIFF
--- a/gui/src/main/java/org/astraea/gui/Query.java
+++ b/gui/src/main/java/org/astraea/gui/Query.java
@@ -281,7 +281,7 @@ public interface Query {
         });
   }
 
-  private static Optional<Query> forString(String predicateString) {
+  static Optional<Query> forString(String predicateString) {
     if (predicateString == null || predicateString.isBlank()) return Optional.empty();
     if (predicateString.contains("==")
         || predicateString.contains("<=")
@@ -301,9 +301,12 @@ public interface Query {
           public boolean required(Map<String, Object> item) {
             return item.entrySet().stream()
                 .anyMatch(
-                    entry ->
-                        keyPattern.matcher(entry.getKey()).matches()
-                            && valuePattern.matcher(entry.getValue().toString()).matches());
+                    entry -> {
+                      if (!keyPattern.matcher(entry.getKey()).matches()) return false;
+                      var string = entry.getValue().toString();
+                      if (string.isBlank()) return false;
+                      return valuePattern.matcher(string).matches();
+                    });
           }
         });
   }

--- a/gui/src/test/java/org/astraea/gui/QueryTest.java
+++ b/gui/src/test/java/org/astraea/gui/QueryTest.java
@@ -19,6 +19,7 @@ package org.astraea.gui;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.astraea.common.DataSize;
@@ -142,5 +143,15 @@ public class QueryTest {
                 NEGATIVE_QUERIES.stream(),
                 Stream.of(POSITIVE_QUERIES.get((int) (POSITIVE_QUERIES.size() * Math.random()))))
             .collect(Collectors.joining("||")));
+  }
+
+  @Test
+  void testEmptyString() {
+    var predicate = Query.forString("string=*");
+    Assertions.assertNotEquals(Optional.empty(), predicate);
+    Assertions.assertFalse(predicate.get().required(Map.of("string", "")));
+    Assertions.assertFalse(predicate.get().required(Map.of("string", " ")));
+    Assertions.assertFalse(predicate.get().required(Map.of("string", "  ")));
+    Assertions.assertTrue(predicate.get().required(Map.of("string", "1")));
   }
 }


### PR DESCRIPTION
如題，空白的字串應該使用`xxx=`來搜尋，`xxx=*`應該比對到任何有值的內容