### PR TITLE
[CONNECTOR] enable to validate configs

### DIFF
--- a/common/src/main/java/org/astraea/common/connector/Builder.java
+++ b/common/src/main/java/org/astraea/common/connector/Builder.java
@@ -128,6 +128,16 @@ public class Builder {
       }
 
       @Override
+      public CompletionStage<Validation> validate(String name, Map<String, String> configs) {
+        return httpExecutor
+            .put(
+                getURL("/connector-plugins") + "/" + name + "/config/validate",
+                configs,
+                TypeRef.of(Validation.class))
+            .thenApply(Response::body);
+      }
+
+      @Override
       public CompletionStage<Set<PluginInfo>> plugins() {
         return httpExecutor
             .get(getURL("/connector-plugins"), TypeRef.set(PluginInfo.class))

--- a/common/src/main/java/org/astraea/common/connector/Config.java
+++ b/common/src/main/java/org/astraea/common/connector/Config.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.connector;
+
+public class Config {
+  private Definition definition;
+
+  public Definition definition() {
+    return definition;
+  }
+
+  public Value value() {
+    return value;
+  }
+
+  private Value value;
+}

--- a/common/src/main/java/org/astraea/common/connector/ConnectorClient.java
+++ b/common/src/main/java/org/astraea/common/connector/ConnectorClient.java
@@ -55,6 +55,8 @@ public interface ConnectorClient {
 
   CompletionStage<Void> deleteConnector(String name);
 
+  CompletionStage<Validation> validate(String name, Map<String, String> configs);
+
   CompletionStage<Set<PluginInfo>> plugins();
 
   default CompletionStage<Boolean> waitConnectorInfo(

--- a/common/src/main/java/org/astraea/common/connector/Definition.java
+++ b/common/src/main/java/org/astraea/common/connector/Definition.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.connector;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Optional;
+
+public class Definition {
+
+  private String name;
+  private String type;
+  private boolean required;
+
+  @JsonProperty("default_value")
+  private Optional<String> defaultValue = Optional.empty();
+
+  private String importance;
+  private String documentation;
+  private Optional<String> group = Optional.empty();
+  private String width;
+
+  @JsonProperty("display_name")
+  private String displayName;
+
+  private List<String> dependents = List.of();
+  private int order;
+
+  public String name() {
+    return name;
+  }
+
+  public String type() {
+    return type;
+  }
+
+  public boolean required() {
+    return required;
+  }
+
+  public Optional<String> defaultValue() {
+    return defaultValue;
+  }
+
+  public String importance() {
+    return importance;
+  }
+
+  public String documentation() {
+    return documentation;
+  }
+
+  public Optional<String> group() {
+    return group;
+  }
+
+  public String width() {
+    return width;
+  }
+
+  public String displayName() {
+    return displayName;
+  }
+
+  public List<String> dependents() {
+    return dependents;
+  }
+
+  public int order() {
+    return order;
+  }
+}

--- a/common/src/main/java/org/astraea/common/connector/Validation.java
+++ b/common/src/main/java/org/astraea/common/connector/Validation.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.connector;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public class Validation {
+
+  private String name;
+
+  @JsonProperty("error_count")
+  private int errorCount;
+
+  private List<String> groups = List.of();
+  private List<Config> configs = List.of();
+
+  public String name() {
+    return name;
+  }
+
+  public int errorCount() {
+    return errorCount;
+  }
+
+  public List<String> groups() {
+    return groups;
+  }
+
+  public List<Config> configs() {
+    return configs;
+  }
+}

--- a/common/src/main/java/org/astraea/common/connector/Value.java
+++ b/common/src/main/java/org/astraea/common/connector/Value.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.connector;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Optional;
+
+public class Value {
+
+  private String name;
+  private Optional<String> value = Optional.empty();
+
+  @JsonProperty("recommended_values")
+  private List<String> recommendedValues = List.of();
+
+  private List<String> errors = List.of();
+  private boolean visible;
+
+  public String name() {
+    return name;
+  }
+
+  public Optional<String> value() {
+    return value;
+  }
+
+  public List<String> recommendedValues() {
+    return recommendedValues;
+  }
+
+  public List<String> errors() {
+    return errors;
+  }
+
+  public boolean visible() {
+    return visible;
+  }
+}

--- a/common/src/test/java/org/astraea/common/connector/ConnectorClientTest.java
+++ b/common/src/test/java/org/astraea/common/connector/ConnectorClientTest.java
@@ -18,6 +18,7 @@ package org.astraea.common.connector;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -44,6 +45,19 @@ import org.astraea.it.RequireWorkerCluster;
 import org.junit.jupiter.api.Test;
 
 class ConnectorClientTest extends RequireWorkerCluster {
+  @Test
+  void testValidate() {
+    var connectorClient = ConnectorClient.builder().url(workerUrl()).build();
+    var validation =
+        connectorClient
+            .validate(
+                "TestTextSourceConnector",
+                Map.of(
+                    ConnectorClient.CONNECTOR_CLASS_KEY, TestTextSourceConnector.class.getName()))
+            .toCompletableFuture()
+            .join();
+    assertNotEquals(0, validation.errorCount());
+  }
 
   @Test
   void testInfo() {

--- a/common/src/test/java/org/astraea/common/connector/impl/TestTextSourceConnector.java
+++ b/common/src/test/java/org/astraea/common/connector/impl/TestTextSourceConnector.java
@@ -47,7 +47,9 @@ public class TestTextSourceConnector extends SourceConnector {
 
   @Override
   public ConfigDef config() {
-    return new ConfigDef();
+    var config = new ConfigDef();
+    config.define("abc", ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.HIGH, "hi");
+    return config;
   }
 
   @Override


### PR DESCRIPTION
如題，實作 https://docs.confluent.io/platform/current/connect/references/restapi.html#put--connector-plugins-(string-name)-config-validate