### PR TITLE
Move score away from zero

### DIFF
--- a/common/src/main/java/org/astraea/common/partitioner/RoundRobin.java
+++ b/common/src/main/java/org/astraea/common/partitioner/RoundRobin.java
@@ -50,6 +50,10 @@ public interface RoundRobin<E> {
     private volatile Map<E, Double> currentScores;
 
     private SmoothRoundRobin(Map<E, Double> scores) {
+      // The effective score should not be zero
+      if (scores.values().stream().anyMatch(score -> score == 0.0)){
+        throw new IllegalArgumentException("Effective score in smooth round-robin should not be zero");
+      }
       this.effectiveScores = Collections.unmodifiableMap(scores);
       this.currentScores =
           scores.keySet().stream()

--- a/common/src/main/java/org/astraea/common/partitioner/RoundRobin.java
+++ b/common/src/main/java/org/astraea/common/partitioner/RoundRobin.java
@@ -51,8 +51,9 @@ public interface RoundRobin<E> {
 
     private SmoothRoundRobin(Map<E, Double> scores) {
       // The effective score should not be zero
-      if (scores.values().stream().anyMatch(score -> score == 0.0)){
-        throw new IllegalArgumentException("Effective score in smooth round-robin should not be zero");
+      if (scores.values().stream().anyMatch(score -> score == 0.0)) {
+        throw new IllegalArgumentException(
+            "Effective score in smooth round-robin should not be zero");
       }
       this.effectiveScores = Collections.unmodifiableMap(scores);
       this.currentScores =

--- a/common/src/main/java/org/astraea/common/partitioner/RoundRobin.java
+++ b/common/src/main/java/org/astraea/common/partitioner/RoundRobin.java
@@ -51,7 +51,7 @@ public interface RoundRobin<E> {
 
     private SmoothRoundRobin(Map<E, Double> scores) {
       // The effective score should not be zero
-      if (scores.values().stream().anyMatch(score -> score == 0.0)) {
+      if (scores.values().stream().anyMatch(score -> score <= 0.0)) {
         throw new IllegalArgumentException(
             "Effective score in smooth round-robin should not be zero");
       }

--- a/common/src/main/java/org/astraea/common/partitioner/StrictCostDispatcher.java
+++ b/common/src/main/java/org/astraea/common/partitioner/StrictCostDispatcher.java
@@ -140,10 +140,13 @@ public class StrictCostDispatcher implements Dispatcher {
    */
   static Map<Integer, Double> costToScore(BrokerCost cost) {
     var max = cost.value().values().stream().max(Double::compare);
+    var min = cost.value().values().stream().min(Double::compare);
     return max.map(
             m ->
                 cost.value().entrySet().stream()
-                    .collect(Collectors.toMap(Map.Entry::getKey, e -> m - e.getValue())))
+                    .collect(
+                        Collectors.toMap(
+                            Map.Entry::getKey, e -> m - e.getValue() + min.orElse(0.0))))
         .orElse(cost.value());
   }
 

--- a/common/src/test/java/org/astraea/common/partitioner/RoundRobinTest.java
+++ b/common/src/test/java/org/astraea/common/partitioner/RoundRobinTest.java
@@ -55,7 +55,7 @@ public class RoundRobinTest {
   }
 
   @Test
-  void testNegativeScore(){
+  void testNegativeScore() {
     var scores = Map.of(0, -1D, 1, 5D);
     Assertions.assertThrows(IllegalArgumentException.class, () -> RoundRobin.smooth(scores));
   }

--- a/common/src/test/java/org/astraea/common/partitioner/RoundRobinTest.java
+++ b/common/src/test/java/org/astraea/common/partitioner/RoundRobinTest.java
@@ -49,7 +49,7 @@ public class RoundRobinTest {
   }
 
   @Test
-  void testZeroScore(){
+  void testZeroScore() {
     var scores = Map.of(0, 0D, 1, 5D);
     Assertions.assertThrows(IllegalArgumentException.class, () -> RoundRobin.smooth(scores));
   }

--- a/common/src/test/java/org/astraea/common/partitioner/RoundRobinTest.java
+++ b/common/src/test/java/org/astraea/common/partitioner/RoundRobinTest.java
@@ -53,4 +53,10 @@ public class RoundRobinTest {
     var scores = Map.of(0, 0D, 1, 5D);
     Assertions.assertThrows(IllegalArgumentException.class, () -> RoundRobin.smooth(scores));
   }
+
+  @Test
+  void testNegativeScore(){
+    var scores = Map.of(0, -1D, 1, 5D);
+    Assertions.assertThrows(IllegalArgumentException.class, () -> RoundRobin.smooth(scores));
+  }
 }

--- a/common/src/test/java/org/astraea/common/partitioner/RoundRobinTest.java
+++ b/common/src/test/java/org/astraea/common/partitioner/RoundRobinTest.java
@@ -47,4 +47,10 @@ public class RoundRobinTest {
     Assertions.assertEquals(Optional.of(1), rr.next(Set.of(0, 1)));
     Assertions.assertEquals(Optional.of(0), rr.next(Set.of(0, 1)));
   }
+
+  @Test
+  void testZeroScore(){
+    var scores = Map.of(0, 0D, 1, 5D);
+    Assertions.assertThrows(IllegalArgumentException.class, () -> RoundRobin.smooth(scores));
+  }
 }


### PR DESCRIPTION
Solve #598 
Kafka Producer metrics 中，`producer-node-metrics` 中的 `request-latency-avg` 會出現 NaN 的原因是，當我們的 `request-latency-avg` 在某一次測到很高的值時，我們的 `StrictCostDispatcher` 會完全不發送資料到該節點上，不發送資料 `request-latency-avg` 就不會更新，所以一直保持在很高的值沒辦法更新。最後超過紀錄的時間區間，然後變成沒有數據 NaN。

這隻 PR 的解決方法是，就由平移計算出來的 broker 分數，來讓 `StrictCostDispatcher` 也有機會選到 cost 最高的 broker。

---

### 實驗

實際跑過以後也沒有觀察到 NaN 的狀況，結果也超乎預期：

以下是實驗環境簡單敘述：

實驗執行軟體

| 執行軟體                 |  B1  |  B2  |  B3  |  C1  |  C2  |  C3  |
| ------------------------ | :--: | :--: | :--: | :--: | :--: | :--: |
| Zookeeper                |  V   |      |      |      |      |      |
| Kakfa Broker             |  V   |  V   |  V   |     |     |      |
| Node Exporter            |  V   |  V   |  V   |     |     |      |
| Prometheus               |      |      |   V   |      |     |      |
| Grafana                  |      |      |   V   |      |     |      |
| Astraea Performance tool |      |      |      |   V   |   V   |  V   |

實驗開了 3 個 topic，各有 36 個 partitions，partition 分佈不平均。
topic partition 分佈

| # of partitions | B1   | B2   | B3   |
| --------------- | ---- | ---- | ---- |
| testing-1       | 22   | 10   | 4    |
| testing-2       | 16   | 16   | 4    |
| testing-3       | 12   | 12   | 12   |

(B1 持有較多的 partition，B2 次多，B3 最少)

---

實驗執行 3 次分別跑 `StrictCostDispatcher`、`BuiltInPartitioner`、以及按 key 發送的 `DefaultPartitioner`。

![2022-12-09_12-51](https://user-images.githubusercontent.com/26920893/206630334-f41cd750-efae-4be2-a685-e66bb83daff9.png)

這張圖是按 broker 來繪製的，x 軸是時間，y 軸是 broker 內 topic 大小增加的速率。
結果不會像之前 "一段時間都避開某節點，最後出現 NaN" 的情況。

