### PR TITLE
Implement query cache mechanism for `ClusterBean#*Metrics()`

### DIFF
--- a/common/src/main/java/org/astraea/common/admin/ClusterBean.java
+++ b/common/src/main/java/org/astraea/common/admin/ClusterBean.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -70,14 +71,94 @@ public interface ClusterBean {
                             entry -> (Collection<HasBeanObject>) entry.getValue())));
 
     return new ClusterBean() {
+      final Map<Class<? extends HasBeanObject>, Lazy<Map<?, ?>>> topicCache =
+          new ConcurrentHashMap<>();
+      final Map<Class<? extends HasBeanObject>, Lazy<Map<?, ?>>> topicPartitionCache =
+          new ConcurrentHashMap<>();
+      final Map<Class<? extends HasBeanObject>, Lazy<Map<?, ?>>> topicPartitionReplicaCache =
+          new ConcurrentHashMap<>();
+      final Map<Class<? extends HasBeanObject>, Lazy<Map<?, ?>>> brokerTopicCache =
+          new ConcurrentHashMap<>();
+
       @Override
       public Map<Integer, Collection<HasBeanObject>> all() {
         return Collections.unmodifiableMap(allBeans);
       }
 
+      @SuppressWarnings("unchecked")
+      @Override
+      public <Bean extends HasBeanObject> Stream<Bean> topicMetrics(
+          String topic, Class<Bean> metricClass) {
+        return ((Map<String, List<Bean>>)
+                topicCache
+                    .computeIfAbsent(
+                        metricClass, (m) -> Lazy.of(() -> map(m, (id, bean) -> bean.topicIndex())))
+                    .get())
+            .getOrDefault(topic, List.of()).stream();
+      }
+
+      @SuppressWarnings("unchecked")
+      @Override
+      public <Bean extends HasBeanObject> Stream<Bean> partitionMetrics(
+          TopicPartition topicPartition, Class<Bean> metricClass) {
+        return ((Map<TopicPartition, List<Bean>>)
+                topicPartitionCache
+                    .computeIfAbsent(
+                        metricClass,
+                        (m) -> Lazy.of(() -> map(m, (id, bean) -> bean.partitionIndex())))
+                    .get())
+            .getOrDefault(topicPartition, List.of()).stream();
+      }
+
+      @SuppressWarnings("unchecked")
+      @Override
+      public <Bean extends HasBeanObject> Stream<Bean> replicaMetrics(
+          TopicPartitionReplica replica, Class<Bean> metricClass) {
+        return ((Map<TopicPartitionReplica, List<Bean>>)
+                topicPartitionReplicaCache
+                    .computeIfAbsent(
+                        metricClass,
+                        (m) -> Lazy.of(() -> map(m, (id, bean) -> bean.replicaIndex(id))))
+                    .get())
+            .getOrDefault(replica, List.of()).stream();
+      }
+
+      @SuppressWarnings("unchecked")
+      @Override
+      public <Bean extends HasBeanObject> Stream<Bean> brokerTopicMetrics(
+          BrokerTopic brokerTopic, Class<Bean> metricClass) {
+        return ((Map<BrokerTopic, List<Bean>>)
+                brokerTopicCache
+                    .computeIfAbsent(
+                        metricClass,
+                        (m) -> Lazy.of(() -> map(m, (id, bean) -> bean.brokerTopicIndex(id))))
+                    .get())
+            .getOrDefault(brokerTopic, List.of()).stream();
+      }
+
       @Override
       public Map<TopicPartitionReplica, Collection<HasBeanObject>> mapByReplica() {
         return lazyReplica.get();
+      }
+
+      private <Bean extends HasBeanObject, Key> Map<Key, List<Bean>> map(
+          Class<Bean> metricClass, BiFunction<Integer, Bean, Optional<Key>> keyMapper) {
+        return all().entrySet().stream()
+            .flatMap(
+                e ->
+                    e.getValue().stream()
+                        .filter(bean -> bean.getClass() == metricClass)
+                        .map(metricClass::cast)
+                        .flatMap(
+                            bean ->
+                                keyMapper
+                                    .apply(e.getKey(), bean)
+                                    .map(key -> Map.entry(key, bean))
+                                    .stream()))
+            .collect(
+                Collectors.groupingBy(
+                    Map.Entry::getKey,
+                    Collectors.mapping(Map.Entry::getValue, Collectors.toUnmodifiableList())));
       }
     };
   }
@@ -95,67 +176,83 @@ public interface ClusterBean {
    */
   Map<TopicPartitionReplica, Collection<HasBeanObject>> mapByReplica();
 
-  private <Bean extends HasBeanObject, Key> Map<Key, List<Bean>> map(
-      Class<Bean> metricClass, BiFunction<Integer, Bean, Optional<Key>> keyMapper) {
-    return all().entrySet().stream()
-        .flatMap(
-            e ->
-                e.getValue().stream()
-                    .filter(bean -> bean.getClass() == metricClass)
-                    .map(metricClass::cast)
-                    .flatMap(
-                        bean ->
-                            keyMapper
-                                .apply(e.getKey(), bean)
-                                .map(key -> Map.entry(key, bean))
-                                .stream()))
-        .collect(
-            Collectors.groupingBy(
-                Map.Entry::getKey,
-                Collectors.mapping(Map.Entry::getValue, Collectors.toUnmodifiableList())));
-  }
+  /**
+   * Query a specific class of metric where they are from the specified topic.
+   *
+   * @param topic to query.
+   * @param metricClass to query.
+   * @return a stream of the matched metrics.
+   * @param <Bean> the metric to query.
+   */
+  <Bean extends HasBeanObject> Stream<Bean> topicMetrics(String topic, Class<Bean> metricClass);
 
+  /**
+   * Query a specific class of metric where they are from the specified partition.
+   *
+   * @param topicPartition to query.
+   * @param metricClass to query.
+   * @return a stream of the matched metrics.
+   * @param <Bean> the metric to query.
+   */
+  <Bean extends HasBeanObject> Stream<Bean> partitionMetrics(
+      TopicPartition topicPartition, Class<Bean> metricClass);
+
+  /**
+   * Query a specific class of metric where they are from the specified replica.
+   *
+   * @param replica to query.
+   * @param metricClass to query.
+   * @return a stream of the matched metrics.
+   * @param <Bean> the metric to query.
+   */
+  <Bean extends HasBeanObject> Stream<Bean> replicaMetrics(
+      TopicPartitionReplica replica, Class<Bean> metricClass);
+
+  /**
+   * Query a specific class of metric where they are sampled from the specific broker and are
+   * related to a specific topic.
+   *
+   * @param brokerTopic to query.
+   * @param metricClass to query.
+   * @return a stream of the matched metrics.
+   * @param <Bean> the metric to query.
+   */
+  <Bean extends HasBeanObject> Stream<Bean> brokerTopicMetrics(
+      BrokerTopic brokerTopic, Class<Bean> metricClass);
+
+  /**
+   * @return the set of topic that has some related metrics within the internal storage.
+   */
   default Set<String> topics() {
     return all().values().stream()
         .flatMap(bs -> bs.stream().flatMap(b -> b.topicIndex().stream()))
         .collect(Collectors.toUnmodifiableSet());
   }
 
+  /**
+   * @return the set of partition that has some related metrics within the internal storage.
+   */
   default Set<TopicPartition> partitions() {
     return all().values().stream()
         .flatMap(bs -> bs.stream().flatMap(b -> b.partitionIndex().stream()))
         .collect(Collectors.toUnmodifiableSet());
   }
 
+  /**
+   * @return the set of replicas that has some related metrics within the internal storage.
+   */
   default Set<TopicPartitionReplica> replicas() {
     return all().entrySet().stream()
         .flatMap(e -> e.getValue().stream().flatMap(b -> b.replicaIndex(e.getKey()).stream()))
         .collect(Collectors.toUnmodifiableSet());
   }
 
+  /**
+   * @return the set of broker/topic pair that has some related metrics within the internal storage.
+   */
   default Set<BrokerTopic> brokerTopics() {
     return all().entrySet().stream()
         .flatMap(e -> e.getValue().stream().flatMap(b -> b.brokerTopicIndex(e.getKey()).stream()))
         .collect(Collectors.toUnmodifiableSet());
-  }
-
-  default <Bean extends HasBeanObject> Stream<Bean> topicMetrics(
-      String topic, Class<Bean> metricClass) {
-    return map(metricClass, (id, bean) -> bean.topicIndex()).get(topic).stream();
-  }
-
-  default <Bean extends HasBeanObject> Stream<Bean> partitionMetrics(
-      TopicPartition topicPartition, Class<Bean> metricClass) {
-    return map(metricClass, (id, bean) -> bean.partitionIndex()).get(topicPartition).stream();
-  }
-
-  default <Bean extends HasBeanObject> Stream<Bean> replicaMetrics(
-      TopicPartitionReplica replica, Class<Bean> metricClass) {
-    return map(metricClass, (id, bean) -> bean.replicaIndex(id)).get(replica).stream();
-  }
-
-  default <Bean extends HasBeanObject> Stream<Bean> brokerTopicMetrics(
-      BrokerTopic brokerTopic, Class<Bean> metricClass) {
-    return map(metricClass, (id, bean) -> bean.brokerTopicIndex(id)).get(brokerTopic).stream();
   }
 }

--- a/common/src/main/java/org/astraea/common/admin/ClusterBean.java
+++ b/common/src/main/java/org/astraea/common/admin/ClusterBean.java
@@ -80,6 +80,26 @@ public interface ClusterBean {
             .map(metricClass::cast);
       }
 
+      @Override
+      public Set<String> topics() {
+        return topicCache.get().keySet();
+      }
+
+      @Override
+      public Set<TopicPartition> partitions() {
+        return partitionCache.get().keySet();
+      }
+
+      @Override
+      public Set<TopicPartitionReplica> replicas() {
+        return replicaCache.get().keySet();
+      }
+
+      @Override
+      public Set<BrokerTopic> brokerTopics() {
+        return brokerTopicCache.get().keySet();
+      }
+
       private <Key> Map<Key, List<HasBeanObject>> map(
           BiFunction<Integer, HasBeanObject, Optional<Key>> keyMapper) {
         return all().entrySet().stream()
@@ -153,36 +173,20 @@ public interface ClusterBean {
   /**
    * @return the set of topic that has some related metrics within the internal storage.
    */
-  default Set<String> topics() {
-    return all().values().stream()
-        .flatMap(bs -> bs.stream().flatMap(b -> b.topicIndex().stream()))
-        .collect(Collectors.toUnmodifiableSet());
-  }
+  Set<String> topics();
 
   /**
    * @return the set of partition that has some related metrics within the internal storage.
    */
-  default Set<TopicPartition> partitions() {
-    return all().values().stream()
-        .flatMap(bs -> bs.stream().flatMap(b -> b.partitionIndex().stream()))
-        .collect(Collectors.toUnmodifiableSet());
-  }
+  Set<TopicPartition> partitions();
 
   /**
    * @return the set of replicas that has some related metrics within the internal storage.
    */
-  default Set<TopicPartitionReplica> replicas() {
-    return all().entrySet().stream()
-        .flatMap(e -> e.getValue().stream().flatMap(b -> b.replicaIndex(e.getKey()).stream()))
-        .collect(Collectors.toUnmodifiableSet());
-  }
+  Set<TopicPartitionReplica> replicas();
 
   /**
    * @return the set of broker/topic pair that has some related metrics within the internal storage.
    */
-  default Set<BrokerTopic> brokerTopics() {
-    return all().entrySet().stream()
-        .flatMap(e -> e.getValue().stream().flatMap(b -> b.brokerTopicIndex(e.getKey()).stream()))
-        .collect(Collectors.toUnmodifiableSet());
-  }
+  Set<BrokerTopic> brokerTopics();
 }

--- a/common/src/test/java/org/astraea/common/admin/ClusterBeanTest.java
+++ b/common/src/test/java/org/astraea/common/admin/ClusterBeanTest.java
@@ -34,6 +34,7 @@ import org.astraea.common.metrics.broker.LogMetrics;
 import org.astraea.common.metrics.broker.ServerMetrics;
 import org.astraea.common.metrics.platform.JvmMemory;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 class ClusterBeanTest {
@@ -173,7 +174,7 @@ class ClusterBeanTest {
           .flatMap(Collection::stream)
           .collect(Collectors.toUnmodifiableSet());
 
-  @Test
+  @RepeatedTest(5)
   void testMetricQuery() {
     // test index lookup
     var allTopicIndex =

--- a/common/src/test/java/org/astraea/common/admin/ClusterBeanTest.java
+++ b/common/src/test/java/org/astraea/common/admin/ClusterBeanTest.java
@@ -103,11 +103,6 @@ class ClusterBeanTest {
     Assertions.assertEquals(2, clusterBean.all().size());
     Assertions.assertEquals(1, clusterBean.all().get(1).size());
     Assertions.assertEquals(3, clusterBean.all().get(2).size());
-
-    // test get beanObject by replica
-    Assertions.assertEquals(2, clusterBean.mapByReplica().size());
-    Assertions.assertEquals(
-        2, clusterBean.mapByReplica().get(TopicPartitionReplica.of("testBeans", 0, 2)).size());
   }
 
   static List<String> fakeTopics =


### PR DESCRIPTION
Context: https://github.com/skiptests/astraea/pull/1215#discussion_r1041251610

* 給 `ClusterBean#*Metrics()` 的查詢方法實作快取機制。
* 給查詢方法添加測試
* 透過 `ClusterBean#replicaMetrics()` 取代 `ClusterBean#mapByReplica()`