### PR TITLE
Fix heap memory problem in SmoothWeightRoundRobinDispatcher

### DIFF
--- a/common/src/main/java/org/astraea/common/partitioner/PartitionerUtils.java
+++ b/common/src/main/java/org/astraea/common/partitioner/PartitionerUtils.java
@@ -70,8 +70,9 @@ public class PartitionerUtils {
     var properties = new Properties();
     try {
       var partitionerConfig = (String) configs.get("partitioner.config");
-      if (partitionerConfig == null){
-        throw new IllegalArgumentException("This Partitioner requires \"partitioner.config\" being set.");
+      if (partitionerConfig == null) {
+        throw new IllegalArgumentException(
+            "This Partitioner requires \"partitioner.config\" being set.");
       }
       properties.load(new FileInputStream(partitionerConfig));
     } catch (IOException e) {

--- a/common/src/main/java/org/astraea/common/partitioner/PartitionerUtils.java
+++ b/common/src/main/java/org/astraea/common/partitioner/PartitionerUtils.java
@@ -69,7 +69,11 @@ public class PartitionerUtils {
   public static Properties partitionerConfig(Map<String, ?> configs) {
     var properties = new Properties();
     try {
-      properties.load(new FileInputStream((String) configs.get("partitioner.config")));
+      var partitionerConfig = (String) configs.get("partitioner.config");
+      if (partitionerConfig == null){
+        throw new IllegalArgumentException("This Partitioner requires \"partitioner.config\" being set.");
+      }
+      properties.load(new FileInputStream(partitionerConfig));
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/common/src/main/java/org/astraea/common/partitioner/smooth/SmoothWeightRoundRobinDispatcher.java
+++ b/common/src/main/java/org/astraea/common/partitioner/smooth/SmoothWeightRoundRobinDispatcher.java
@@ -18,13 +18,10 @@ package org.astraea.common.partitioner.smooth;
 
 import java.net.InetSocketAddress;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -56,13 +53,6 @@ public class SmoothWeightRoundRobinDispatcher implements Dispatcher {
   private final Optional<Integer> jmxPortDefault = Optional.empty();
   private final Map<Integer, Integer> jmxPorts = new TreeMap<>();
 
-  /* These two map ("hasPartitions", "hasPartitionsSet") should be updated together. One for random access, one for existence checking*/
-  // Map of "broker id" and "collection of partitions"
-  // TODO: This is not aware of topic.
-  private final Map<Integer, List<Integer>> hasPartitions = new TreeMap<>();
-
-  private final Map<Integer, Set<Integer>> hasPartitionsSet = new TreeMap<>();
-
   private final Lazy<SmoothWeightRoundRobin> smoothWeightRoundRobinCal = Lazy.of();
 
   private final NeutralIntegratedCost neutralIntegratedCost = new NeutralIntegratedCost();
@@ -93,12 +83,14 @@ public class SmoothWeightRoundRobinDispatcher implements Dispatcher {
       var smooth = smoothWeightRoundRobinCal.get(() -> new SmoothWeightRoundRobin(supplier.get()));
       smooth.init(supplier);
       var targetBroker = smooth.getAndChoose(topic, clusterInfo);
+      var targetPartitions =
+          clusterInfo.availableReplicas(topic).stream()
+              .filter(r -> r.nodeInfo().id() == targetBroker)
+              .collect(Collectors.toUnmodifiableList());
       targetPartition =
-          hasPartitions
-              .get(targetBroker)
-              .get(
-                  nextValue(topic, clusterInfo, targetBroker)
-                      % hasPartitions.get(targetBroker).size());
+          targetPartitions
+              .get(nextValue(topic, clusterInfo, targetBroker) % targetPartitions.size())
+              .partition();
     }
 
     return targetPartition;
@@ -152,19 +144,6 @@ public class SmoothWeightRoundRobinDispatcher implements Dispatcher {
 
   private void refreshPartitionMetaData(ClusterInfo<ReplicaInfo> clusterInfo, String topic) {
     partitions = clusterInfo.availableReplicas(topic);
-
-    partitions.forEach(
-        p -> {
-          // Check for partition existence. If not (a new partition), add to candidate list
-          if (hasPartitionsSet
-              .computeIfAbsent(p.nodeInfo().id(), ignore -> new HashSet<>())
-              .add(p.partition())) {
-            hasPartitions
-                .computeIfAbsent(p.nodeInfo().id(), ignore -> new ArrayList<>())
-                .add(p.partition());
-          }
-        });
-
     neutralIntegratedCost
         .fetcher()
         .ifPresent(


### PR DESCRIPTION
現在的 `SmoothWeightRoundRobinDispatcher` 在全力打資料的時候，大概會執行在 1 分鐘後出現 heap 記憶體不足，其原因來自於內部的 arrayList 不斷的增大，之前沒有出現問題是因為之前的版本跟新速率沒有那麼快 (10 秒更新一次)，增加的速率也不會讓 heap 在 30 分鐘內耗盡。

現在修正為：有新的 partition 才加入 arrayList。
為了計算速度，新增了一個變數 `hasPartitionsSet` 用來紀錄元素是否已經出現過；同時保留原來的 arrayList ，用來做快速的隨機讀取。

---

新增一個 TODO，現在 partition 的選擇是從 broker 內的 partition 選擇 (紀錄在 `hasPartitions`)，但是卻沒有對 topic 篩選，如果這個 producer 同時會發送不同 topic 的 record，那有可能就會出錯了？

---

新增具有描述性的錯誤訊息。
現在的 `SmoothWeightRoundRobinDispatcher` 如果沒有配置 "partitioner.config" 的路徑，會跑出 `NullPointerException`。現在在讀檔前先檢查使用者是否有設定 "partitioner.config"。