### PR TITLE
[WEB] Remove RequestObject

### DIFF
--- a/app/src/main/java/org/astraea/app/web/Channel.java
+++ b/app/src/main/java/org/astraea/app/web/Channel.java
@@ -129,7 +129,7 @@ interface Channel {
         }
 
         @Override
-        public <T> T request(TypeRef<T> typeRef) {
+        public <T extends Request> T request(TypeRef<T> typeRef) {
           var json = body.orElse("{}");
           return JsonConverter.defaultConverter().fromJson(json, typeRef);
         }
@@ -270,7 +270,7 @@ interface Channel {
   /**
    * @return body request
    */
-  <T> T request(TypeRef<T> typeRef);
+  <T extends Request> T request(TypeRef<T> typeRef);
 
   /**
    * @return the queries appended to URL

--- a/app/src/main/java/org/astraea/app/web/RecordHandler.java
+++ b/app/src/main/java/org/astraea/app/web/RecordHandler.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.astraea.app.web.Request.RequestObject;
 import org.astraea.common.Cache;
 import org.astraea.common.EnumInfo;
 import org.astraea.common.FutureUtils;
@@ -450,7 +449,7 @@ public class RecordHandler implements Handler {
     }
   }
 
-  static class PostRecord implements RequestObject {
+  static class PostRecord implements Request {
     String topic;
     Optional<Integer> partition = Optional.empty();
     String keySerializer = "STRING";

--- a/app/src/main/java/org/astraea/app/web/Request.java
+++ b/app/src/main/java/org/astraea/app/web/Request.java
@@ -16,8 +16,10 @@
  */
 package org.astraea.app.web;
 
-public interface Request {
-
-  /** Indicates the object used in the request */
-  interface RequestObject {}
-}
+/**
+ * This interface is a kind of PUT/POST request. The {@link Channel} is able to convert json string
+ * to obj which implements this Request interface. For another, the unit test of Request is able to
+ * find out the invalid declaration for Request implementations. Hence, each handle ought to
+ * consider applying this interface to all POST/PUT request.
+ */
+public interface Request {}

--- a/common/src/main/java/org/astraea/common/Utils.java
+++ b/common/src/main/java/org/astraea/common/Utils.java
@@ -340,16 +340,5 @@ public final class Utils {
         string.replaceAll("\\?", ".").replaceAll("\\*", ".*"), Pattern.CASE_INSENSITIVE);
   }
 
-  public static boolean isWrapper(Class<?> cls) {
-    return cls == Double.class
-        || cls == Float.class
-        || cls == Long.class
-        || cls == Integer.class
-        || cls == Short.class
-        || cls == Character.class
-        || cls == Byte.class
-        || cls == Boolean.class;
-  }
-
   private Utils() {}
 }

--- a/common/src/main/java/org/astraea/common/json/JsonConverter.java
+++ b/common/src/main/java/org/astraea/common/json/JsonConverter.java
@@ -115,25 +115,33 @@ public interface JsonConverter {
         preventNull(name + "[" + i + "]", c);
         i++;
       }
-    } else if (Optional.class == objClass) {
+      return;
+    }
+    if (Optional.class == objClass) {
       var opt = (Optional<?>) obj;
       opt.ifPresent(o -> preventNull(name, o));
-    } else if (Map.class.isAssignableFrom(objClass)) {
+      return;
+    }
+    if (Map.class.isAssignableFrom(objClass)) {
       var map = (Map<?, ?>) obj;
       map.forEach((k, v) -> preventNull(name + "." + k, v));
-    } else if (objClass.isPrimitive()
-        || Utils.isWrapper(objClass)
-        || String.class == objClass
-        || Object.class == objClass) {
       return;
-    } else {
-      var declaredFields = objClass.getDeclaredFields();
-      Arrays.stream(declaredFields)
-          .forEach(
-              x -> {
-                x.setAccessible(true);
-                preventNull(name + "." + x.getName(), Utils.packException(() -> x.get(obj)));
-              });
     }
+    if (objClass.isPrimitive()
+        || objClass == Double.class
+        || objClass == Float.class
+        || objClass == Long.class
+        || objClass == Integer.class
+        || objClass == Short.class
+        || objClass == Character.class
+        || objClass == Byte.class
+        || objClass == Boolean.class
+        || objClass == String.class
+        || objClass == Object.class) {
+      return;
+    }
+    Arrays.stream(objClass.getDeclaredFields())
+        .peek(x -> x.setAccessible(true))
+        .forEach(x -> preventNull(name + "." + x.getName(), Utils.packException(() -> x.get(obj))));
   }
 }


### PR DESCRIPTION
如題，移除`RequestObject`改以`Request`替代，並且限制request的轉型只能針對`Request`

已知限制：

Class a {
  Optional<T> b;
}

上述的generic type `T` 目前沒有做進一步的檢查，換言之，handle 如何放了一個非 `Request` 在裡面，unit test 無法得知，但如果該型別可以正確通過 json 轉換，則 production code 視為沒問題