### PR TITLE
Refactor MetricsCollector

### DIFF
--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -20,6 +20,7 @@ import com.google.gson.Gson;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -684,9 +685,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                   // BalancerHandler#put
                   .thenApplyAsync(
                       i -> {
-                        System.out.println("before block");
                         Utils.packException(() -> latch.await());
-                        System.out.println("after block");
                         return i;
                       });
             }
@@ -730,9 +729,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
       Assertions.assertNull(progress1.exception);
 
       // it is done
-      System.out.println("before countDown");
       theExecutor.latch.countDown();
-      System.out.println("after countDown");
       Utils.sleep(Duration.ofSeconds(1));
       var progress2 =
           Assertions.assertInstanceOf(
@@ -1066,7 +1063,8 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
       FetcherAndCost.callback.set(
           (clusterBean) -> {
             var metrics =
-                clusterBean.all().get(0).stream()
+                clusterBean.all().values().stream()
+                    .flatMap(Collection::stream)
                     .filter(x -> x instanceof JvmMemory)
                     .collect(Collectors.toUnmodifiableSet());
             if (metrics.size() < 3)

--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricCollector.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricCollector.java
@@ -18,12 +18,9 @@ package org.astraea.common.metrics.collector;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.astraea.common.admin.ClusterBean;
 import org.astraea.common.metrics.HasBeanObject;
 
@@ -79,36 +76,26 @@ public interface MetricCollector extends AutoCloseable {
   Set<Class<? extends HasBeanObject>> listMetricTypes();
 
   /**
-   * retrieve metrics since the specific moment of time.
-   *
-   * <p>{@link MetricCollector} keeps metrics for a specific amount of time. Reading outdated
-   * metrics is considered as undefined behavior.
-   *
-   * @param since retrieve metrics since this moment of time. The time is measured by {@link
-   *     System#currentTimeMillis()}.
-   * @return a {@link Iterator} that returns metrics from the given time to the metrics that is
-   *     ready for consume.
+   * @return size of stored beans
    */
-  <T extends HasBeanObject> List<T> metrics(Class<T> metricClass, int identity, long since);
+  int size();
+
+  /**
+   * @return a weak consistency stream for stored beans.
+   */
+  Stream<HasBeanObject> metrics();
+
+  /**
+   * @return a weak consistency stream for stored beans.
+   */
+  default <T extends HasBeanObject> Stream<T> metrics(Class<T> clz) {
+    return metrics().filter(b -> clz.isAssignableFrom(b.getClass())).map(clz::cast);
+  }
 
   /**
    * @return the {@link ClusterBean}.
    */
-  default ClusterBean clusterBean() {
-    var metricClasses = listMetricTypes();
-    Map<Integer, Collection<HasBeanObject>> metrics =
-        listIdentities().stream()
-            .collect(
-                Collectors.toUnmodifiableMap(
-                    broker -> broker,
-                    broker ->
-                        metricClasses.stream()
-                            .map(mClass -> metrics(mClass, broker, 0))
-                            .flatMap(Collection::stream)
-                            .collect(Collectors.toUnmodifiableSet())));
-
-    return ClusterBean.of(metrics);
-  }
+  ClusterBean clusterBean();
 
   @Override
   void close();

--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricCollectorImpl.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricCollectorImpl.java
@@ -18,9 +18,7 @@ package org.astraea.common.metrics.collector;
 
 import java.net.InetSocketAddress;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -28,52 +26,93 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ConcurrentNavigableMap;
-import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.DelayQueue;
 import java.util.concurrent.Delayed;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicLongArray;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.astraea.common.Utils;
+import org.astraea.common.admin.ClusterBean;
 import org.astraea.common.metrics.HasBeanObject;
 import org.astraea.common.metrics.MBeanClient;
 
 public class MetricCollectorImpl implements MetricCollector {
 
-  private final Map<Integer, MBeanClient> mBeanClients;
-  private final CopyOnWriteArrayList<Map.Entry<Fetcher, BiConsumer<Integer, Exception>>> fetchers;
-  private final Duration expiration;
-  private final Duration interval;
-  private final Map<Class<? extends HasBeanObject>, MetricStorage<? extends HasBeanObject>>
-      storages;
+  private final Map<Integer, MBeanClient> mBeanClients = new ConcurrentHashMap<>();
+  private final CopyOnWriteArrayList<Map.Entry<Fetcher, BiConsumer<Integer, Exception>>> fetchers =
+      new CopyOnWriteArrayList<>();
   private final ScheduledExecutorService executorService;
   private final DelayQueue<DelayedIdentity> delayedWorks;
-  private final ThreadTimeHighWatermark threadTime;
+
+  // identity (broker id or producer/consumer id) -> beans
+  private final ConcurrentMap<Integer, Collection<HasBeanObject>> beans = new ConcurrentHashMap<>();
 
   public MetricCollectorImpl(
       int threadCount, Duration expiration, Duration interval, Duration cleanerInterval) {
-    this.mBeanClients = new ConcurrentHashMap<>();
-    this.fetchers = new CopyOnWriteArrayList<>();
-    this.expiration = expiration;
-    this.interval = interval;
-    this.storages = new ConcurrentHashMap<>();
-    this.threadTime = new ThreadTimeHighWatermark(threadCount);
     this.executorService = Executors.newScheduledThreadPool(threadCount + 1);
     this.delayedWorks = new DelayQueue<>();
 
     // TODO: restart cleaner if it is dead
+    // cleaner
     executorService.scheduleWithFixedDelay(
-        clear(), cleanerInterval.toMillis(), cleanerInterval.toMillis(), TimeUnit.MILLISECONDS);
-    IntStream.range(0, threadCount).forEach(i -> executorService.submit(process(i)));
+        () -> {
+          var before = System.currentTimeMillis() - expiration.toMillis();
+          beans
+              .values()
+              .forEach(
+                  bs -> bs.removeIf(hasBeanObject -> hasBeanObject.createdTimestamp() < before));
+        },
+        cleanerInterval.toMillis(),
+        cleanerInterval.toMillis(),
+        TimeUnit.MILLISECONDS);
+
+    // processor
+    IntStream.range(0, threadCount)
+        .forEach(
+            i ->
+                executorService.submit(
+                    () -> {
+                      while (!Thread.currentThread().isInterrupted()) {
+
+                        DelayedIdentity identity = null;
+                        try {
+                          identity = delayedWorks.take();
+                          // TODO: employ better sampling mechanism
+                          // see
+                          // https://github.com/skiptests/astraea/pull/1035#discussion_r1010506993
+                          // see
+                          // https://github.com/skiptests/astraea/pull/1035#discussion_r1011079711
+
+                          // for each fetcher, perform the fetching and store the metrics
+                          for (var fetcher : fetchers) {
+                            try {
+                              beans
+                                  .computeIfAbsent(
+                                      identity.id, ignored -> new ConcurrentLinkedQueue<>())
+                                  .addAll(fetcher.getKey().fetch(mBeanClients.get(identity.id)));
+                            } catch (NoSuchElementException e) {
+                              // MBeanClient can throw NoSuchElementException if the result of query
+                              // is empty
+                              fetcher.getValue().accept(identity.id, e);
+                            }
+                          }
+                        } catch (InterruptedException e) {
+                          // swallow the interrupt exception and exit immediately
+                          Thread.currentThread().interrupt();
+                        } finally {
+                          // if we pull out an identity, we must put it back
+                          if (identity != null)
+                            delayedWorks.put(new DelayedIdentity(interval, identity.id));
+                        }
+                      }
+                    }));
   }
 
   @Override
@@ -117,7 +156,15 @@ public class MetricCollectorImpl implements MetricCollector {
 
   @Override
   public Set<Class<? extends HasBeanObject>> listMetricTypes() {
-    return storages.keySet();
+    return beans.values().stream()
+        .flatMap(Collection::stream)
+        .map(HasBeanObject::getClass)
+        .collect(Collectors.toUnmodifiableSet());
+  }
+
+  @Override
+  public int size() {
+    return beans.values().stream().mapToInt(Collection::size).sum();
   }
 
   @SuppressWarnings("resource")
@@ -132,100 +179,14 @@ public class MetricCollectorImpl implements MetricCollector {
     this.delayedWorks.put(new DelayedIdentity(Duration.ZERO, identity));
   }
 
-  @SuppressWarnings("unchecked")
-  @Override
-  public <T extends HasBeanObject> List<T> metrics(Class<T> metricClass, int identity, long since) {
-    return (List<T>)
-        (storages.computeIfAbsent(metricClass, (ignore) -> new MetricStorage<>(metricClass)))
-                .storage
-                .getOrDefault(identity, MetricStorage.emptyStorage())
-                // query range [since, threadTime)
-                // It's design as a half-open interval for a very specific reason.
-                // Other threads might insert metrics at the minimum thread time moment.
-                // Have to exclude that point of metrics, to prevent client miss any metrics.
-                .subMap(since, true, threadTime.read(), false)
-                .values()
-                .stream()
-                .flatMap(Collection::stream)
-                .collect(Collectors.toUnmodifiableList());
+  public ClusterBean clusterBean() {
+    return ClusterBean.of(
+        beans.entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> List.copyOf(e.getValue()))));
   }
 
-  /** Store the metrics into the storage of specific identity */
-  private void store(int identity, Collection<? extends HasBeanObject> metrics) {
-    metrics.forEach(
-        (metric) ->
-            storages
-                .computeIfAbsent(
-                    metric.getClass(), (ignore) -> new MetricStorage<>(metric.getClass()))
-                .put(identity, metric));
-  }
-
-  /** Return a {@link Runnable} that perform the metric sampling task */
-  private Runnable process(int threadId) {
-    return () -> {
-      while (!Thread.currentThread().isInterrupted()) {
-        DelayedIdentity identity = null;
-        try {
-          identity = delayedWorks.poll(5, TimeUnit.MILLISECONDS);
-          if (identity == null) {
-            threadTime.update(threadId, System.currentTimeMillis());
-            continue;
-          }
-          var id = identity.id();
-          var client = mBeanClients.get(id);
-
-          // TODO: employ better sampling mechanism
-          // see https://github.com/skiptests/astraea/pull/1035#discussion_r1010506993
-          // see https://github.com/skiptests/astraea/pull/1035#discussion_r1011079711
-
-          // for each fetcher, perform the fetching and store the metrics
-          fetchers.stream()
-              .map(
-                  entry -> {
-                    try {
-                      return entry.getKey().fetch(client);
-                    } catch (NoSuchElementException e) {
-                      entry.getValue().accept(id, e);
-                      return Collections.<HasBeanObject>emptyList();
-                    }
-                  })
-              .peek(metrics -> store(id, metrics))
-              .forEach(
-                  i -> {
-                    // Intentional sleep, make sure the recent result is published
-                    Utils.packException(() -> TimeUnit.MILLISECONDS.sleep(1));
-                    threadTime.update(threadId, System.currentTimeMillis());
-                  });
-        } catch (RuntimeException e) {
-          if (e.getCause() instanceof InterruptedException)
-            // swallow the interrupt exception and exit immediately
-            Thread.currentThread().interrupt();
-          else e.printStackTrace();
-        } catch (InterruptedException e) {
-          // swallow the interrupt exception and exit immediately
-          Thread.currentThread().interrupt();
-        } catch (Exception e) {
-          e.printStackTrace();
-        } finally {
-          // if we pull out an identity, we must put it back
-          if (identity != null) delayedWorks.put(new DelayedIdentity(interval, identity.id()));
-        }
-      }
-    };
-  }
-
-  /** Return a {@link Runnable} that clears old metrics */
-  private Runnable clear() {
-    return () -> {
-      try {
-        var before = System.currentTimeMillis() - expiration.toMillis();
-        for (var storage : this.storages.values()) storage.clear(before);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
-    };
+  public Stream<HasBeanObject> metrics() {
+    return beans.values().stream().flatMap(Collection::stream);
   }
 
   @Override
@@ -234,52 +195,6 @@ public class MetricCollectorImpl implements MetricCollector {
     this.executorService.shutdownNow();
     Utils.packException(() -> this.executorService.awaitTermination(20, TimeUnit.SECONDS));
     this.mBeanClients.forEach((ignore, client) -> client.close());
-  }
-
-  private static class MetricStorage<T extends HasBeanObject> {
-    private static final ConcurrentNavigableMap<Long, ConcurrentLinkedQueue<?>> EMPTY_STORAGE =
-        new ConcurrentSkipListMap<>();
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private static <T> ConcurrentNavigableMap<Long, ConcurrentLinkedQueue<T>> emptyStorage() {
-      return ((ConcurrentSkipListMap) EMPTY_STORAGE);
-    }
-
-    private final Class<T> theClass;
-    private final Map<Integer, ConcurrentNavigableMap<Long, ConcurrentLinkedQueue<T>>> storage;
-    private final ReentrantLock cleanerLock;
-
-    public MetricStorage(Class<T> theClass) {
-      this.theClass = theClass;
-      this.cleanerLock = new ReentrantLock();
-      this.storage = new ConcurrentHashMap<>();
-    }
-
-    @SuppressWarnings("unchecked")
-    public void put(int identity, HasBeanObject metric) {
-      storage
-          .computeIfAbsent(identity, (ignore) -> new ConcurrentSkipListMap<>())
-          .computeIfAbsent(metric.createdTimestamp(), (ignore) -> new ConcurrentLinkedQueue<>())
-          .add((T) metric);
-    }
-
-    /** Scanning from the last metrics, delete any metrics that is sampled before the given time. */
-    public void clear(long before) throws InterruptedException {
-      try {
-        cleanerLock.lockInterruptibly();
-        storage.forEach(
-            (identity, map) ->
-                map.entrySet().stream()
-                    .takeWhile(x -> x.getKey() < before)
-                    .forEach(x -> map.remove(x.getKey())));
-      } finally {
-        if (cleanerLock.isHeldByCurrentThread()) cleanerLock.unlock();
-      }
-    }
-
-    public Class<T> metricClass() {
-      return theClass;
-    }
   }
 
   public static class Builder {
@@ -327,10 +242,6 @@ public class MetricCollectorImpl implements MetricCollector {
 
     private final int id;
 
-    public int id() {
-      return id;
-    }
-
     @Override
     public long getDelay(TimeUnit timeUnit) {
       return timeUnit.convert(deadlineNs - System.nanoTime(), TimeUnit.NANOSECONDS);
@@ -340,35 +251,6 @@ public class MetricCollectorImpl implements MetricCollector {
     public int compareTo(Delayed delayed) {
       return Long.compare(
           this.getDelay(TimeUnit.NANOSECONDS), delayed.getDelay(TimeUnit.NANOSECONDS));
-    }
-  }
-
-  /** Tracking the metric timestamp that is safe to expose. */
-  private static class ThreadTimeHighWatermark {
-
-    private final AtomicLongArray threadTimes;
-    private final AtomicLong highWatermark;
-
-    public ThreadTimeHighWatermark(int threadCount) {
-      final var defaultTime = new long[threadCount];
-      Arrays.fill(defaultTime, Long.MAX_VALUE);
-      this.threadTimes = new AtomicLongArray(defaultTime);
-      this.highWatermark = new AtomicLong(Long.MAX_VALUE);
-    }
-
-    /** set thread time for specific thread id, and update the high watermark. */
-    public void update(int threadId, long threadTime) {
-      threadTimes.set(threadId, threadTime);
-      long min = threadTimes.get(0);
-      for (int i = 1; i < threadTimes.length(); i++) min = Math.min(min, threadTimes.get(i));
-      highWatermark.set(min);
-    }
-
-    /**
-     * @return the high watermark
-     */
-    public long read() {
-      return highWatermark.get();
     }
   }
 }

--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricCollectorImpl.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricCollectorImpl.java
@@ -232,15 +232,13 @@ public class MetricCollectorImpl implements MetricCollector {
   }
 
   private static class DelayedIdentity implements Delayed {
-
     private final long deadlineNs;
+    private final int id;
 
     private DelayedIdentity(Duration delay, int id) {
       this.deadlineNs = delay.toNanos() + System.nanoTime();
       this.id = id;
     }
-
-    private final int id;
 
     @Override
     public long getDelay(TimeUnit timeUnit) {

--- a/common/src/main/java/org/astraea/common/partitioner/smooth/SmoothWeightRoundRobinDispatcher.java
+++ b/common/src/main/java/org/astraea/common/partitioner/smooth/SmoothWeightRoundRobinDispatcher.java
@@ -166,13 +166,7 @@ public class SmoothWeightRoundRobinDispatcher implements Dispatcher {
                         metricCollector.addFetcher(fetcher);
 
                         // Wait until the initial value of metrics is exists.
-                        while (metricCollector.listMetricTypes().stream()
-                                .map(x -> metricCollector.metrics(x, p.nodeInfo().id(), 0))
-                                .mapToInt(List::size)
-                                .sum()
-                            == 0) {
-                          Utils.sleep(Duration.ofMillis(5));
-                        }
+                        while (metricCollector.size() == 0) Utils.sleep(Duration.ofMillis(5));
                       });
             });
   }

--- a/common/src/test/java/org/astraea/common/cost/BrokerInputCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/BrokerInputCostTest.java
@@ -67,7 +67,8 @@ public class BrokerInputCostTest extends RequireBrokerCluster {
 
       // Test the fetched object's type, and its metric name.
       Assertions.assertTrue(
-          collector.metrics(ServerMetrics.BrokerTopic.Meter.class, 0, 0).stream()
+          collector
+              .metrics(ServerMetrics.BrokerTopic.Meter.class)
               .allMatch(
                   o ->
                       (o != null)
@@ -77,7 +78,8 @@ public class BrokerInputCostTest extends RequireBrokerCluster {
 
       // Test the fetched object's value.
       Assertions.assertTrue(
-          collector.metrics(ServerMetrics.BrokerTopic.Meter.class, 0, 0).stream()
+          collector
+              .metrics(ServerMetrics.BrokerTopic.Meter.class)
               .allMatch(result -> result.count() == 0));
     }
   }

--- a/common/src/test/java/org/astraea/common/cost/BrokerOutputCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/BrokerOutputCostTest.java
@@ -60,7 +60,8 @@ public class BrokerOutputCostTest extends RequireBrokerCluster {
 
       // Test the fetched object's type, and its metric name.
       Assertions.assertTrue(
-          collector.metrics(ServerMetrics.BrokerTopic.Meter.class, 0, 0).stream()
+          collector
+              .metrics(ServerMetrics.BrokerTopic.Meter.class)
               .allMatch(
                   o ->
                       (o != null)
@@ -70,8 +71,7 @@ public class BrokerOutputCostTest extends RequireBrokerCluster {
 
       // Test the fetched object's value.
       Assertions.assertTrue(
-          collector.metrics(ServerMetrics.BrokerTopic.Meter.class, 0, 0).stream()
-              .allMatch(r -> r.count() == 0));
+          collector.metrics(ServerMetrics.BrokerTopic.Meter.class).allMatch(r -> r.count() == 0));
     }
   }
 

--- a/common/src/test/java/org/astraea/common/cost/CpuCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/CpuCostTest.java
@@ -62,13 +62,14 @@ public class CpuCostTest {
 
       Utils.sleep(interval);
 
-      Assertions.assertFalse(collector.metrics(OperatingSystemInfo.class, 0, 0).isEmpty());
+      Assertions.assertFalse(collector.metrics(OperatingSystemInfo.class).findAny().isEmpty());
       Assertions.assertTrue(
-          collector.metrics(OperatingSystemInfo.class, 0, 0).stream().allMatch(Objects::nonNull));
+          collector.metrics(OperatingSystemInfo.class).allMatch(Objects::nonNull));
 
       // Test if we can get the value between 0 ~ 1
       Assertions.assertTrue(
-          collector.metrics(OperatingSystemInfo.class, 0, 0).stream()
+          collector
+              .metrics(OperatingSystemInfo.class)
               .allMatch(
                   OSInfo -> (OSInfo.systemCpuLoad() <= 1.0) && (OSInfo.systemCpuLoad() >= 0.0)));
     }

--- a/common/src/test/java/org/astraea/common/cost/MemoryCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/MemoryCostTest.java
@@ -63,12 +63,12 @@ public class MemoryCostTest {
 
       Assertions.assertFalse(collector.listFetchers().isEmpty());
       Assertions.assertFalse(collector.listIdentities().isEmpty());
-      Assertions.assertTrue(
-          collector.metrics(JvmMemory.class, 0, 0).stream().allMatch(Objects::nonNull));
+      Assertions.assertTrue(collector.metrics(JvmMemory.class).allMatch(Objects::nonNull));
 
       // Test if we can get "used memory" and "max memory".
       Assertions.assertTrue(
-          collector.metrics(JvmMemory.class, 0, 0).stream()
+          collector
+              .metrics(JvmMemory.class)
               .allMatch(mem -> mem.heapMemoryUsage().getUsed() <= mem.heapMemoryUsage().getMax()));
     }
   }

--- a/common/src/test/java/org/astraea/common/metrics/collector/MetricCollectorTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/collector/MetricCollectorTest.java
@@ -159,6 +159,7 @@ class MetricCollectorTest extends RequireBrokerCluster {
 
       // memory and os
       Assertions.assertEquals(2, collector.metrics().count());
+      Assertions.assertEquals(2, collector.size());
     }
   }
 


### PR DESCRIPTION
beans 的索引責任即將交給 ClusterBean，因此 MetricsCollector 可以專心負責收集 beans 即可

ref: https://github.com/skiptests/astraea/pull/1171