### PR TITLE
Implement `Broker#equals` and `Broker#hashcode`

### DIFF
--- a/common/src/main/java/org/astraea/common/admin/Broker.java
+++ b/common/src/main/java/org/astraea/common/admin/Broker.java
@@ -19,6 +19,7 @@ package org.astraea.common.admin;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.requests.DescribeLogDirsResponse;
@@ -127,6 +128,23 @@ public interface Broker extends NodeInfo {
       @Override
       public Set<TopicPartition> topicPartitionLeaders() {
         return topicPartitionLeaders;
+      }
+
+      // Broker is used to be key of Map commonly, so creating hash can reduce the memory pressure
+      private final int hashCode = Objects.hash(id(), host(), port());
+
+      @Override
+      public int hashCode() {
+        return hashCode;
+      }
+
+      @Override
+      public boolean equals(Object other) {
+        if (other instanceof NodeInfo) {
+          var node = (NodeInfo) other;
+          return id() == node.id() && port() == node.port() && host().equals(node.host());
+        }
+        return false;
       }
     };
   }

--- a/common/src/test/java/org/astraea/common/admin/NodeInfoTest.java
+++ b/common/src/test/java/org/astraea/common/admin/NodeInfoTest.java
@@ -16,9 +16,14 @@
  */
 package org.astraea.common.admin;
 
+import java.util.List;
+import java.util.Map;
 import org.apache.kafka.common.Node;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class NodeInfoTest {
 
@@ -34,5 +39,24 @@ public class NodeInfoTest {
     Assertions.assertEquals(kafkaNode.host(), node.host());
     Assertions.assertEquals(kafkaNode.id(), node.id());
     Assertions.assertEquals(kafkaNode.port(), node.port());
+  }
+
+  @DisplayName("Broker can interact with normal NodeInfo properly")
+  @ParameterizedTest
+  @CsvSource(
+      value = {
+        "  1, host1, 1000",
+        " 20, host2, 2000",
+        "300, host3, 3000",
+      })
+  void testFakeBrokerInteraction(int id, String host, int port) {
+    var node = NodeInfo.of(id, host, port);
+    var broker = Broker.of(false, new Node(id, host, port), Map.of(), Map.of(), List.of());
+    var nodeOther = NodeInfo.of(id + 1, host, port);
+
+    Assertions.assertEquals(node.hashCode(), broker.hashCode());
+    Assertions.assertEquals(node, broker);
+    Assertions.assertNotEquals(nodeOther.hashCode(), broker.hashCode());
+    Assertions.assertNotEquals(nodeOther, broker);
   }
 }


### PR DESCRIPTION
`Broker` 缺少 `equals` 和 `hashcode` 函數，他沒辦法和 `NodeInfo` 互動
因此在做 `Collectors.groupingBy` 操作時，裡面的實作把 `Broker` 和 `NodeInfo` 被當做是不同的物件。

這個 PR 給 `Broker` 補上這些應有的實作，還有用一個測試來確保這個行為。