### PR TITLE
[WEB] Fix the HTTP request stream read issue temporarily

### DIFF
--- a/app/src/main/java/org/astraea/app/web/TopicHandler.java
+++ b/app/src/main/java/org/astraea/app/web/TopicHandler.java
@@ -209,19 +209,23 @@ class TopicHandler implements Handler {
   }
 
   static class TopicPostRequest implements Request {
-    private List<Topic> topics = List.of();
+    List<Topic> topics = List.of();
   }
 
   static class Topic implements Request {
-    private String name;
-    private int partitions = 1;
-    private short replicas = 1;
-    private Optional<Double> probability = Optional.empty();
-    private Map<String, String> configs = Map.of();
+    String name;
+    int partitions = 1;
+    short replicas = 1;
+    Optional<Double> probability = Optional.empty();
+    Map<String, String> configs = Map.of();
   }
 
   static class Topics implements Response {
     final List<TopicInfo> topics;
+
+    private Topics() {
+      this.topics = List.of();
+    }
 
     private Topics(List<TopicInfo> topics) {
       this.topics = topics;
@@ -234,6 +238,13 @@ class TopicHandler implements Handler {
     final Set<String> activeGroupIds;
     final List<Partition> partitions;
     final Map<String, String> configs;
+
+    private TopicInfo() {
+      name = "";
+      activeGroupIds = Set.of();
+      partitions = List.of();
+      configs = Map.of();
+    }
 
     private TopicInfo(
         String name,
@@ -259,6 +270,15 @@ class TopicHandler implements Handler {
     // optional field
     final Long timestampOfLatestRecord;
 
+    private Partition() {
+      id = -1;
+      earliest = 0;
+      latest = 0;
+      replicas = List.of();
+      maxTimestamp = 0L;
+      timestampOfLatestRecord = 0L;
+    }
+
     Partition(
         int id,
         long earliest,
@@ -283,6 +303,16 @@ class TopicHandler implements Handler {
     final boolean inSync;
     final boolean isFuture;
     final String path;
+
+    private Replica() {
+      broker = -1;
+      lag = 0;
+      size = 0;
+      leader = false;
+      inSync = false;
+      isFuture = false;
+      path = "";
+    }
 
     Replica(org.astraea.common.admin.Replica replica) {
       this(

--- a/app/src/test/java/org/astraea/app/web/TopicHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/TopicHandlerTest.java
@@ -19,10 +19,14 @@ package org.astraea.app.web;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.astraea.common.Utils;
@@ -30,6 +34,9 @@ import org.astraea.common.admin.Admin;
 import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.consumer.Consumer;
 import org.astraea.common.consumer.ConsumerConfigs;
+import org.astraea.common.http.HttpExecutor;
+import org.astraea.common.http.Response;
+import org.astraea.common.json.TypeRef;
 import org.astraea.common.producer.Producer;
 import org.astraea.common.producer.Record;
 import org.astraea.it.RequireBrokerCluster;
@@ -37,6 +44,56 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TopicHandlerTest extends RequireBrokerCluster {
+
+  @Test
+  void testWithWebService() {
+    try (Admin admin = Admin.of(bootstrapServers())) {
+      var topicName = Utils.randomString();
+      var partitions = ThreadLocalRandom.current().nextInt(1, 11);
+      var replicas = (short) ThreadLocalRandom.current().nextInt(1, 4);
+      var request = new TopicHandler.TopicPostRequest();
+      var topic = new TopicHandler.Topic();
+      topic.name = topicName;
+      topic.partitions = partitions;
+      topic.replicas = replicas;
+      request.topics = List.of(topic);
+
+      var serviceThread = Executors.newSingleThreadExecutor();
+      var servicePort = ThreadLocalRandom.current().nextInt(10000, 65536);
+      serviceThread.submit(
+          () ->
+              Utils.packException(
+                  () ->
+                      WebService.main(
+                          new String[] {
+                            "--port",
+                            String.valueOf(servicePort),
+                            "--bootstrap.servers",
+                            bootstrapServers()
+                          })));
+      Response<TopicHandler.Topics> response =
+          HttpExecutor.builder()
+              .build()
+              .post(
+                  "http://localhost:" + servicePort + "/topics",
+                  request,
+                  TypeRef.of(TopicHandler.Topics.class))
+              .toCompletableFuture()
+              .join();
+      Utils.sleep(Duration.ofSeconds(1));
+
+      var clusterInfo = admin.clusterInfo(Set.of(topicName)).toCompletableFuture().join();
+      Assertions.assertEquals(200, response.statusCode());
+      Assertions.assertEquals(1, response.body().topics.size());
+      Assertions.assertEquals(partitions, response.body().topics.get(0).partitions.size());
+      Assertions.assertEquals(Set.of(topicName), clusterInfo.topics());
+      Assertions.assertEquals(partitions, clusterInfo.topicPartitions().size());
+      Assertions.assertEquals(partitions * replicas, clusterInfo.replicas().size());
+      serviceThread.shutdown();
+      Assertions.assertTrue(
+          Utils.packException(() -> serviceThread.awaitTermination(10, TimeUnit.SECONDS)));
+    }
+  }
 
   @Test
   void testListTopics() {


### PR DESCRIPTION
我在 a1558e20 執行 Web Service，嘗試用他來建立 Topic，不過沒有建立成功。

```shell
curl -X POST --location "http://localhost:8001/topics" \
    -H "Content-Type: application/json" \
    -d "{
          \"topics\": [
            {
              \"name\": \"shoot\",
              \"partitions\": 100,
              \"replicas\": 1
            }
          ]
        }"
```

```
{}
```

原因和目前 Channel 內的 HTTP Request Body 解析有關，目前的更動有讀取 Request Body 兩次的需求

https://github.com/skiptests/astraea/blob/41180158b5e6d4b78e410d77f233cbc7fbf414d2/app/src/main/java/org/astraea/app/web/Channel.java#L233-L234

不過 HttpExcange 回傳的 Request Body 在 InputStream 裡面，裡面的資料只能讀一次，導致 `PostRequest` 有內容但是 `Request` 版本的沒有內容，這個 PR 暫時把它改成預讀然後複製兩個 Buffer 出來供給資訊。