### PR TITLE
Move MBeanRegister from org.astraea.common.metrics.jmx to org.astraea…

### DIFF
--- a/common/src/main/java/org/astraea/common/balancer/algorithms/GreedyBalancer.java
+++ b/common/src/main/java/org/astraea/common/balancer/algorithms/GreedyBalancer.java
@@ -32,7 +32,7 @@ import org.astraea.common.admin.Replica;
 import org.astraea.common.balancer.Balancer;
 import org.astraea.common.balancer.tweakers.ShuffleTweaker;
 import org.astraea.common.cost.ClusterCost;
-import org.astraea.common.metrics.jmx.MBeanRegister;
+import org.astraea.common.metrics.MBeanRegister;
 
 /**
  * A single-state hill-climbing algorithm. It discovers rebalance solution by tweaking the cluster

--- a/common/src/main/java/org/astraea/common/metrics/MBeanRegister.java
+++ b/common/src/main/java/org/astraea/common/metrics/MBeanRegister.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.astraea.common.metrics.jmx;
+package org.astraea.common.metrics;
 
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;

--- a/common/src/test/java/org/astraea/common/metrics/MBeanRegisterTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/MBeanRegisterTest.java
@@ -19,7 +19,6 @@ package org.astraea.common.metrics;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Supplier;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/common/src/test/java/org/astraea/common/metrics/MBeanRegisterTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/MBeanRegisterTest.java
@@ -14,14 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.astraea.common.metrics.jmx;
+package org.astraea.common.metrics;
 
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Supplier;
-import org.astraea.common.metrics.BeanObject;
-import org.astraea.common.metrics.BeanQuery;
-import org.astraea.common.metrics.MBeanClient;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
將 metrics client 的兩個互動元件 (`MBeanRegister` and `MBeanClient`) 放在一起