### PR TITLE
[CONNECTOR] Fix flaky ConnectorTest#testRunCustomConnector

### DIFF
--- a/connector/src/test/java/org/astraea/connector/ConnectorTest.java
+++ b/connector/src/test/java/org/astraea/connector/ConnectorTest.java
@@ -72,16 +72,17 @@ public class ConnectorTest extends RequireWorkerCluster {
     Utils.sleep(Duration.ofSeconds(3));
     Assertions.assertEquals(
         3, client.connectorInfo(name).toCompletableFuture().join().tasks().size());
-    Assertions.assertEquals(1, MySource.INIT_COUNT.get());
-    Assertions.assertEquals(3, MySourceTask.INIT_COUNT.get());
-    Assertions.assertEquals(0, MySource.CLOSE_COUNT.get());
-    Assertions.assertEquals(0, MySourceTask.CLOSE_COUNT.get());
 
-    // test close
     client.deleteConnector(name).toCompletableFuture().join();
     Utils.sleep(Duration.ofSeconds(3));
-    Assertions.assertEquals(1, MySource.CLOSE_COUNT.get());
-    Assertions.assertEquals(3, MySourceTask.CLOSE_COUNT.get());
+
+    Assertions.assertNotEquals(0, MySource.INIT_COUNT.get());
+    Assertions.assertNotEquals(0, MySourceTask.INIT_COUNT.get());
+    Assertions.assertNotEquals(0, MySource.CLOSE_COUNT.get());
+    Assertions.assertNotEquals(0, MySourceTask.CLOSE_COUNT.get());
+
+    Assertions.assertEquals(MySource.INIT_COUNT.get(), MySource.CLOSE_COUNT.get());
+    Assertions.assertEquals(MySourceTask.INIT_COUNT.get(), MySourceTask.CLOSE_COUNT.get());
   }
 
   public static class MySource extends SourceConnector {


### PR DESCRIPTION
worker re-balance 發生時就會導致測試失敗，因此調整成確認初始化和關閉的次數相同

fix #1225