### PR TITLE
Remove `Comparable` interface from `NodeInfo`

### DIFF
--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -256,22 +256,6 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                       .path("/tmp/aa")
                       .build()));
 
-      var clusterLogAllocation =
-          ClusterInfo.of(
-              List.of(
-                  Replica.builder()
-                      .topic("topic")
-                      .partition(0)
-                      .nodeInfo(NodeInfo.of(11, "host", 22))
-                      .lag(0)
-                      .size(100)
-                      .isLeader(true)
-                      .inSync(true)
-                      .isFuture(false)
-                      .isOffline(false)
-                      .isPreferredLeader(true)
-                      .path("/tmp/aa")
-                      .build()));
       HasClusterCost clusterCostFunction =
           (clusterInfo, clusterBean) -> () -> clusterInfo == currentClusterInfo ? 100D : 10D;
       HasMoveCost moveCostFunction =

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -240,7 +240,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
     try (var admin = Admin.of(bootstrapServers())) {
       var currentClusterInfo =
           ClusterInfo.of(
-              Set.of(NodeInfo.of(10, "host", 22), NodeInfo.of(11, "host", 22)),
+              List.of(NodeInfo.of(10, "host", 22), NodeInfo.of(11, "host", 22)),
               List.of(
                   Replica.builder()
                       .topic("topic")

--- a/common/src/main/java/org/astraea/common/admin/Admin.java
+++ b/common/src/main/java/org/astraea/common/admin/Admin.java
@@ -144,7 +144,7 @@ public interface Admin extends AutoCloseable {
   /**
    * @return online node information
    */
-  CompletionStage<Set<NodeInfo>> nodeInfos();
+  CompletionStage<List<NodeInfo>> nodeInfos();
 
   /**
    * @return online broker information

--- a/common/src/main/java/org/astraea/common/admin/AdminImpl.java
+++ b/common/src/main/java/org/astraea/common/admin/AdminImpl.java
@@ -440,11 +440,10 @@ class AdminImpl implements Admin {
   }
 
   @Override
-  public CompletionStage<Set<NodeInfo>> nodeInfos() {
+  public CompletionStage<List<NodeInfo>> nodeInfos() {
     return to(kafkaAdmin.describeCluster().nodes())
         .thenApply(
-            nodes ->
-                nodes.stream().map(NodeInfo::of).collect(Collectors.toCollection(TreeSet::new)));
+            nodes -> nodes.stream().map(NodeInfo::of).collect(Collectors.toUnmodifiableList()));
   }
 
   @Override
@@ -591,7 +590,7 @@ class AdminImpl implements Admin {
                 brokers ->
                     brokers.stream()
                         .map(x -> (NodeInfo) x)
-                        .collect(Collectors.toUnmodifiableSet())),
+                        .collect(Collectors.toUnmodifiableList())),
         replicas(topics),
         ClusterInfo::of);
   }

--- a/common/src/main/java/org/astraea/common/admin/ClusterInfo.java
+++ b/common/src/main/java/org/astraea/common/admin/ClusterInfo.java
@@ -220,33 +220,6 @@ public interface ClusterInfo<T extends ReplicaInfo> {
   }
 
   /**
-   * build a cluster info based on replicas. Noted that the node info are collected by the replicas.
-   *
-   * <p>Be aware that the <code>replicas</code> parameter describes <strong>the replica lists of a
-   * subset of topic/partitions</strong>. It doesn't require the topic/partition part to have
-   * cluster-wide complete information. But the replica list has to be complete. Provide a partial
-   * replica list might result in data loss or unintended replica drop during rebalance plan
-   * proposing & execution.
-   *
-   * @param replicas used to build cluster info
-   * @return cluster info
-   * @param <T> ReplicaInfo or Replica
-   */
-  static <T extends ReplicaInfo> ClusterInfo<T> of(List<T> replicas) {
-    // TODO: this method is not suitable for production use. Move it to the test scope.
-    //  see https://github.com/skiptests/astraea/issues/1185
-    return of(
-        replicas.stream()
-            .map(ReplicaInfo::nodeInfo)
-            .collect(Collectors.groupingBy(NodeInfo::id, Collectors.reducing((x, y) -> x)))
-            .values()
-            .stream()
-            .flatMap(Optional::stream)
-            .collect(Collectors.toUnmodifiableList()),
-        replicas);
-  }
-
-  /**
    * build a cluster info based on replicas and a set of cluster node information.
    *
    * <p>Be aware that this the <code>replicas</code>parameter describes <strong>the replica lists of

--- a/common/src/main/java/org/astraea/common/admin/NodeInfo.java
+++ b/common/src/main/java/org/astraea/common/admin/NodeInfo.java
@@ -18,7 +18,7 @@ package org.astraea.common.admin;
 
 import java.util.Objects;
 
-public interface NodeInfo extends Comparable<NodeInfo> {
+public interface NodeInfo {
 
   static NodeInfo of(org.apache.kafka.common.Node node) {
     return of(node.id(), node.host(), node.port());
@@ -85,14 +85,5 @@ public interface NodeInfo extends Comparable<NodeInfo> {
    */
   default boolean offline() {
     return host() == null || host().isEmpty() || port() < 0;
-  }
-
-  @Override
-  default int compareTo(NodeInfo other) {
-    var r = Integer.compare(id(), other.id());
-    if (r != 0) return r;
-    r = host().compareTo(other.host());
-    if (r != 0) return r;
-    return Integer.compare(port(), other.port());
   }
 }

--- a/common/src/test/java/org/astraea/common/admin/AdminTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AdminTest.java
@@ -306,7 +306,7 @@ public class AdminTest extends RequireBrokerCluster {
       Assertions.assertInstanceOf(
           SortedSet.class, admin.topicPartitionReplicas(brokerIds()).toCompletableFuture().join());
 
-      Assertions.assertInstanceOf(SortedSet.class, admin.nodeInfos().toCompletableFuture().join());
+      Assertions.assertInstanceOf(List.class, admin.nodeInfos().toCompletableFuture().join());
 
       var brokers = admin.brokers().toCompletableFuture().join();
       Assertions.assertEquals(

--- a/common/src/test/java/org/astraea/common/admin/ClusterInfoBuilderTest.java
+++ b/common/src/test/java/org/astraea/common/admin/ClusterInfoBuilderTest.java
@@ -43,20 +43,20 @@ class ClusterInfoBuilderTest {
             .isPreferredLeader(true)
             .isLeader(true)
             .build();
-    var cluster = ClusterInfo.of(Set.of(host1000, host2000, host3000), List.of(replica));
+    var cluster = ClusterInfo.of(List.of(host1000, host2000, host3000), List.of(replica));
 
     Assertions.assertEquals(
-        Set.of(host1000, host2000, host3000), ClusterInfoBuilder.builder(cluster).build().nodes());
+        List.of(host1000, host2000, host3000), ClusterInfoBuilder.builder(cluster).build().nodes());
     Assertions.assertEquals(
         List.of(replica), ClusterInfoBuilder.builder(cluster).build().replicas());
-    Assertions.assertEquals(Set.of(), ClusterInfoBuilder.builder().build().nodes());
+    Assertions.assertEquals(List.of(), ClusterInfoBuilder.builder().build().nodes());
     Assertions.assertEquals(List.of(), ClusterInfoBuilder.builder().build().replicas());
   }
 
   @Test
   void addNode() {
     Assertions.assertEquals(
-        Set.of(), ClusterInfoBuilder.builder().addNode(Set.of()).build().nodes());
+        List.of(), ClusterInfoBuilder.builder().addNode(Set.of()).build().nodes());
     Assertions.assertEquals(
         Set.of(1, 2, 3, 4, 5, 100),
         ClusterInfoBuilder.builder().addNode(Set.of(1, 2, 3, 4, 5, 100)).build().nodes().stream()

--- a/common/src/test/java/org/astraea/common/admin/ClusterInfoTest.java
+++ b/common/src/test/java/org/astraea/common/admin/ClusterInfoTest.java
@@ -169,7 +169,7 @@ public class ClusterInfoTest {
                 .isPreferredLeader(false)
                 .path("/data-folder-01")
                 .build());
-    var nodeInfos = Set.of(NodeInfo.of(0, "", -1), NodeInfo.of(1, "", -1), NodeInfo.of(2, "", -1));
+    var nodeInfos = List.of(NodeInfo.of(0, "", -1), NodeInfo.of(1, "", -1), NodeInfo.of(2, "", -1));
     var before = ClusterInfo.of(nodeInfos, beforeReplicas);
     var after = ClusterInfo.of(nodeInfos, afterReplicas);
     var changes = ClusterInfo.diff(before, after);

--- a/common/src/test/java/org/astraea/common/admin/ReplicaInfoTest.java
+++ b/common/src/test/java/org/astraea/common/admin/ReplicaInfoTest.java
@@ -18,7 +18,6 @@ package org.astraea.common.admin;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.Node;
@@ -41,12 +40,12 @@ public class ReplicaInfoTest {
     var kafkaPartition = partitionInfo();
     var replicaInfo = ReplicaInfo.of(kafkaPartition);
     var followerReplicaNode =
-        (Supplier<Set<NodeInfo>>)
+        (Supplier<List<NodeInfo>>)
             () ->
                 Arrays.stream(kafkaPartition.replicas())
                     .map(NodeInfo::of)
                     .filter(node -> !node.equals(NodeInfo.of(kafkaPartition.leader())))
-                    .collect(Collectors.toUnmodifiableSet());
+                    .collect(Collectors.toUnmodifiableList());
     final List<ReplicaInfo> leader =
         replicaInfo.stream().filter(ReplicaInfo::isLeader).collect(Collectors.toList());
     var followers =
@@ -70,7 +69,7 @@ public class ReplicaInfoTest {
         "The follower replica node count should match");
     Assertions.assertEquals(
         followerReplicaNode.get(),
-        followers.stream().map(ReplicaInfo::nodeInfo).collect(Collectors.toUnmodifiableSet()),
+        followers.stream().map(ReplicaInfo::nodeInfo).collect(Collectors.toUnmodifiableList()),
         "The follower replica node set should match");
   }
 }

--- a/common/src/test/java/org/astraea/common/balancer/FakeClusterInfo.java
+++ b/common/src/test/java/org/astraea/common/balancer/FakeClusterInfo.java
@@ -170,6 +170,6 @@ public class FakeClusterInfo {
                                     .build()))
             .collect(Collectors.toUnmodifiableList());
 
-    return ClusterInfo.of(Set.copyOf(nodes), replicas);
+    return ClusterInfo.of(List.copyOf(nodes), replicas);
   }
 }

--- a/common/src/test/java/org/astraea/common/balancer/executor/StraightPlanExecutorTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/executor/StraightPlanExecutorTest.java
@@ -26,6 +26,7 @@ import java.util.stream.IntStream;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.admin.ClusterInfoTest;
 import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.Replica;
 import org.astraea.common.admin.TopicPartition;
@@ -97,7 +98,7 @@ class StraightPlanExecutorTest extends RequireBrokerCluster {
               .stream()
               .flatMap(Collection::stream)
               .collect(Collectors.toUnmodifiableList());
-      final var expectedAllocation = ClusterInfo.of(allocation);
+      final var expectedAllocation = ClusterInfoTest.of(allocation);
       final var expectedTopicPartition = expectedAllocation.topicPartitions();
 
       var execute =

--- a/common/src/test/java/org/astraea/common/balancer/tweakers/ShuffleTweakerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/tweakers/ShuffleTweakerTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.admin.ClusterInfoTest;
 import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.Replica;
 import org.astraea.common.admin.TopicPartition;
@@ -201,7 +202,7 @@ class ShuffleTweakerTest {
             .path("/a")
             .build();
     var allocation =
-        ClusterInfo.of(
+        ClusterInfoTest.of(
             List.of(
                 Replica.builder(base)
                     .topic("normal-topic")

--- a/common/src/test/java/org/astraea/common/cost/ReplicaLeaderCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/ReplicaLeaderCostTest.java
@@ -18,7 +18,6 @@ package org.astraea.common.cost;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.astraea.common.admin.ClusterBean;
 import org.astraea.common.admin.ClusterInfo;
@@ -44,7 +43,7 @@ public class ReplicaLeaderCostTest {
             ReplicaInfo.of("topic", 0, NodeInfo.of(11, "broker1", 1111), true, true, false));
     var clusterInfo =
         ClusterInfo.of(
-            Set.of(
+            List.of(
                 NodeInfo.of(10, "host1", 8080),
                 NodeInfo.of(11, "host1", 8080),
                 NodeInfo.of(12, "host1", 8080)),

--- a/common/src/test/java/org/astraea/common/cost/ReplicaLeaderCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/ReplicaLeaderCostTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.astraea.common.admin.ClusterBean;
 import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.admin.ClusterInfoTest;
 import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.Replica;
 import org.astraea.common.admin.ReplicaInfo;
@@ -192,8 +193,8 @@ public class ReplicaLeaderCostTest {
                 .isPreferredLeader(false)
                 .path("")
                 .build());
-    var beforeClusterInfo = ClusterInfo.of(before);
-    var afterClusterInfo = ClusterInfo.of(after);
+    var beforeClusterInfo = ClusterInfoTest.of(before);
+    var afterClusterInfo = ClusterInfoTest.of(after);
     var moveCost = costFunction.moveCost(beforeClusterInfo, afterClusterInfo, ClusterBean.EMPTY);
     Assertions.assertEquals(1, moveCost.totalCost());
     Assertions.assertEquals(2, moveCost.changes().size());

--- a/common/src/test/java/org/astraea/common/cost/ReplicaNumberCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/ReplicaNumberCostTest.java
@@ -18,7 +18,6 @@ package org.astraea.common.cost;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.astraea.common.admin.ClusterBean;
@@ -35,7 +34,7 @@ class ReplicaNumberCostTest {
     var nodeInfo = NodeInfo.of(10, "h", 100);
     var replica = Replica.builder().nodeInfo(nodeInfo).topic("t").build();
     var clusterInfo =
-        ClusterInfo.of(Set.of(nodeInfo, NodeInfo.of(100, "h", 100)), List.of(replica));
+        ClusterInfo.of(List.of(nodeInfo, NodeInfo.of(100, "h", 100)), List.of(replica));
     var cost = new ReplicaNumberCost();
     Assertions.assertEquals(
         Long.MAX_VALUE, cost.clusterCost(clusterInfo, ClusterBean.EMPTY).value());
@@ -44,7 +43,7 @@ class ReplicaNumberCostTest {
   @Test
   void testClusterCostForSingleNode() {
     var nodeInfo = NodeInfo.of(10, "h", 100);
-    var clusterInfo = ClusterInfo.of(Set.of(nodeInfo), List.<Replica>of());
+    var clusterInfo = ClusterInfo.of(List.of(nodeInfo), List.<Replica>of());
     var cost = new ReplicaNumberCost();
     Assertions.assertEquals(0, cost.clusterCost(clusterInfo, ClusterBean.EMPTY).value());
   }
@@ -53,7 +52,8 @@ class ReplicaNumberCostTest {
   void testClusterCostForAllInSingleNode() {
     var nodeInfo = NodeInfo.of(10, "h", 100);
     var replica = Replica.builder().nodeInfo(nodeInfo).topic("t").build();
-    var clusterInfo = ClusterInfo.of(Set.of(nodeInfo, NodeInfo.of(11, "j", 100)), List.of(replica));
+    var clusterInfo =
+        ClusterInfo.of(List.of(nodeInfo, NodeInfo.of(11, "j", 100)), List.of(replica));
     var cost = new ReplicaNumberCost();
     Assertions.assertEquals(
         Long.MAX_VALUE, cost.clusterCost(clusterInfo, ClusterBean.EMPTY).value());
@@ -67,7 +67,7 @@ class ReplicaNumberCostTest {
             .mapToObj(i -> Replica.builder().nodeInfo(nodeInfo).topic("t").build())
             .collect(Collectors.toCollection(ArrayList::new));
     replicas.add(Replica.builder().nodeInfo(NodeInfo.of(11, "j", 100)).topic("t").build());
-    var clusterInfo = ClusterInfo.of(Set.of(nodeInfo, NodeInfo.of(11, "j", 100)), replicas);
+    var clusterInfo = ClusterInfo.of(List.of(nodeInfo, NodeInfo.of(11, "j", 100)), replicas);
     var cost = new ReplicaNumberCost();
     Assertions.assertEquals(9, cost.clusterCost(clusterInfo, ClusterBean.EMPTY).value());
   }

--- a/common/src/test/java/org/astraea/common/cost/ReplicaNumberCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/ReplicaNumberCostTest.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.astraea.common.admin.ClusterBean;
 import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.admin.ClusterInfoTest;
 import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.Replica;
 import org.junit.jupiter.api.Assertions;
@@ -183,8 +184,8 @@ class ReplicaNumberCostTest {
                 .isPreferredLeader(false)
                 .path("")
                 .build());
-    var beforeClusterInfo = ClusterInfo.of(before);
-    var afterClusterInfo = ClusterInfo.of(after);
+    var beforeClusterInfo = ClusterInfoTest.of(before);
+    var afterClusterInfo = ClusterInfoTest.of(after);
     var movecost = costFunction.moveCost(beforeClusterInfo, afterClusterInfo, ClusterBean.EMPTY);
     Assertions.assertEquals(2, movecost.totalCost());
     Assertions.assertEquals(3, movecost.changes().size());

--- a/common/src/test/java/org/astraea/common/cost/ReplicaSizeCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/ReplicaSizeCostTest.java
@@ -18,7 +18,6 @@ package org.astraea.common.cost;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.astraea.common.admin.ClusterBean;
 import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.admin.NodeInfo;
@@ -72,7 +71,7 @@ class ReplicaSizeCostTest {
 
   static ClusterInfo<Replica> getClusterInfo(List<Replica> replicas) {
     return ClusterInfo.of(
-        Set.of(NodeInfo.of(1, "", -1), NodeInfo.of(2, "", -1), NodeInfo.of(3, "", -1)),
+        List.of(NodeInfo.of(1, "", -1), NodeInfo.of(2, "", -1), NodeInfo.of(3, "", -1)),
         List.of(
             replicas.get(0),
             replicas.get(1),

--- a/common/src/test/java/org/astraea/common/partitioner/StrictCostDispatcherTest.java
+++ b/common/src/test/java/org/astraea/common/partitioner/StrictCostDispatcherTest.java
@@ -27,6 +27,7 @@ import org.astraea.common.Configuration;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.ClusterBean;
 import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.admin.ClusterInfoTest;
 import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.ReplicaInfo;
 import org.astraea.common.cost.BrokerCost;
@@ -109,7 +110,7 @@ public class StrictCostDispatcherTest {
       Assertions.assertEquals(
           10,
           dispatcher.partition(
-              "topic", new byte[0], new byte[0], ClusterInfo.of(List.of(replicaInfo))));
+              "topic", new byte[0], new byte[0], ClusterInfoTest.of(List.of(replicaInfo))));
     }
   }
 
@@ -161,7 +162,10 @@ public class StrictCostDispatcherTest {
       dispatcher.configure(
           Map.of(costFunction, 1D), Optional.empty(), Map.of(), Duration.ofSeconds(10));
       dispatcher.partition(
-          "topic", new byte[0], new byte[0], ClusterInfo.of(List.of(replicaInfo0, replicaInfo1)));
+          "topic",
+          new byte[0],
+          new byte[0],
+          ClusterInfoTest.of(List.of(replicaInfo0, replicaInfo1)));
       Assertions.assertEquals(0, dispatcher.metricCollector.listFetchers().size());
     }
   }
@@ -214,7 +218,7 @@ public class StrictCostDispatcherTest {
               "topic",
               new byte[0],
               new byte[0],
-              ClusterInfo.of(List.of(replicaInfo0, replicaInfo1))));
+              ClusterInfoTest.of(List.of(replicaInfo0, replicaInfo1))));
     }
   }
 
@@ -269,7 +273,7 @@ public class StrictCostDispatcherTest {
         try (var dispatcher = new StrictCostDispatcher()) {
           var nodeInfo = NodeInfo.of(10, "host", 2222);
           var clusterInfo =
-              ClusterInfo.of(List.of(ReplicaInfo.of("topic", 0, nodeInfo, true, true, false)));
+              ClusterInfoTest.of(List.of(ReplicaInfo.of("topic", 0, nodeInfo, true, true, false)));
 
           Assertions.assertEquals(0, dispatcher.metricCollector.listIdentities().size());
           dispatcher.costFunction =

--- a/common/src/test/java/org/astraea/common/partitioner/smooth/SmoothWeightRoundRobinDispatchTest.java
+++ b/common/src/test/java/org/astraea/common/partitioner/smooth/SmoothWeightRoundRobinDispatchTest.java
@@ -272,7 +272,7 @@ public class SmoothWeightRoundRobinDispatchTest extends RequireBrokerCluster {
     var node3 = Mockito.mock(NodeInfo.class);
     Mockito.when(node3.id()).thenReturn(3);
     var re3 = ReplicaInfo.of(topic, 2, node3, true, true, false);
-    var testCluster = ClusterInfo.of(List.of(re1, re2, re3));
+    var testCluster = ClusterInfo.of(List.of(node1, node2, node3), List.of(re1, re2, re3));
     Assertions.assertEquals(1, smoothWeight.getAndChoose(topic, testCluster));
     Assertions.assertEquals(2, smoothWeight.getAndChoose(topic, testCluster));
     Assertions.assertEquals(3, smoothWeight.getAndChoose(topic, testCluster));

--- a/common/src/test/java/org/astraea/common/partitioner/smooth/SmoothWeightRoundRobinTest.java
+++ b/common/src/test/java/org/astraea/common/partitioner/smooth/SmoothWeightRoundRobinTest.java
@@ -56,10 +56,16 @@ public class SmoothWeightRoundRobinTest {
   }
 
   ClusterInfo<ReplicaInfo> clusterInfo() {
-    return ClusterInfo.of(
+    var nodes =
         List.of(
-            ReplicaInfo.of("test", 1, NodeInfo.of(1, "host", 1111), true, true, false),
-            ReplicaInfo.of("test", 2, NodeInfo.of(2, "host", 1111), true, true, false),
-            ReplicaInfo.of("test", 3, NodeInfo.of(3, "host", 1111), true, true, false)));
+            NodeInfo.of(1, "host", 1111),
+            NodeInfo.of(2, "host", 1111),
+            NodeInfo.of(3, "host", 1111));
+    return ClusterInfo.of(
+        nodes,
+        List.of(
+            ReplicaInfo.of("test", 1, nodes.get(0), true, true, false),
+            ReplicaInfo.of("test", 2, nodes.get(1), true, true, false),
+            ReplicaInfo.of("test", 3, nodes.get(2), true, true, false)));
   }
 }

--- a/gui/src/main/java/org/astraea/gui/tab/BrokerNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/BrokerNode.java
@@ -229,7 +229,7 @@ public class BrokerNode {
                                 .map(
                                     entry -> {
                                       var result = new LinkedHashMap<String, Object>();
-                                      result.put(BROKER_ID_KEY, entry.getKey().id());
+                                      result.put(BROKER_ID_KEY, entry.getKey());
                                       entry.getValue().stream()
                                           .flatMap(e -> e.getValue().entrySet().stream())
                                           .sorted(
@@ -376,7 +376,7 @@ public class BrokerNode {
         (id, path) ->
             context.hasMetrics()
                 ? context.clients().entrySet().stream()
-                    .filter(e -> e.getKey().id() == id)
+                    .filter(e -> e.getKey() == id)
                     .findFirst()
                     .map(Map.Entry::getValue)
                     .map(

--- a/gui/src/main/java/org/astraea/gui/tab/topic/TopicNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/topic/TopicNode.java
@@ -96,8 +96,8 @@ public class TopicNode {
                                 var map = new LinkedHashMap<String, Object>();
                                 map.put(TOPIC_NAME_KEY, topic);
                                 nodeMeters.forEach(
-                                    (nodeInfo, meters) -> {
-                                      var key = String.valueOf(nodeInfo.id());
+                                    (nodeId, meters) -> {
+                                      var key = String.valueOf(nodeId);
                                       var value =
                                           meters.stream()
                                               .filter(m -> m.topic().equals(topic))

--- a/gui/src/test/java/org/astraea/gui/tab/BalancerNodeTest.java
+++ b/gui/src/test/java/org/astraea/gui/tab/BalancerNodeTest.java
@@ -156,7 +156,7 @@ class BalancerNodeTest extends RequireBrokerCluster {
                 .size(leaderSize)
                 .path("/tmp/bbb")
                 .build());
-    var beforeClusterInfo = ClusterInfo.of(Set.of(), beforeReplicas);
+    var beforeClusterInfo = ClusterInfo.of(List.of(), beforeReplicas);
 
     var results =
         BalancerNode.assignmentResult(

--- a/gui/src/test/java/org/astraea/gui/tab/BalancerNodeTest.java
+++ b/gui/src/test/java/org/astraea/gui/tab/BalancerNodeTest.java
@@ -116,6 +116,8 @@ class BalancerNodeTest extends RequireBrokerCluster {
   void testResult() {
     var topic = Utils.randomString();
     var leaderSize = 100;
+    var allNodes =
+        List.of(NodeInfo.of(0, "aa", 0), NodeInfo.of(1, "aa", 0), NodeInfo.of(3, "aa", 0));
     var beforeReplicas =
         List.of(
             Replica.builder()
@@ -123,7 +125,7 @@ class BalancerNodeTest extends RequireBrokerCluster {
                 .isPreferredLeader(false)
                 .topic(topic)
                 .partition(0)
-                .nodeInfo(NodeInfo.of(0, "aa", 0))
+                .nodeInfo(allNodes.get(0))
                 .size(leaderSize)
                 .path("/tmp/aaa")
                 .build(),
@@ -132,7 +134,7 @@ class BalancerNodeTest extends RequireBrokerCluster {
                 .isPreferredLeader(true)
                 .topic(topic)
                 .partition(0)
-                .nodeInfo(NodeInfo.of(1, "aa", 0))
+                .nodeInfo(allNodes.get(1))
                 .size(leaderSize)
                 .path("/tmp/bbb")
                 .build());
@@ -143,7 +145,7 @@ class BalancerNodeTest extends RequireBrokerCluster {
                 .isPreferredLeader(false)
                 .topic(topic)
                 .partition(0)
-                .nodeInfo(NodeInfo.of(3, "aa", 0))
+                .nodeInfo(allNodes.get(2))
                 .size(leaderSize)
                 .path("/tmp/ddd")
                 .build(),
@@ -152,7 +154,7 @@ class BalancerNodeTest extends RequireBrokerCluster {
                 .isPreferredLeader(true)
                 .topic(topic)
                 .partition(0)
-                .nodeInfo(NodeInfo.of(1, "aa", 0))
+                .nodeInfo(allNodes.get(1))
                 .size(leaderSize)
                 .path("/tmp/bbb")
                 .build());
@@ -162,7 +164,7 @@ class BalancerNodeTest extends RequireBrokerCluster {
         BalancerNode.assignmentResult(
             beforeClusterInfo,
             new Balancer.Plan(
-                ClusterInfo.of(afterReplicas),
+                ClusterInfo.of(allNodes, afterReplicas),
                 new ReplicaLeaderCost().clusterCost(beforeClusterInfo, ClusterBean.EMPTY),
                 new ReplicaLeaderCost().clusterCost(beforeClusterInfo, ClusterBean.EMPTY),
                 List.of(MoveCost.builder().build())));

--- a/gui/src/test/java/org/astraea/gui/tab/topic/ReplicaNodeTest.java
+++ b/gui/src/test/java/org/astraea/gui/tab/topic/ReplicaNodeTest.java
@@ -135,13 +135,14 @@ public class ReplicaNodeTest extends RequireBrokerCluster {
     var topic = Utils.randomString();
     var partition = 0;
     var leaderSize = 100;
+    var nodes = List.of(NodeInfo.of(0, "aa", 0), NodeInfo.of(1, "aa", 0), NodeInfo.of(2, "aa", 0));
     var replicas =
         List.of(
             Replica.builder()
                 .isLeader(true)
                 .topic(topic)
                 .partition(partition)
-                .nodeInfo(NodeInfo.of(0, "aa", 0))
+                .nodeInfo(nodes.get(0))
                 .size(leaderSize)
                 .path("/tmp/aaa")
                 .build(),
@@ -149,17 +150,17 @@ public class ReplicaNodeTest extends RequireBrokerCluster {
                 .isLeader(false)
                 .topic(topic)
                 .partition(partition)
-                .nodeInfo(NodeInfo.of(1, "aa", 0))
+                .nodeInfo(nodes.get(1))
                 .size(20)
                 .build(),
             Replica.builder()
                 .isLeader(false)
                 .topic(topic)
                 .partition(partition)
-                .nodeInfo(NodeInfo.of(2, "aa", 0))
+                .nodeInfo(nodes.get(2))
                 .size(30)
                 .build());
-    var results = ReplicaNode.allResult(ClusterInfo.of(replicas));
+    var results = ReplicaNode.allResult(ClusterInfo.of(nodes, replicas));
     Assertions.assertEquals(3, results.size());
     Assertions.assertEquals(
         1,


### PR DESCRIPTION
Resolve #1189, #1185.

* 移除 `NodeInfo` 的 `Comparable` 界面
* `ClusterInfo` 內使用 `List` 儲存 `Node`
* `Clusterinfo#of(List)` 移動到 test scope.