### PR TITLE
[CONNECTOR] Fix flaky ConnectorClientTest#testUrls

### DIFF
--- a/common/src/test/java/org/astraea/common/connector/ConnectorClientTest.java
+++ b/common/src/test/java/org/astraea/common/connector/ConnectorClientTest.java
@@ -146,6 +146,9 @@ class ConnectorClientTest extends RequireWorkerCluster {
     assertEquals("2", connector.config().get("tasks.max"));
     assertEquals("myTopic2", connector.config().get("topics"));
 
+    // wait for syncing configs
+    Utils.sleep(Duration.ofSeconds(2));
+
     connector = connectorClient.connector(connectorName).toCompletableFuture().get();
     assertEquals("2", connector.config().get("tasks.max"));
     assertEquals("myTopic2", connector.config().get("topics"));
@@ -193,6 +196,10 @@ class ConnectorClientTest extends RequireWorkerCluster {
         .createConnector(connectorName, getExampleConnector())
         .toCompletableFuture()
         .get();
+
+    // wait for syncing configs
+    Utils.sleep(Duration.ofSeconds(2));
+
     IntStream.range(0, 15)
         .forEach(
             x ->


### PR DESCRIPTION
如題，一樣是同步的問題， kafka connector 透過 kafka topic 來同步資料，因此會出現同步資料的時間區間，此時索取資料就會遇到`Cannot complete request momentarily due to stale configuration (typically caused by a concurrent config change)`

fix #1205