### PR TITLE
Deps image should include dependencies of etl test scope

### DIFF
--- a/docker/build_deps_image.sh
+++ b/docker/build_deps_image.sh
@@ -46,9 +46,9 @@ WORKDIR /astraea
 RUN git clone https://github.com/skiptests/astraea.git /astraea
 RUN ./gradlew clean build -x test
 # download test dependencies
-RUN ./gradlew clean compileTestJava
+RUN ./gradlew clean build testClasses -x test --no-daemon
 # download database
-RUN ./gradlew cleanTest it:test --tests DatabaseTest
+RUN ./gradlew cleanTest it:test --tests DatabaseTest --no-daemon
 
 WORKDIR /root
 " >"$DOCKERFILE"


### PR DESCRIPTION
#1153 之後，我們可能會在 etl test scope 中加入更多相依性，因此 deps image 建置的時候要明確建構 etl test code確保相關的相依函式庫都有被拉進來