### PR TITLE
Apply BrokerTopic to ClusterInfo

### DIFF
--- a/common/src/main/java/org/astraea/common/partitioner/StrictCostDispatcher.java
+++ b/common/src/main/java/org/astraea/common/partitioner/StrictCostDispatcher.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.astraea.common.Configuration;
 import org.astraea.common.Utils;
+import org.astraea.common.admin.BrokerTopic;
 import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.ReplicaInfo;
@@ -112,7 +113,8 @@ public class StrictCostDispatcher implements Dispatcher {
             next.getAndUpdate(previous -> previous >= roundRobin.length - 1 ? 0 : previous + 1)];
 
     // TODO: if the topic partitions are existent in fewer brokers, the target gets -1 in most cases
-    var candidate = target < 0 ? partitionLeaders : clusterInfo.replicaLeaders(target, topic);
+    var candidate =
+        target < 0 ? partitionLeaders : clusterInfo.replicaLeaders(BrokerTopic.of(target, topic));
     candidate = candidate.isEmpty() ? partitionLeaders : candidate;
     return candidate.get((int) (Math.random() * candidate.size())).partition();
   }

--- a/common/src/test/java/org/astraea/common/admin/ClusterInfoTest.java
+++ b/common/src/test/java/org/astraea/common/admin/ClusterInfoTest.java
@@ -285,7 +285,7 @@ public class ClusterInfoTest {
     Assertions.assertNotEquals(0, maskedClusterInfoHasReplicas.replicas().size());
     Assertions.assertEquals(0, maskedClusterInfoNoReplicas.replicas().size());
 
-    Assertions.assertNotEquals(0, clusterInfo.replicaLeaders(0, "test-1").size());
+    Assertions.assertNotEquals(0, clusterInfo.replicaLeaders(BrokerTopic.of(0, "test-1")).size());
   }
 
   @Test

--- a/common/src/test/java/org/astraea/common/cost/ClusterInfoIntegratedTest.java
+++ b/common/src/test/java/org/astraea/common/cost/ClusterInfoIntegratedTest.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.Optional;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
+import org.astraea.common.admin.BrokerTopic;
 import org.astraea.it.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -72,7 +73,10 @@ public class ClusterInfoIntegratedTest extends RequireBrokerCluster {
           .forEach(t -> Assertions.assertNotEquals(0, clusterInfo.replicaLeaders(t).size()));
       clusterInfo
           .topics()
-          .forEach(t -> Assertions.assertNotEquals(0, clusterInfo.replicaLeaders(0, t).size()));
+          .forEach(
+              t ->
+                  Assertions.assertNotEquals(
+                      0, clusterInfo.replicaLeaders(BrokerTopic.of(0, t)).size()));
 
       Assertions.assertNotEquals(0, clusterInfo.replicaLeaders().size());
     }


### PR DESCRIPTION
#1215 引入了新的資料結構 `BrokerTopic`，這可以取代原本的`Map.Entry<Integer, String>`