### PR TITLE
Embed broker folders information into `ClusterInfo`

### DIFF
--- a/app/src/main/java/org/astraea/app/balancer/BalanceProcessDemo.java
+++ b/app/src/main/java/org/astraea/app/balancer/BalanceProcessDemo.java
@@ -44,14 +44,12 @@ public class BalanceProcessDemo {
               .clusterInfo(admin.topicNames(false).toCompletableFuture().join())
               .toCompletableFuture()
               .join();
-      var brokerFolders = admin.brokerFolders().toCompletableFuture().join();
       Predicate<String> filter = topic -> !argument.ignoredTopics.contains(topic);
       var plan =
           Balancer.Official.SingleStep.create(
                   AlgorithmConfig.builder()
                       .clusterCost(new ReplicaLeaderCost())
                       .topicFilter(filter)
-                      .dataFolders(brokerFolders)
                       .config("iteration", "1000")
                       .build())
               .offer(clusterInfo, Duration.ofSeconds(3));

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -286,7 +286,6 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                   AlgorithmConfig.builder()
                       .clusterCost(clusterCostFunction)
                       .clusterConstraint((before, after) -> after.value() <= before.value())
-                      .dataFolders(admin.brokerFolders().toCompletableFuture().join())
                       .moveCost(List.of(moveCostFunction))
                       .movementConstraint(moveCosts -> true)
                       .build())
@@ -308,7 +307,6 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                       AlgorithmConfig.builder()
                           .clusterCost(clusterCostFunction)
                           .clusterConstraint((before, after) -> true)
-                          .dataFolders(admin.brokerFolders().toCompletableFuture().join())
                           .moveCost(List.of(moveCostFunction))
                           .movementConstraint(moveCosts -> true)
                           .config("iteration", "0")
@@ -328,7 +326,6 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                   AlgorithmConfig.builder()
                       .clusterCost(clusterCostFunction)
                       .clusterConstraint((before, after) -> false)
-                      .dataFolders(admin.brokerFolders().toCompletableFuture().join())
                       .moveCost(List.of(moveCostFunction))
                       .movementConstraint(moveCosts -> true)
                       .build())
@@ -347,7 +344,6 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                   AlgorithmConfig.builder()
                       .clusterCost(clusterCostFunction)
                       .clusterConstraint((before, after) -> true)
-                      .dataFolders(admin.brokerFolders().toCompletableFuture().join())
                       .moveCost(List.of(moveCostFunction))
                       .movementConstraint(moveCosts -> false)
                       .build())
@@ -928,7 +924,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
           admin.topicNames(false).thenCompose(admin::clusterInfo).toCompletableFuture().join();
       {
         // default
-        var postRequest = BalancerHandler.parsePostRequest(Channel.EMPTY, clusterInfo, Map.of());
+        var postRequest = BalancerHandler.parsePostRequest(Channel.EMPTY, clusterInfo);
         var config = postRequest.configBuilder.get().build();
         Assertions.assertTrue(config.algorithmConfig().entrySet().isEmpty());
         Assertions.assertInstanceOf(HasClusterCost.class, config.clusterCostFunction());
@@ -955,7 +951,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                 defaultDecreasing);
         var postRequest =
             BalancerHandler.parsePostRequest(
-                Channel.ofRequest(PostRequest.of(request)), clusterInfo, Map.of());
+                Channel.ofRequest(PostRequest.of(request)), clusterInfo);
         var config = postRequest.configBuilder.get().build();
         Assertions.assertEquals(
             Set.of(Map.entry("KEY", "VALUE")), config.algorithmConfig().entrySet());
@@ -989,24 +985,14 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
             () ->
                 BalancerHandler.parsePostRequest(
                     Channel.ofRequest(PostRequest.of(Map.of(BalancerHandler.TOPICS_KEY, ""))),
-                    clusterInfo,
-                    Map.of()),
+                    clusterInfo),
             "Empty topic filter, nothing to rebalance");
         Assertions.assertThrows(
             IllegalArgumentException.class,
             () ->
                 BalancerHandler.parsePostRequest(
                     Channel.ofRequest(PostRequest.of(Map.of(BalancerHandler.TIMEOUT_KEY, 0))),
-                    clusterInfo,
-                    Map.of()),
-            "Zero timeout");
-        Assertions.assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                BalancerHandler.parsePostRequest(
-                    Channel.ofRequest(PostRequest.of(Map.of(BalancerHandler.TIMEOUT_KEY, -5566))),
-                    clusterInfo,
-                    Map.of()),
+                    clusterInfo),
             "Negative timeout");
         Assertions.assertThrows(
             IllegalArgumentException.class,
@@ -1015,8 +1001,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                     Channel.ofRequest(
                         PostRequest.of(
                             Map.of(BalancerHandler.COST_WEIGHT_KEY, "[{\"cost\": \"yes\"}]"))),
-                    clusterInfo,
-                    Map.of()),
+                    clusterInfo),
             "Malformed cost weight");
         Assertions.assertThrows(
             IllegalArgumentException.class,
@@ -1027,8 +1012,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                             Map.of(
                                 BalancerHandler.COST_WEIGHT_KEY,
                                 "[{\"cost\": \"yes\", \"weight\": \"a lot\"}]"))),
-                    clusterInfo,
-                    Map.of()),
+                    clusterInfo),
             "Malformed cost weight");
         Assertions.assertThrows(
             IllegalArgumentException.class,
@@ -1037,8 +1021,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                     Channel.ofRequest(
                         PostRequest.of(
                             Map.of(BalancerHandler.COST_WEIGHT_KEY, "[{\"weight\": \"a lot\"}]"))),
-                    clusterInfo,
-                    Map.of()),
+                    clusterInfo),
             "Malformed cost weight");
       }
     }

--- a/common/src/main/java/org/astraea/common/admin/AdminImpl.java
+++ b/common/src/main/java/org/astraea/common/admin/AdminImpl.java
@@ -585,7 +585,15 @@ class AdminImpl implements Admin {
 
   @Override
   public CompletionStage<ClusterInfo<Replica>> clusterInfo(Set<String> topics) {
-    return FutureUtils.combine(nodeInfos(), replicas(topics), ClusterInfo::of);
+    return FutureUtils.combine(
+        brokers()
+            .thenApply(
+                brokers ->
+                    brokers.stream()
+                        .map(x -> (NodeInfo) x)
+                        .collect(Collectors.toUnmodifiableSet())),
+        replicas(topics),
+        ClusterInfo::of);
   }
 
   private CompletionStage<List<Replica>> replicas(Set<String> topics) {

--- a/common/src/main/java/org/astraea/common/admin/ClusterInfo.java
+++ b/common/src/main/java/org/astraea/common/admin/ClusterInfo.java
@@ -403,6 +403,27 @@ public interface ClusterInfo<T extends ReplicaInfo> {
         .orElseThrow(() -> new NoSuchElementException(id + " is nonexistent"));
   }
 
+  /**
+   * @return the data folders of all nodes. If such information is not available to a specific node,
+   *     then an empty set will be associated with that node.
+   */
+  default Map<Integer, Set<String>> brokerFolders() {
+    return nodes().stream()
+        .collect(
+            Collectors.toUnmodifiableMap(
+                NodeInfo::id,
+                node -> {
+                  if (node instanceof Broker) {
+                    return ((Broker) node)
+                        .dataFolders().stream()
+                            .map(Broker.DataFolder::path)
+                            .collect(Collectors.toUnmodifiableSet());
+                  } else {
+                    return Set.of();
+                  }
+                }));
+  }
+
   // ---------------------[streams methods]---------------------//
   // implements following methods by smart index to speed up the queries
 

--- a/common/src/main/java/org/astraea/common/balancer/algorithms/AlgorithmConfig.java
+++ b/common/src/main/java/org/astraea/common/balancer/algorithms/AlgorithmConfig.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.UUID;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
@@ -45,11 +44,6 @@ public interface AlgorithmConfig {
    *     logging usage.
    */
   String executionId();
-
-  /**
-   * @return the data folders of al brokers.
-   */
-  Map<Integer, Set<String>> dataFolders();
 
   /**
    * @return the cluster cost function for this problem.
@@ -90,7 +84,6 @@ public interface AlgorithmConfig {
 
     private String executionId = "noname-" + UUID.randomUUID();
     private HasClusterCost clusterCostFunction;
-    private Map<Integer, Set<String>> dataFolders;
     private List<HasMoveCost> moveCostFunction = List.of(HasMoveCost.EMPTY);
     private BiPredicate<ClusterCost, ClusterCost> clusterConstraint =
         (before, after) -> after.value() < before.value();
@@ -107,18 +100,6 @@ public interface AlgorithmConfig {
      */
     public Builder executionId(String id) {
       this.executionId = id;
-      return this;
-    }
-
-    /**
-     * Specify the data folders of all brokers
-     *
-     * @return this.
-     */
-    public Builder dataFolders(Map<Integer, Set<String>> dataFolders) {
-      // TODO: Embedded these data folders information into ClusterInfo
-      //       see https://github.com/skiptests/astraea/issues/1106
-      this.dataFolders = Objects.requireNonNull(dataFolders);
       return this;
     }
 
@@ -221,17 +202,11 @@ public interface AlgorithmConfig {
 
     public AlgorithmConfig build() {
       Objects.requireNonNull(clusterCostFunction);
-      Objects.requireNonNull(dataFolders);
 
       return new AlgorithmConfig() {
         @Override
         public String executionId() {
           return executionId;
-        }
-
-        @Override
-        public Map<Integer, Set<String>> dataFolders() {
-          return dataFolders;
         }
 
         @Override

--- a/common/src/main/java/org/astraea/common/balancer/algorithms/GreedyBalancer.java
+++ b/common/src/main/java/org/astraea/common/balancer/algorithms/GreedyBalancer.java
@@ -99,7 +99,7 @@ public class GreedyBalancer implements Balancer {
     BiFunction<ClusterLogAllocation, ClusterCost, Optional<Balancer.Plan>> next =
         (currentAllocation, currentCost) ->
             allocationTweaker
-                .generate(config.dataFolders(), currentAllocation)
+                .generate(currentClusterInfo.brokerFolders(), currentAllocation)
                 .takeWhile(ignored -> moreRoom.get())
                 .map(
                     newAllocation -> {

--- a/common/src/main/java/org/astraea/common/balancer/algorithms/GreedyBalancer.java
+++ b/common/src/main/java/org/astraea/common/balancer/algorithms/GreedyBalancer.java
@@ -99,7 +99,7 @@ public class GreedyBalancer implements Balancer {
     BiFunction<ClusterLogAllocation, ClusterCost, Optional<Balancer.Plan>> next =
         (currentAllocation, currentCost) ->
             allocationTweaker
-                .generate(currentClusterInfo.brokerFolders(), currentAllocation)
+                .generate(currentAllocation)
                 .takeWhile(ignored -> moreRoom.get())
                 .map(
                     newAllocation -> {

--- a/common/src/main/java/org/astraea/common/balancer/algorithms/SingleStepBalancer.java
+++ b/common/src/main/java/org/astraea/common/balancer/algorithms/SingleStepBalancer.java
@@ -83,7 +83,7 @@ public class SingleStepBalancer implements Balancer {
 
     var start = System.currentTimeMillis();
     return allocationTweaker
-        .generate(config.dataFolders(), ClusterLogAllocation.of(generatorClusterInfo))
+        .generate(currentClusterInfo.brokerFolders(), ClusterLogAllocation.of(generatorClusterInfo))
         .parallel()
         .limit(iteration)
         .takeWhile(ignored -> System.currentTimeMillis() - start <= timeout.toMillis())

--- a/common/src/main/java/org/astraea/common/balancer/algorithms/SingleStepBalancer.java
+++ b/common/src/main/java/org/astraea/common/balancer/algorithms/SingleStepBalancer.java
@@ -83,7 +83,7 @@ public class SingleStepBalancer implements Balancer {
 
     var start = System.currentTimeMillis();
     return allocationTweaker
-        .generate(currentClusterInfo.brokerFolders(), ClusterLogAllocation.of(generatorClusterInfo))
+        .generate(ClusterLogAllocation.of(generatorClusterInfo))
         .parallel()
         .limit(iteration)
         .takeWhile(ignored -> System.currentTimeMillis() - start <= timeout.toMillis())

--- a/common/src/main/java/org/astraea/common/balancer/tweakers/AllocationTweaker.java
+++ b/common/src/main/java/org/astraea/common/balancer/tweakers/AllocationTweaker.java
@@ -16,8 +16,6 @@
  */
 package org.astraea.common.balancer.tweakers;
 
-import java.util.Map;
-import java.util.Set;
 import java.util.stream.Stream;
 import org.astraea.common.balancer.log.ClusterLogAllocation;
 
@@ -40,10 +38,8 @@ public interface AllocationTweaker {
    * original {@link ClusterLogAllocation} as part of the Stream result. Since there is no tweaking
    * occurred.
    *
-   * @param brokerFolders key is the broker id, and the value is the folder used to keep data
    * @param baseAllocation the {@link ClusterLogAllocation} as the base being tweaked.
    * @return a {@link Stream} of possible tweaked {@link ClusterLogAllocation}.
    */
-  Stream<ClusterLogAllocation> generate(
-      Map<Integer, Set<String>> brokerFolders, ClusterLogAllocation baseAllocation);
+  Stream<ClusterLogAllocation> generate(ClusterLogAllocation baseAllocation);
 }

--- a/common/src/main/java/org/astraea/common/balancer/tweakers/ShuffleTweaker.java
+++ b/common/src/main/java/org/astraea/common/balancer/tweakers/ShuffleTweaker.java
@@ -57,17 +57,16 @@ public class ShuffleTweaker implements AllocationTweaker {
   }
 
   @Override
-  public Stream<ClusterLogAllocation> generate(
-      Map<Integer, Set<String>> brokerFolders, ClusterLogAllocation baseAllocation) {
+  public Stream<ClusterLogAllocation> generate(ClusterLogAllocation baseAllocation) {
     // There is no broker
-    if (brokerFolders.isEmpty()) return Stream.of();
+    if (baseAllocation.nodes().isEmpty()) return Stream.of();
 
     // No non-ignored topic to working on.
     if (baseAllocation.topicPartitions().isEmpty()) return Stream.of();
 
     // Only one broker & one folder exists, unable to do any log migration
-    if (brokerFolders.size() == 1
-        && brokerFolders.values().stream().findFirst().orElseThrow().size() == 1)
+    if (baseAllocation.nodes().size() == 1
+        && baseAllocation.brokerFolders().values().stream().findFirst().orElseThrow().size() == 1)
       return Stream.of();
 
     return Stream.generate(
@@ -76,7 +75,7 @@ public class ShuffleTweaker implements AllocationTweaker {
 
           var candidates =
               IntStream.range(0, shuffleCount)
-                  .mapToObj(i -> allocationGenerator(brokerFolders))
+                  .mapToObj(i -> allocationGenerator(baseAllocation.brokerFolders()))
                   .collect(Collectors.toUnmodifiableList());
 
           var currentAllocation = baseAllocation;

--- a/common/src/test/java/org/astraea/common/admin/AdminTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AdminTest.java
@@ -181,6 +181,17 @@ public class AdminTest extends RequireBrokerCluster {
             replicas.forEach(r -> Assertions.assertFalse(r.isAdding()));
             replicas.forEach(r -> Assertions.assertFalse(r.isRemoving()));
           });
+
+      var clusterInfo =
+          admin
+              .clusterInfo(topics.stream().map(Topic::name).collect(Collectors.toUnmodifiableSet()))
+              .toCompletableFuture()
+              .join();
+
+      Assertions.assertEquals(
+          logFolders(),
+          clusterInfo.brokerFolders(),
+          "The log folder information is available from the admin version of ClusterInfo");
     }
   }
 

--- a/common/src/test/java/org/astraea/common/balancer/BalancerAlgorithmTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerAlgorithmTest.java
@@ -86,10 +86,7 @@ public class BalancerAlgorithmTest extends RequireBrokerCluster {
       var planOfGreedy =
           Balancer.create(
                   GreedyBalancer.class,
-                  AlgorithmConfig.builder()
-                      .clusterCost(new ReplicaNumberCost())
-                      .dataFolders(admin.brokerFolders().toCompletableFuture().join())
-                      .build())
+                  AlgorithmConfig.builder().clusterCost(new ReplicaNumberCost()).build())
               .offer(
                   admin
                       .clusterInfo(admin.topicNames(false).toCompletableFuture().join())
@@ -101,10 +98,7 @@ public class BalancerAlgorithmTest extends RequireBrokerCluster {
       var plan =
           Balancer.create(
                   SingleStepBalancer.class,
-                  AlgorithmConfig.builder()
-                      .clusterCost(new ReplicaNumberCost())
-                      .dataFolders(admin.brokerFolders().toCompletableFuture().join())
-                      .build())
+                  AlgorithmConfig.builder().clusterCost(new ReplicaNumberCost()).build())
               .offer(
                   admin
                       .clusterInfo(admin.topicNames(false).toCompletableFuture().join())

--- a/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
@@ -97,7 +97,6 @@ class BalancerTest extends RequireBrokerCluster {
                   theClass,
                   AlgorithmConfig.builder()
                       .clusterCost(new ReplicaLeaderCost())
-                      .dataFolders(admin.brokerFolders().toCompletableFuture().join())
                       .topicFilter(topic -> topic.equals(topicName))
                       .build())
               .offer(
@@ -150,13 +149,11 @@ class BalancerTest extends RequireBrokerCluster {
               .clusterInfo(admin.topicNames(false).toCompletableFuture().join())
               .toCompletableFuture()
               .join();
-      var brokerFolders = admin.brokerFolders().toCompletableFuture().join();
       var newAllocation =
           Balancer.create(
                   theClass,
                   AlgorithmConfig.builder()
                       .topicFilter(t -> t.equals(theTopic))
-                      .dataFolders(brokerFolders)
                       .clusterCost(randomScore)
                       .config("iteration", "500")
                       .build())
@@ -198,7 +195,6 @@ class BalancerTest extends RequireBrokerCluster {
                           theClass,
                           AlgorithmConfig.builder()
                               .clusterCost((clusterInfo, bean) -> Math::random)
-                              .dataFolders(admin.brokerFolders().toCompletableFuture().join())
                               .build())
                       .offer(
                           admin
@@ -254,7 +250,6 @@ class BalancerTest extends RequireBrokerCluster {
                   theClass,
                   AlgorithmConfig.builder()
                       .clusterCost(theCostFunction)
-                      .dataFolders(Map.of())
                       .metricSource(metricSource)
                       .config("iteration", "500")
                       .build())

--- a/common/src/test/java/org/astraea/common/balancer/FakeClusterInfo.java
+++ b/common/src/test/java/org/astraea/common/balancer/FakeClusterInfo.java
@@ -35,6 +35,11 @@ public class FakeClusterInfo extends ClusterInfo.Optimized<Replica> {
 
   public static FakeClusterInfo of(
       int nodeCount, int topicCount, int partitionCount, int replicaCount) {
+    return of(nodeCount, topicCount, partitionCount, replicaCount, 3);
+  }
+
+  public static FakeClusterInfo of(
+      int nodeCount, int topicCount, int partitionCount, int replicaCount, int folderCount) {
     final var random = new Random();
     random.setSeed(0);
 
@@ -43,6 +48,7 @@ public class FakeClusterInfo extends ClusterInfo.Optimized<Replica> {
         topicCount,
         partitionCount,
         replicaCount,
+        folderCount,
         (partition) ->
             IntStream.range(0, partition)
                 .mapToObj(
@@ -63,10 +69,10 @@ public class FakeClusterInfo extends ClusterInfo.Optimized<Replica> {
       int topicCount,
       int partitionCount,
       int replicaCount,
+      int folderCount,
       Function<Integer, Set<String>> topicNameGenerator) {
-    final var dataDirCount = 3;
     final var dataDirectories =
-        IntStream.range(0, dataDirCount)
+        IntStream.range(0, folderCount)
             .mapToObj(i -> "/tmp/data-directory-" + i)
             .collect(Collectors.toUnmodifiableSet());
     final var nodes =

--- a/common/src/test/java/org/astraea/common/balancer/FakeClusterInfo.java
+++ b/common/src/test/java/org/astraea/common/balancer/FakeClusterInfo.java
@@ -16,7 +16,6 @@
  */
 package org.astraea.common.balancer;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -31,14 +30,14 @@ import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.Replica;
 import org.astraea.common.admin.TopicPartition;
 
-public class FakeClusterInfo extends ClusterInfo.Optimized<Replica> {
+public class FakeClusterInfo {
 
-  public static FakeClusterInfo of(
+  public static ClusterInfo<Replica> of(
       int nodeCount, int topicCount, int partitionCount, int replicaCount) {
     return of(nodeCount, topicCount, partitionCount, replicaCount, 3);
   }
 
-  public static FakeClusterInfo of(
+  public static ClusterInfo<Replica> of(
       int nodeCount, int topicCount, int partitionCount, int replicaCount, int folderCount) {
     final var random = new Random();
     random.setSeed(0);
@@ -64,7 +63,7 @@ public class FakeClusterInfo extends ClusterInfo.Optimized<Replica> {
                 .collect(Collectors.toUnmodifiableSet()));
   }
 
-  public static FakeClusterInfo of(
+  public static ClusterInfo<Replica> of(
       int nodeCount,
       int topicCount,
       int partitionCount,
@@ -171,10 +170,6 @@ public class FakeClusterInfo extends ClusterInfo.Optimized<Replica> {
                                     .build()))
             .collect(Collectors.toUnmodifiableList());
 
-    return new FakeClusterInfo(new HashSet<>(nodes), replicas);
-  }
-
-  FakeClusterInfo(Set<NodeInfo> nodes, List<Replica> replicas) {
-    super(nodes, replicas);
+    return ClusterInfo.of(Set.copyOf(nodes), replicas);
   }
 }

--- a/common/src/test/java/org/astraea/common/balancer/algorithms/GreedyBalancerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/algorithms/GreedyBalancerTest.java
@@ -60,7 +60,6 @@ class GreedyBalancerTest {
             GreedyBalancer.class,
             AlgorithmConfig.builder()
                 .executionId(id)
-                .dataFolders(clusterInfo.dataDirectories())
                 .clusterCost(cost)
                 .config(GreedyBalancer.ITERATION_CONFIG, "100")
                 .build());

--- a/common/src/test/java/org/astraea/common/balancer/tweakers/ShuffleTweakerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/tweakers/ShuffleTweakerTest.java
@@ -43,8 +43,7 @@ class ShuffleTweakerTest {
   void testRun() {
     final var shuffleTweaker = new ShuffleTweaker(5, 10);
     final var fakeCluster = FakeClusterInfo.of(100, 10, 10, 3);
-    final var stream =
-        shuffleTweaker.generate(fakeCluster.brokerFolders(), ClusterLogAllocation.of(fakeCluster));
+    final var stream = shuffleTweaker.generate(ClusterLogAllocation.of(fakeCluster));
     final var iterator = stream.iterator();
 
     Assertions.assertDoesNotThrow(() -> System.out.println(iterator.next()));
@@ -60,7 +59,7 @@ class ShuffleTweakerTest {
     final var shuffleTweaker = new ShuffleTweaker(() -> shuffle);
 
     shuffleTweaker
-        .generate(fakeCluster.brokerFolders(), ClusterLogAllocation.of(fakeCluster))
+        .generate(ClusterLogAllocation.of(fakeCluster))
         .limit(100)
         .forEach(
             that -> {
@@ -83,31 +82,18 @@ class ShuffleTweakerTest {
 
     Assertions.assertEquals(
         0,
-        (int)
-            shuffleTweaker
-                .generate(fakeCluster.brokerFolders(), ClusterLogAllocation.of(fakeCluster))
-                .count(),
+        (int) shuffleTweaker.generate(ClusterLogAllocation.of(fakeCluster)).count(),
         "No possible tweak");
   }
 
   @Test
   void testOneNode() {
-    final var fakeCluster = FakeClusterInfo.of(1, 1, 1, 1);
+    final var fakeCluster = FakeClusterInfo.of(1, 1, 1, 1, 1);
     final var shuffleTweaker = new ShuffleTweaker(() -> 3);
 
     Assertions.assertEquals(
         0,
-        (int)
-            shuffleTweaker
-                .generate(
-                    fakeCluster.brokerFolders().entrySet().stream()
-                        .limit(1)
-                        .collect(
-                            Collectors.toMap(
-                                Map.Entry::getKey,
-                                e -> e.getValue().stream().limit(1).collect(Collectors.toSet()))),
-                    ClusterLogAllocation.of(fakeCluster))
-                .count(),
+        (int) shuffleTweaker.generate(ClusterLogAllocation.of(fakeCluster)).count(),
         "No possible tweak");
   }
 
@@ -118,10 +104,7 @@ class ShuffleTweakerTest {
 
     Assertions.assertEquals(
         0,
-        (int)
-            shuffleTweaker
-                .generate(fakeCluster.brokerFolders(), ClusterLogAllocation.of(fakeCluster))
-                .count(),
+        (int) shuffleTweaker.generate(ClusterLogAllocation.of(fakeCluster)).count(),
         "No possible tweak");
   }
 
@@ -148,10 +131,7 @@ class ShuffleTweakerTest {
 
     final long s = System.nanoTime();
     final var count =
-        shuffleTweaker
-            .generate(fakeCluster.brokerFolders(), ClusterLogAllocation.of(fakeCluster))
-            .limit(size)
-            .count();
+        shuffleTweaker.generate(ClusterLogAllocation.of(fakeCluster)).limit(size).count();
     final long t = System.nanoTime();
     Assertions.assertEquals(size, count);
     System.out.printf("[%s]%n", scenario);
@@ -171,7 +151,7 @@ class ShuffleTweakerTest {
     Assertions.assertDoesNotThrow(
         () ->
             shuffleTweaker
-                .generate(fakeCluster.brokerFolders(), ClusterLogAllocation.of(fakeCluster))
+                .generate(ClusterLogAllocation.of(fakeCluster))
                 .parallel()
                 .limit(100)
                 .count());
@@ -189,7 +169,7 @@ class ShuffleTweakerTest {
     forkJoinPool.submit(
         () ->
             shuffleTweaker
-                .generate(fakeCluster.brokerFolders(), ClusterLogAllocation.of(fakeCluster))
+                .generate(ClusterLogAllocation.of(fakeCluster))
                 .parallel()
                 .forEach((ignore) -> counter.increment()));
 
@@ -258,7 +238,7 @@ class ShuffleTweakerTest {
                     Replica.builder(base).topic("no-leader").nodeInfo(nodeB).build(),
                     Replica.builder(base).topic("no-leader").nodeInfo(nodeC).build())));
     shuffleTweaker
-        .generate(dataDir, allocation)
+        .generate(allocation)
         .limit(30)
         .forEach(
             newAllocation -> {

--- a/common/src/test/java/org/astraea/common/balancer/tweakers/ShuffleTweakerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/tweakers/ShuffleTweakerTest.java
@@ -44,8 +44,7 @@ class ShuffleTweakerTest {
     final var shuffleTweaker = new ShuffleTweaker(5, 10);
     final var fakeCluster = FakeClusterInfo.of(100, 10, 10, 3);
     final var stream =
-        shuffleTweaker.generate(
-            fakeCluster.dataDirectories(), ClusterLogAllocation.of(fakeCluster));
+        shuffleTweaker.generate(fakeCluster.brokerFolders(), ClusterLogAllocation.of(fakeCluster));
     final var iterator = stream.iterator();
 
     Assertions.assertDoesNotThrow(() -> System.out.println(iterator.next()));
@@ -61,7 +60,7 @@ class ShuffleTweakerTest {
     final var shuffleTweaker = new ShuffleTweaker(() -> shuffle);
 
     shuffleTweaker
-        .generate(fakeCluster.dataDirectories(), ClusterLogAllocation.of(fakeCluster))
+        .generate(fakeCluster.brokerFolders(), ClusterLogAllocation.of(fakeCluster))
         .limit(100)
         .forEach(
             that -> {
@@ -86,7 +85,7 @@ class ShuffleTweakerTest {
         0,
         (int)
             shuffleTweaker
-                .generate(fakeCluster.dataDirectories(), ClusterLogAllocation.of(fakeCluster))
+                .generate(fakeCluster.brokerFolders(), ClusterLogAllocation.of(fakeCluster))
                 .count(),
         "No possible tweak");
   }
@@ -101,7 +100,7 @@ class ShuffleTweakerTest {
         (int)
             shuffleTweaker
                 .generate(
-                    fakeCluster.dataDirectories().entrySet().stream()
+                    fakeCluster.brokerFolders().entrySet().stream()
                         .limit(1)
                         .collect(
                             Collectors.toMap(
@@ -121,7 +120,7 @@ class ShuffleTweakerTest {
         0,
         (int)
             shuffleTweaker
-                .generate(fakeCluster.dataDirectories(), ClusterLogAllocation.of(fakeCluster))
+                .generate(fakeCluster.brokerFolders(), ClusterLogAllocation.of(fakeCluster))
                 .count(),
         "No possible tweak");
   }
@@ -150,7 +149,7 @@ class ShuffleTweakerTest {
     final long s = System.nanoTime();
     final var count =
         shuffleTweaker
-            .generate(fakeCluster.dataDirectories(), ClusterLogAllocation.of(fakeCluster))
+            .generate(fakeCluster.brokerFolders(), ClusterLogAllocation.of(fakeCluster))
             .limit(size)
             .count();
     final long t = System.nanoTime();
@@ -172,7 +171,7 @@ class ShuffleTweakerTest {
     Assertions.assertDoesNotThrow(
         () ->
             shuffleTweaker
-                .generate(fakeCluster.dataDirectories(), ClusterLogAllocation.of(fakeCluster))
+                .generate(fakeCluster.brokerFolders(), ClusterLogAllocation.of(fakeCluster))
                 .parallel()
                 .limit(100)
                 .count());
@@ -190,7 +189,7 @@ class ShuffleTweakerTest {
     forkJoinPool.submit(
         () ->
             shuffleTweaker
-                .generate(fakeCluster.dataDirectories(), ClusterLogAllocation.of(fakeCluster))
+                .generate(fakeCluster.brokerFolders(), ClusterLogAllocation.of(fakeCluster))
                 .parallel()
                 .forEach((ignore) -> counter.increment()));
 

--- a/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
@@ -182,49 +182,37 @@ public class BalancerNode {
             .admin()
             .topicNames(false)
             .thenCompose(context.admin()::clusterInfo)
-            .thenCompose(
-                clusterInfo ->
-                    context
-                        .admin()
-                        .brokerFolders()
-                        .thenApply(
-                            brokerFolders -> {
-                              var patterns =
-                                  argument
-                                      .texts()
-                                      .get(TOPIC_NAME_KEY)
-                                      .map(
-                                          ss ->
-                                              Arrays.stream(ss.split(","))
-                                                  .map(Utils::wildcardToPattern)
-                                                  .collect(Collectors.toList()))
-                                      .orElse(List.of());
-                              logger.log("searching better assignments ... ");
-                              return Map.entry(
-                                  clusterInfo,
-                                  Balancer.create(
-                                          GreedyBalancer.class,
-                                          AlgorithmConfig.builder()
-                                              .clusterCost(
-                                                  HasClusterCost.of(
-                                                      clusterCosts(argument.selectedKeys())))
-                                              .dataFolders(brokerFolders)
-                                              .moveCost(
-                                                  List.of(
-                                                      new ReplicaSizeCost(),
-                                                      new ReplicaLeaderCost()))
-                                              .movementConstraint(
-                                                  movementConstraint(argument.nonEmptyTexts()))
-                                              .topicFilter(
-                                                  topic ->
-                                                      patterns.isEmpty()
-                                                          || patterns.stream()
-                                                              .anyMatch(
-                                                                  p -> p.matcher(topic).matches()))
-                                              .config("iteration", "10000")
-                                              .build())
-                                      .offer(clusterInfo, Duration.ofSeconds(10)));
-                            }))
+            .thenApply(
+                clusterInfo -> {
+                  var patterns =
+                      argument
+                          .texts()
+                          .get(TOPIC_NAME_KEY)
+                          .map(
+                              ss ->
+                                  Arrays.stream(ss.split(","))
+                                      .map(Utils::wildcardToPattern)
+                                      .collect(Collectors.toList()))
+                          .orElse(List.of());
+                  logger.log("searching better assignments ... ");
+                  return Map.entry(
+                      clusterInfo,
+                      Balancer.create(
+                              GreedyBalancer.class,
+                              AlgorithmConfig.builder()
+                                  .clusterCost(
+                                      HasClusterCost.of(clusterCosts(argument.selectedKeys())))
+                                  .moveCost(List.of(new ReplicaSizeCost(), new ReplicaLeaderCost()))
+                                  .movementConstraint(movementConstraint(argument.nonEmptyTexts()))
+                                  .topicFilter(
+                                      topic ->
+                                          patterns.isEmpty()
+                                              || patterns.stream()
+                                                  .anyMatch(p -> p.matcher(topic).matches()))
+                                  .config("iteration", "10000")
+                                  .build())
+                          .offer(clusterInfo, Duration.ofSeconds(10)));
+                })
             .thenApply(
                 entry -> {
                   entry.getValue().ifPresent(LAST_PLAN::set);


### PR DESCRIPTION
resolve #1106

* 新增 `ClusterInfo#brokerFolders()`，透過 `Broker` 形態的 `NodeInfo` 來推導這個關係。
* 移除 `AlgorithmConfig#dataFolders()`，現在 Balancer 可以直接從傳入的 ClusterInfo 取得這些資訊。
* 移除 `AllocationTweaker#generate()` 函數簽名上的 data folder 需求，這個訊息可以從另外一個 ClusterInfo 參數中取得。