### PR TITLE
Remove redundant fetcher adding

### DIFF
--- a/common/src/main/java/org/astraea/common/partitioner/StrictCostDispatcher.java
+++ b/common/src/main/java/org/astraea/common/partitioner/StrictCostDispatcher.java
@@ -90,7 +90,6 @@ public class StrictCostDispatcher implements Dispatcher {
                                         metricCollector.registerJmx(
                                             node.id(),
                                             InetSocketAddress.createUnresolved(node.host(), port)));
-                            metricCollector.addFetcher(fetcher);
                           }
                         }));
   }

--- a/common/src/test/java/org/astraea/common/partitioner/StrictCostDispatcherTest.java
+++ b/common/src/test/java/org/astraea/common/partitioner/StrictCostDispatcherTest.java
@@ -288,11 +288,9 @@ public class StrictCostDispatcherTest {
           dispatcher.jmxPortGetter = id -> Optional.of(1111);
           dispatcher.tryToUpdateFetcher(clusterInfo);
           Assertions.assertEquals(1, dispatcher.metricCollector.listIdentities().size());
-          Assertions.assertEquals(1, dispatcher.metricCollector.listFetchers().size());
 
           dispatcher.tryToUpdateFetcher(clusterInfo);
           Assertions.assertEquals(1, dispatcher.metricCollector.listIdentities().size());
-          Assertions.assertEquals(1, dispatcher.metricCollector.listFetchers().size());
         }
       }
     }


### PR DESCRIPTION
現在的 `MetricCollector` `fetcher` 是共用的，相比之前的 `BeanCollector` 是每個 node 都有自己的 `fetcher` ，也因此不需要每新增一個 node 就加入 `fetcher`，故刪除。