### PR TITLE
[FS] enable to create file system dynamically

### DIFF
--- a/app/src/main/java/org/astraea/app/backup/Exporter.java
+++ b/app/src/main/java/org/astraea/app/backup/Exporter.java
@@ -50,7 +50,7 @@ public class Exporter {
   public static Map<TopicPartition, Stat> execute(Argument argument) {
     if (!argument.output.toFile().isDirectory())
       throw new IllegalArgumentException("--output must be a existent folder");
-    try (var fs = FileSystem.local(Configuration.EMPTY)) {
+    try (var fs = FileSystem.of("local", Configuration.EMPTY)) {
       var iter =
           Consumer.forTopics(Set.copyOf(argument.topics))
               .bootstrapServers(argument.bootstrapServers())

--- a/common/src/main/java/org/astraea/common/Utils.java
+++ b/common/src/main/java/org/astraea/common/Utils.java
@@ -151,14 +151,33 @@ public final class Utils {
     }
   }
 
+  @SuppressWarnings("unchecked")
+  public static <T> T construct(String path, Class<T> baseClass, Configuration configuration) {
+    try {
+      var clz = Class.forName(path);
+      if (!baseClass.isAssignableFrom(clz))
+        throw new IllegalArgumentException(
+            path + " class is not sub class of " + baseClass.getName());
+      return construct((Class<T>) clz, configuration);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   public static <T> T construct(Class<T> target, Configuration configuration) {
     try {
       // case 0: create the class by the given configuration
       var constructor = target.getConstructor(Configuration.class);
+      constructor.setAccessible(true);
       return packException(() -> constructor.newInstance(configuration));
     } catch (NoSuchMethodException e) {
       // case 1: create the class by empty constructor
-      return packException(() -> target.getConstructor().newInstance());
+      return packException(
+          () -> {
+            var constructor = target.getConstructor();
+            constructor.setAccessible(true);
+            return constructor.newInstance();
+          });
     }
   }
 

--- a/common/src/test/java/org/astraea/common/UtilsTest.java
+++ b/common/src/test/java/org/astraea/common/UtilsTest.java
@@ -129,15 +129,19 @@ public class UtilsTest {
   @ParameterizedTest
   @ValueSource(classes = {TestCostFunction.class, TestConfigCostFunction.class})
   void testConstruct(Class<? extends CostFunction> aClass) {
-    // arrange
     var config = Configuration.of(Map.of());
 
-    // act
     var costFunction = Utils.construct(aClass, config);
-
-    // assert
     Assertions.assertInstanceOf(CostFunction.class, costFunction);
     Assertions.assertInstanceOf(aClass, costFunction);
+
+    var costFunction2 = Utils.construct(aClass.getName(), CostFunction.class, config);
+    Assertions.assertInstanceOf(CostFunction.class, costFunction2);
+    Assertions.assertInstanceOf(aClass, costFunction2);
+
+    // Cost function class can't be cast to String class
+    Assertions.assertThrows(
+        RuntimeException.class, () -> Utils.construct(aClass.getName(), String.class, config));
   }
 
   @Test

--- a/fs/src/test/java/org/astraea/fs/AbstractFileSystemTest.java
+++ b/fs/src/test/java/org/astraea/fs/AbstractFileSystemTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.fs;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public abstract class AbstractFileSystemTest {
+
+  protected abstract FileSystem fileSystem();
+
+  @Test
+  protected void testList() throws IOException {
+    try (var fs = fileSystem()) {
+      Assertions.assertEquals(0, fs.listFiles("/").size());
+      Assertions.assertEquals(0, fs.listFolders("/").size());
+
+      Assertions.assertThrows(IllegalArgumentException.class, () -> fs.listFiles("/aa"));
+      Assertions.assertThrows(IllegalArgumentException.class, () -> fs.listFolders("/aa"));
+
+      // create a file
+      try (var output = fs.write("/aa")) {
+        output.write("abc".getBytes(StandardCharsets.UTF_8));
+      }
+      var f = fs.listFiles("/");
+      Assertions.assertEquals(1, f.size());
+      Assertions.assertEquals("/aa", f.get(0));
+
+      // can't list a file
+      Assertions.assertThrows(IllegalArgumentException.class, () -> fs.listFiles("/aa"));
+      Assertions.assertThrows(IllegalArgumentException.class, () -> fs.listFolders("/aa"));
+
+      fs.mkdir("/bb");
+      Assertions.assertEquals(0, fs.listFiles("/bb").size());
+      Assertions.assertEquals(0, fs.listFolders("/bb").size());
+    }
+  }
+
+  @Test
+  protected void testMkdir() {
+    try (var fs = fileSystem()) {
+      Assertions.assertEquals(0, fs.listFolders("/").size());
+      fs.mkdir("/tmp/aa");
+
+      Assertions.assertEquals(1, fs.listFolders("/").size());
+      Assertions.assertEquals(1, fs.listFolders("/tmp").size());
+    }
+  }
+
+  @Test
+  protected void testReadWrite() throws IOException {
+    try (var fs = fileSystem()) {
+      var path = "/aaa";
+      try (var output = fs.write(path)) {
+        output.write("abc".getBytes(StandardCharsets.UTF_8));
+      }
+      try (var input = fs.read(path)) {
+        Assertions.assertEquals("abc", new String(input.readAllBytes(), StandardCharsets.UTF_8));
+      }
+    }
+  }
+
+  @Test
+  protected void testWriteToCreateFolder() throws IOException {
+    try (var fs = fileSystem()) {
+      var path = "/tmp/aaa";
+      try (var output = fs.write(path)) {
+        output.write("abc".getBytes(StandardCharsets.UTF_8));
+      }
+      Assertions.assertEquals(1, fs.listFiles("/tmp").size());
+      Assertions.assertEquals(1, fs.listFolders("/").size());
+    }
+  }
+
+  @Test
+  protected void testDelete() throws IOException {
+    try (var fs = fileSystem()) {
+      var path = "/tmp/aaa/bbb";
+      try (var output = fs.write(path)) {
+        output.write("abc".getBytes(StandardCharsets.UTF_8));
+      }
+      fs.delete("/tmp");
+      Assertions.assertEquals(0, fs.listFolders("/").size());
+    }
+  }
+
+  @Test
+  protected void testDeleteEmpty() {
+    try (var fs = fileSystem()) {
+      var path = "/tmp/aaa/bbb";
+      Assertions.assertEquals(Type.NONEXISTENT, fs.type(path));
+      fs.delete(path);
+    }
+  }
+
+  @Test
+  protected void testDeleteRoot() {
+    try (var fs = fileSystem()) {
+      Assertions.assertThrows(IllegalArgumentException.class, () -> fs.delete("/"));
+    }
+  }
+
+  @Test
+  protected void testMkdirOnRoot() {
+    try (var fs = fileSystem()) {
+      fs.mkdir("/");
+    }
+  }
+}

--- a/fs/src/test/java/org/astraea/fs/ftp/FtpFileSystemTest.java
+++ b/fs/src/test/java/org/astraea/fs/ftp/FtpFileSystemTest.java
@@ -18,18 +18,19 @@ package org.astraea.fs.ftp;
 
 import java.util.Map;
 import org.astraea.common.Configuration;
+import org.astraea.fs.AbstractFileSystemTest;
 import org.astraea.fs.FileSystem;
-import org.astraea.fs.FileSystemTest;
 import org.astraea.it.FtpServer;
 import org.junit.jupiter.api.AfterEach;
 
-public class FtpFileSystemTest extends FileSystemTest {
+public class FtpFileSystemTest extends AbstractFileSystemTest {
 
   private final FtpServer server = FtpServer.local();
 
   @Override
   protected FileSystem fileSystem() {
-    return FileSystem.ftp(
+    return FileSystem.of(
+        "ftp",
         Configuration.of(
             Map.of(
                 FtpFileSystem.HOSTNAME_KEY,

--- a/fs/src/test/java/org/astraea/fs/local/LocalFileSystemTest.java
+++ b/fs/src/test/java/org/astraea/fs/local/LocalFileSystemTest.java
@@ -21,16 +21,17 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.util.Map;
 import org.astraea.common.Configuration;
+import org.astraea.fs.AbstractFileSystemTest;
 import org.astraea.fs.FileSystem;
-import org.astraea.fs.FileSystemTest;
 
-public class LocalFileSystemTest extends FileSystemTest {
+public class LocalFileSystemTest extends AbstractFileSystemTest {
 
   @Override
   protected FileSystem fileSystem() {
     try {
       var tmp = Files.createTempDirectory("test_local_fs");
-      return FileSystem.local(Configuration.of(Map.of(LocalFileSystem.ROOT_KEY, tmp.toString())));
+      return FileSystem.of(
+          "local", Configuration.of(Map.of(LocalFileSystem.ROOT_KEY, tmp.toString())));
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }


### PR DESCRIPTION
檔案系統的串接往往會陷入 dependency hell，因此我們入口處用動態的方式隔開各種相依性，同時開放呼叫者透過參數來決定要呼叫哪一種實作，例如：`Map.of("local.impl", "xxx")`可以指定 local file system 改成呼叫"xxx"這個實作，相關測試可以看`FileSystemTest.testOf`