### PR TITLE
[GUI][ETL] Avoid packaging unused dependencies

### DIFF
--- a/app/src/main/java/org/astraea/app/web/BalancerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BalancerHandler.java
@@ -50,7 +50,6 @@ import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.Replica;
 import org.astraea.common.admin.ReplicaInfo;
 import org.astraea.common.admin.TopicPartition;
-import org.astraea.common.argument.DurationField;
 import org.astraea.common.balancer.Balancer;
 import org.astraea.common.balancer.algorithms.AlgorithmConfig;
 import org.astraea.common.balancer.algorithms.GreedyBalancer;
@@ -287,7 +286,7 @@ class BalancerHandler implements Handler {
         channel
             .request()
             .get(TIMEOUT_KEY)
-            .map(DurationField::toDuration)
+            .map(Utils::toDuration)
             .orElse(Duration.ofSeconds(TIMEOUT_DEFAULT));
     var topics =
         channel

--- a/app/src/main/java/org/astraea/app/web/RecordHandler.java
+++ b/app/src/main/java/org/astraea/app/web/RecordHandler.java
@@ -47,7 +47,6 @@ import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.admin.Partition;
 import org.astraea.common.admin.TopicPartition;
-import org.astraea.common.argument.DurationField;
 import org.astraea.common.consumer.Builder;
 import org.astraea.common.consumer.Consumer;
 import org.astraea.common.consumer.ConsumerConfigs;
@@ -111,7 +110,7 @@ public class RecordHandler implements Handler {
     var limit = Integer.parseInt(channel.queries().getOrDefault(LIMIT, "1"));
     var timeout =
         Optional.ofNullable(channel.queries().get(TIMEOUT))
-            .map(DurationField::toDuration)
+            .map(Utils::toDuration)
             .orElse(Duration.ofSeconds(5));
 
     var consumerBuilder =
@@ -182,7 +181,7 @@ public class RecordHandler implements Handler {
   public CompletionStage<Response> post(Channel channel) {
     var async = channel.request().getBoolean(ASYNC).orElse(false);
     var timeout =
-        channel.request().get(TIMEOUT).map(DurationField::toDuration).orElse(Duration.ofSeconds(5));
+        channel.request().get(TIMEOUT).map(Utils::toDuration).orElse(Duration.ofSeconds(5));
     var records = channel.request().values(RECORDS, PostRecord.class);
     if (records.isEmpty())
       throw new IllegalArgumentException("records should contain at least one record");

--- a/app/src/main/java/org/astraea/app/web/TopicHandler.java
+++ b/app/src/main/java/org/astraea/app/web/TopicHandler.java
@@ -28,9 +28,9 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.astraea.common.FutureUtils;
+import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.admin.TopicPartition;
-import org.astraea.common.argument.DurationField;
 import org.astraea.common.scenario.Scenario;
 
 class TopicHandler implements Handler {
@@ -75,7 +75,7 @@ class TopicHandler implements Handler {
                 get(
                     topics,
                     Optional.ofNullable(channel.queries().get(POLL_RECORD_TIMEOUT))
-                        .map(DurationField::toDuration)
+                        .map(Utils::toDuration)
                         .orElse(null),
                     partition ->
                         !channel.queries().containsKey(PARTITION_KEY)

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -381,8 +381,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
           migrationCost -> {
             switch (migrationCost.function) {
               case ReplicaSizeCost.COST_NAME:
-                Assertions.assertTrue(
-                    migrationCost.totalCost <= new DataSize.Field().convert(sizeLimit).bytes());
+                Assertions.assertTrue(migrationCost.totalCost <= DataSize.of(sizeLimit).bytes());
                 break;
               case ReplicaLeaderCost.COST_NAME:
                 Assertions.assertTrue(migrationCost.totalCost <= Integer.parseInt(leaderLimit));

--- a/common/src/main/java/org/astraea/common/DataSize.java
+++ b/common/src/main/java/org/astraea/common/DataSize.java
@@ -24,11 +24,22 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.Objects;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /** Data size class */
 public class DataSize implements Comparable<DataSize> {
+
+  /** Parse number and DataUnit */
+  private static final Pattern DATA_SIZE_PATTERN =
+      Pattern.compile("(?<measurement>[0-9]+)\\s?(?<dataUnit>[a-zA-Z]+)");
+
+  public static DataSize of(String argument) {
+    var matcher = DATA_SIZE_PATTERN.matcher(argument);
+    if (matcher.matches())
+      return DataUnit.valueOf(matcher.group("dataUnit"))
+          .of(Long.parseLong(matcher.group("measurement")));
+    throw new IllegalArgumentException("Unknown DataSize \"" + argument + "\"");
+  }
 
   public static final DataSize ZERO = DataUnit.Byte.of(0);
 
@@ -303,18 +314,14 @@ public class DataSize implements Comparable<DataSize> {
   }
 
   public static class Field extends org.astraea.common.argument.Field<DataSize> {
-    // Parse number and DataUnit
-    private static final Pattern DATA_SIZE_PATTERN =
-        Pattern.compile("(?<measurement>[0-9]+)\\s?(?<dataUnit>[a-zA-Z]+)");
-
     /**
      * Convert string to DataSize.
      *
      * <pre>{@code
-     * new DataSize.Field().convert("500KB");  // 500 KB  (500 * 1000 bytes)
-     * new DataSize.Field().convert("500KiB"); // 500 KiB (500 * 1024 bytes)
-     * new DataSize.Field().convert("500Kb");  // 500 Kb  (500 * 1000 bits)
-     * new DataSize.Field().convert("500Kib"); // 500 Kib (500 * 1024 bits)
+     * DataSize.of("500KB");  // 500 KB  (500 * 1000 bytes)
+     * DataSize.of("500KiB"); // 500 KiB (500 * 1024 bytes)
+     * DataSize.of("500Kb");  // 500 Kb  (500 * 1000 bits)
+     * DataSize.of("500Kib"); // 500 Kib (500 * 1024 bits)
      * }</pre>
      *
      * @param argument number and the unit. e.g. "500MiB", "9876 KB"
@@ -322,13 +329,7 @@ public class DataSize implements Comparable<DataSize> {
      */
     @Override
     public DataSize convert(String argument) {
-      Matcher matcher = DATA_SIZE_PATTERN.matcher(argument);
-      if (matcher.matches()) {
-        return DataUnit.valueOf(matcher.group("dataUnit"))
-            .of(Long.parseLong(matcher.group("measurement")));
-      } else {
-        throw new IllegalArgumentException("Unknown DataSize \"" + argument + "\"");
-      }
+      return DataSize.of(argument);
     }
   }
 }

--- a/common/src/main/java/org/astraea/common/Utils.java
+++ b/common/src/main/java/org/astraea/common/Utils.java
@@ -28,10 +28,80 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public final class Utils {
+
+  // ---------------------[Duration]---------------------//
+
+  public static final Pattern TIME_PATTERN =
+      Pattern.compile("^(?<value>[0-9]+)(?<unit>days|day|h|m|s|ms|us|ns|)$");
+
+  /**
+   * A converter for time unit.
+   *
+   * <p>This converter is able to transform following time string into corresponding {@link
+   * Duration}.
+   *
+   * <ul>
+   *   <li>{@code "30s"} to {@code Duration.ofSeconds(30)}
+   *   <li>{@code "1m"} to {@code Duration.ofMinutes(1)}
+   *   <li>{@code "24h"} to {@code Duration.ofHours(24)}
+   *   <li>{@code "7day"} to {@code Duration.ofDays(7)}
+   *   <li>{@code "7days"} to {@code Duration.ofDays(7)}
+   *   <li>{@code "350ms"} to {@code Duration.ofMillis(350)}
+   *   <li>{@code "123us"} to {@code Duration.ofNanos(123 * 1000)}
+   *   <li>{@code "100ns"} to {@code Duration.ofNanos(100)}
+   * </ul>
+   *
+   * If no unit specified, second unit will be used:
+   *
+   * <ul>
+   *   <li>{@code "1"} to {@code Duration.ofSeconds(1)}
+   *   <li>{@code "0"} to {@code Duration.ofSeconds(0)}
+   * </ul>
+   *
+   * Currently, negative time is not supported. So the following example doesn't work.
+   *
+   * <ul>
+   *   <li><b>(doesn't work)</b> {@code "-1" to {@code Duration.ofSeconds(-1)}}
+   * </ul>
+   *
+   * Currently, floating value time is not supported. So the following example doesn't work.
+   *
+   * <ul>
+   *   <li><b>(doesn't work)</b> {@code "0.5" to {@code Duration.ofMillis(500)}}
+   * </ul>
+   */
+  public static Duration toDuration(String input) {
+    Matcher matcher = TIME_PATTERN.matcher(input);
+    if (matcher.find()) {
+      long value = Long.parseLong(matcher.group("value"));
+      String unit = matcher.group("unit");
+      switch (unit) {
+        case "days":
+        case "day":
+          return Duration.ofDays(value);
+        case "h":
+          return Duration.ofHours(value);
+        case "m":
+          return Duration.ofMinutes(value);
+        case "ms":
+          return Duration.ofMillis(value);
+        case "us":
+          return Duration.ofNanos(value * 1000);
+        case "ns":
+          return Duration.ofNanos(value);
+        case "s":
+        default:
+          return Duration.ofSeconds(value);
+      }
+    } else {
+      throw new IllegalArgumentException("value \"" + input + "\" doesn't match any time format");
+    }
+  }
 
   /**
    * Convert the exception thrown by getter to RuntimeException, except ExecutionException.

--- a/common/src/main/java/org/astraea/common/argument/DurationField.java
+++ b/common/src/main/java/org/astraea/common/argument/DurationField.java
@@ -18,85 +18,18 @@ package org.astraea.common.argument;
 
 import com.beust.jcommander.ParameterException;
 import java.time.Duration;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import org.astraea.common.Utils;
 
-/**
- * A converter for time unit.
- *
- * <p>This converter is able to transform following time string into corresponding {@link Duration}.
- *
- * <ul>
- *   <li>{@code "30s"} to {@code Duration.ofSeconds(30)}
- *   <li>{@code "1m"} to {@code Duration.ofMinutes(1)}
- *   <li>{@code "24h"} to {@code Duration.ofHours(24)}
- *   <li>{@code "7day"} to {@code Duration.ofDays(7)}
- *   <li>{@code "7days"} to {@code Duration.ofDays(7)}
- *   <li>{@code "350ms"} to {@code Duration.ofMillis(350)}
- *   <li>{@code "123us"} to {@code Duration.ofNanos(123 * 1000)}
- *   <li>{@code "100ns"} to {@code Duration.ofNanos(100)}
- * </ul>
- *
- * If no unit specified, second unit will be used:
- *
- * <ul>
- *   <li>{@code "1"} to {@code Duration.ofSeconds(1)}
- *   <li>{@code "0"} to {@code Duration.ofSeconds(0)}
- * </ul>
- *
- * Currently, negative time is not supported. So the following example doesn't work.
- *
- * <ul>
- *   <li><b>(doesn't work)</b> {@code "-1" to {@code Duration.ofSeconds(-1)}}
- * </ul>
- *
- * Currently, floating value time is not supported. So the following example doesn't work.
- *
- * <ul>
- *   <li><b>(doesn't work)</b> {@code "0.5" to {@code Duration.ofMillis(500)}}
- * </ul>
- */
 public class DurationField extends Field<Duration> {
-
-  static final Pattern TIME_PATTERN =
-      Pattern.compile("^(?<value>[0-9]+)(?<unit>days|day|h|m|s|ms|us|ns|)$");
-
-  public static Duration toDuration(String input) {
-    Matcher matcher = TIME_PATTERN.matcher(input);
-    if (matcher.find()) {
-      long value = Long.parseLong(matcher.group("value"));
-      String unit = matcher.group("unit");
-      switch (unit) {
-        case "days":
-        case "day":
-          return Duration.ofDays(value);
-        case "h":
-          return Duration.ofHours(value);
-        case "m":
-          return Duration.ofMinutes(value);
-        case "ms":
-          return Duration.ofMillis(value);
-        case "us":
-          return Duration.ofNanos(value * 1000);
-        case "ns":
-          return Duration.ofNanos(value);
-        case "s":
-        default:
-          return Duration.ofSeconds(value);
-      }
-    } else {
-      throw new IllegalArgumentException("value \"" + input + "\" doesn't match any time format");
-    }
-  }
 
   @Override
   public Duration convert(String input) {
-    return toDuration(input);
+    return Utils.toDuration(input);
   }
 
   @Override
   protected void check(String name, String value) throws ParameterException {
-    if (!TIME_PATTERN.matcher(value).find())
+    if (!Utils.TIME_PATTERN.matcher(value).find())
       throw new ParameterException(
           "field \"" + name + "\"'s value \"" + value + "\" doesn't match time format");
   }

--- a/common/src/main/java/org/astraea/common/argument/DurationMapField.java
+++ b/common/src/main/java/org/astraea/common/argument/DurationMapField.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.astraea.common.Utils;
 
 public class DurationMapField extends Field<Map<String, Duration>> {
   @Override
@@ -30,7 +31,7 @@ public class DurationMapField extends Field<Map<String, Duration>> {
             item -> {
               var keyValue = item.split(":");
               if (keyValue.length != 2) throw new ParameterException("incorrect format: " + item);
-              var valueToDuration = DurationField.toDuration(keyValue[1]);
+              var valueToDuration = Utils.toDuration(keyValue[1]);
               return Map.entry(keyValue[0], valueToDuration);
             })
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/common/src/main/java/org/astraea/common/partitioner/StrictCostDispatcher.java
+++ b/common/src/main/java/org/astraea/common/partitioner/StrictCostDispatcher.java
@@ -30,7 +30,6 @@ import org.astraea.common.Utils;
 import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.ReplicaInfo;
-import org.astraea.common.argument.DurationField;
 import org.astraea.common.cost.BrokerCost;
 import org.astraea.common.cost.HasBrokerCost;
 import org.astraea.common.cost.NodeLatencyCost;
@@ -157,7 +156,7 @@ public class StrictCostDispatcher implements Dispatcher {
         PartitionerUtils.parseIdJMXPort(config),
         config
             .string(ROUND_ROBIN_LEASE_KEY)
-            .map(DurationField::toDuration)
+            .map(Utils::toDuration)
             // The duration of updating beans is 4 seconds, so
             // the default duration of updating RR is 4 seconds.
             .orElse(Duration.ofSeconds(4)));

--- a/etl/build.gradle
+++ b/etl/build.gradle
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 plugins {
-    // Apply the scala Plugin to add support for Scala.
+    id "com.github.johnrengelman.shadow" version "7.1.2"
     id 'scala'
 }
 
@@ -34,10 +34,11 @@ def versions = [
 ]
 
 dependencies {
-    implementation "org.scala-lang:scala-library:${versions["scala"]}"
+    // Astraea etl is run by spark framework, so we don't need to package spark-related dependencies
+    compileOnly "org.scala-lang:scala-library:${versions["scala"]}"
+    compileOnly "org.apache.spark:spark-sql_2.12:${versions["spark_sql"]}"
+    compileOnly "org.apache.spark:spark-sql-kafka-0-10_2.12:${versions["spark_kafka"]}"
     implementation "org.apache.kafka:kafka-clients:${versions["kafka"]}"
-    implementation "org.apache.spark:spark-sql_2.12:${versions["spark_sql"]}"
-    implementation "org.apache.spark:spark-sql-kafka-0-10_2.12:${versions["spark_kafka"]}"
     implementation project(':common')
 
     testImplementation "org.junit.jupiter:junit-jupiter:${versions["junit"]}"

--- a/gui/build.gradle
+++ b/gui/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id 'application'
     id 'org.openjfx.javafxplugin' version '0.0.13'
     id "com.github.johnrengelman.shadow" version "7.1.2"
     id 'maven-publish'
@@ -29,22 +28,25 @@ ext {
 }
 
 archivesBaseName = "astraea-gui"
-mainClassName = 'org.astraea.gui.Main'
+jar {
+    manifest {
+        attributes 'Main-Class': 'org.astraea.gui.Main'
+    }
+}
 
 dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter:${versions["junit"]}"
     testImplementation project(':it')
     implementation project(':common')
     implementation "org.apache.kafka:kafka-clients:${versions["kafka"]}"
-    implementation "com.beust:jcommander:${versions["jcommander"]}"
 }
 
 publishing {
     publications {
-        mavenJava(MavenPublication) {
+        binary(MavenPublication) {
             groupId = 'org.astraea'
             artifactId = 'astraea-gui'
-            from components.java
+            artifact shadowJar
         }
     }
     repositories {

--- a/gui/src/main/java/org/astraea/gui/Query.java
+++ b/gui/src/main/java/org/astraea/gui/Query.java
@@ -129,7 +129,7 @@ public interface Query {
                           if (e.getValue() instanceof DataSize) {
                             var size = ((DataSize) e.getValue());
                             return keyPattern.matcher(e.getKey()).matches()
-                                && size.smallerThan(new DataSize.Field().convert(valueString));
+                                && size.smallerThan(DataSize.of(valueString));
                           }
                           if (e.getValue() instanceof LocalDateTime) {
                             var time = ((LocalDateTime) e.getValue());
@@ -166,7 +166,7 @@ public interface Query {
                           if (e.getValue() instanceof DataSize) {
                             var size = ((DataSize) e.getValue());
                             return keyPattern.matcher(e.getKey()).matches()
-                                && size.equals(new DataSize.Field().convert(valueString));
+                                && size.equals(DataSize.of(valueString));
                           }
                           if (e.getValue() instanceof LocalDateTime) {
                             var time = ((LocalDateTime) e.getValue());
@@ -203,7 +203,7 @@ public interface Query {
                           if (e.getValue() instanceof DataSize) {
                             var size = ((DataSize) e.getValue());
                             return keyPattern.matcher(e.getKey()).matches()
-                                && size.greaterThan(new DataSize.Field().convert(valueString));
+                                && size.greaterThan(DataSize.of(valueString));
                           }
                           if (e.getValue() instanceof LocalDateTime) {
                             var time = ((LocalDateTime) e.getValue());

--- a/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
@@ -156,9 +156,8 @@ public class BalancerNode {
   }
 
   static Predicate<List<MoveCost>> movementConstraint(Map<String, String> input) {
-    var converter = new DataSize.Field();
     var replicaSizeLimit =
-        Optional.ofNullable(input.get(MAX_MIGRATE_LOG_SIZE)).map(x -> converter.convert(x).bytes());
+        Optional.ofNullable(input.get(MAX_MIGRATE_LOG_SIZE)).map(x -> DataSize.of(x).bytes());
     var leaderNumLimit =
         Optional.ofNullable(input.get(MAX_MIGRATE_LEADER_NUM)).map(Integer::parseInt);
     return moveCosts ->

--- a/gui/src/main/java/org/astraea/gui/tab/ClientNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/ClientNode.java
@@ -40,12 +40,12 @@ import javafx.stage.FileChooser;
 import org.astraea.common.DataSize;
 import org.astraea.common.FutureUtils;
 import org.astraea.common.MapUtils;
+import org.astraea.common.Utils;
 import org.astraea.common.admin.ConsumerGroup;
 import org.astraea.common.admin.Partition;
 import org.astraea.common.admin.ProducerState;
 import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.admin.Transaction;
-import org.astraea.common.argument.DurationField;
 import org.astraea.common.consumer.Deserializer;
 import org.astraea.common.csv.CsvReader;
 import org.astraea.common.json.JsonConverter;
@@ -318,7 +318,7 @@ public class ClientNode {
                                         argument.get(recordsKey).map(Integer::parseInt).orElse(1),
                                         argument
                                             .get(timeoutKey)
-                                            .map(DurationField::toDuration)
+                                            .map(Utils::toDuration)
                                             .orElse(Duration.ofSeconds(3))))
                         .thenApply(
                             data ->


### PR DESCRIPTION
1. GUI 模組不應該包含 jcommander，因此將所有引用到的程式碼都隔離開
2. ETL 模組不需要包含 spark 相關的程式碼，因為該模組會透過 spark-submit 來執行