### PR TITLE
Reame `Dispersion#correlationCoefficient` to `Dispersion#cov`

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/BrokerInputCost.java
+++ b/common/src/main/java/org/astraea/common/cost/BrokerInputCost.java
@@ -28,7 +28,7 @@ import org.astraea.common.metrics.broker.ServerMetrics;
 import org.astraea.common.metrics.collector.Fetcher;
 
 public class BrokerInputCost implements HasBrokerCost, HasClusterCost {
-  private final Dispersion dispersion = Dispersion.correlationCoefficient();
+  private final Dispersion dispersion = Dispersion.cov();
 
   @Override
   public BrokerCost brokerCost(

--- a/common/src/main/java/org/astraea/common/cost/BrokerOutputCost.java
+++ b/common/src/main/java/org/astraea/common/cost/BrokerOutputCost.java
@@ -28,7 +28,7 @@ import org.astraea.common.metrics.broker.ServerMetrics;
 import org.astraea.common.metrics.collector.Fetcher;
 
 public class BrokerOutputCost implements HasBrokerCost, HasClusterCost {
-  private final Dispersion dispersion = Dispersion.correlationCoefficient();
+  private final Dispersion dispersion = Dispersion.cov();
 
   @Override
   public BrokerCost brokerCost(

--- a/common/src/main/java/org/astraea/common/cost/Dispersion.java
+++ b/common/src/main/java/org/astraea/common/cost/Dispersion.java
@@ -21,13 +21,22 @@ import java.util.Collection;
 /** Aggregate a sequence into a number */
 @FunctionalInterface
 public interface Dispersion {
-  /** Apply coefficient of variation to a series of values. */
+  /**
+   * Apply coefficient of variation to a series of values.
+   *
+   * <p>This implementation come with some assumption:
+   *
+   * <ul>
+   *   <li>If no number was given, then the cov is zero.
+   *   <li>If all numbers are zero, then the cov is zero.
+   * </ul>
+   */
   static Dispersion cov() {
     return numbers -> {
-      if (numbers.isEmpty()) throw new ArithmeticException("No number was given");
+      if (numbers.isEmpty()) return 0;
       var numSummary = numbers.stream().mapToDouble(Number::doubleValue).summaryStatistics();
       if (numSummary.getAverage() == 0) {
-        if (numSummary.getMax() == numSummary.getMin()) return 0;
+        if (numSummary.getMax() == 0 && numSummary.getMin() == 0) return 0;
         else
           throw new ArithmeticException(
               "Coefficient of variation has no definition with zero average");

--- a/common/src/main/java/org/astraea/common/cost/Dispersion.java
+++ b/common/src/main/java/org/astraea/common/cost/Dispersion.java
@@ -33,14 +33,15 @@ public interface Dispersion {
    */
   static Dispersion cov() {
     return numbers -> {
+      // special case: no number
       if (numbers.isEmpty()) return 0;
       var numSummary = numbers.stream().mapToDouble(Number::doubleValue).summaryStatistics();
-      if (numSummary.getAverage() == 0) {
-        if (numSummary.getMax() == 0 && numSummary.getMin() == 0) return 0;
-        else
-          throw new ArithmeticException(
-              "Coefficient of variation has no definition with zero average");
-      }
+      // special case: all value zero
+      if (numSummary.getMax() == 0 && numSummary.getMin() == 0) return 0;
+      // special case: zero average, no cov defined here
+      if (numSummary.getAverage() == 0)
+        throw new ArithmeticException(
+            "Coefficient of variation has no definition with zero average");
       var numVariance =
           numbers.stream()
               .mapToDouble(Number::doubleValue)

--- a/common/src/main/java/org/astraea/common/cost/Dispersion.java
+++ b/common/src/main/java/org/astraea/common/cost/Dispersion.java
@@ -18,30 +18,36 @@ package org.astraea.common.cost;
 
 import java.util.Collection;
 
-/** used to aggregate a sequence into a number */
+/** Aggregate a sequence into a number */
+@FunctionalInterface
 public interface Dispersion {
-  /**
-   * use correlation coefficient to a aggregate a sequence * @return correlation coefficient
-   * Dispersion
-   */
-  static Dispersion correlationCoefficient() {
-    return brokerCost -> {
-      if (brokerCost.size() == 0) return 0;
-      var dataRateMean = brokerCost.stream().mapToDouble(x -> x).sum() / brokerCost.size();
-      if (dataRateMean == 0) return 0;
-      var dataRateSD =
-          Math.sqrt(
-              brokerCost.stream().mapToDouble(score -> Math.pow((score - dataRateMean), 2)).sum()
-                  / brokerCost.size());
-      return dataRateSD / dataRateMean;
+  /** Apply coefficient of variation to a series of values. */
+  static Dispersion cov() {
+    return numbers -> {
+      if (numbers.isEmpty()) throw new ArithmeticException("No number was given");
+      var numSummary = numbers.stream().mapToDouble(Number::doubleValue).summaryStatistics();
+      if (numSummary.getAverage() == 0) {
+        if (numSummary.getMax() == numSummary.getMin()) return 0;
+        else
+          throw new ArithmeticException(
+              "Coefficient of variation has no definition with zero average");
+      }
+      var numVariance =
+          numbers.stream()
+              .mapToDouble(Number::doubleValue)
+              .map(score -> score - numSummary.getAverage())
+              .map(score -> score * score)
+              .summaryStatistics()
+              .getAverage();
+      return Math.sqrt(numVariance) / numSummary.getAverage();
     };
   }
 
   /**
-   * aggregated the values into a number
+   * Processing a series of values via a specific statistics method.
    *
    * @param scores origin data
    * @return aggregated data
    */
-  double calculate(Collection<Double> scores);
+  double calculate(Collection<? extends Number> scores);
 }

--- a/common/src/main/java/org/astraea/common/cost/ReplicaLeaderCost.java
+++ b/common/src/main/java/org/astraea/common/cost/ReplicaLeaderCost.java
@@ -34,7 +34,7 @@ import org.astraea.common.metrics.collector.Fetcher;
 
 /** more replica leaders -> higher cost */
 public class ReplicaLeaderCost implements HasBrokerCost, HasClusterCost, HasMoveCost.Helper {
-  private final Dispersion dispersion = Dispersion.correlationCoefficient();
+  private final Dispersion dispersion = Dispersion.cov();
   public static final String COST_NAME = "leader";
 
   @Override

--- a/common/src/main/java/org/astraea/common/cost/ReplicaSizeCost.java
+++ b/common/src/main/java/org/astraea/common/cost/ReplicaSizeCost.java
@@ -34,7 +34,7 @@ import org.astraea.common.metrics.collector.Fetcher;
 
 public class ReplicaSizeCost
     implements HasMoveCost, HasBrokerCost, HasClusterCost, HasPartitionCost {
-  private final Dispersion dispersion = Dispersion.correlationCoefficient();
+  private final Dispersion dispersion = Dispersion.cov();
   public static final String COST_NAME = "size";
 
   /**

--- a/common/src/test/java/org/astraea/common/cost/DispersionTest.java
+++ b/common/src/test/java/org/astraea/common/cost/DispersionTest.java
@@ -24,7 +24,7 @@ class DispersionTest {
 
   @Test
   void testCorrelationCoefficient() {
-    var dispersion = Dispersion.correlationCoefficient();
+    var dispersion = Dispersion.cov();
     var scores = List.of(0.2, 0.4, 0.7);
     Assertions.assertEquals(0.47418569253607507, dispersion.calculate(scores));
 

--- a/common/src/test/java/org/astraea/common/cost/ReplicaLeaderCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/ReplicaLeaderCostTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class ReplicaLeaderCostTest {
-  private final Dispersion dispersion = Dispersion.correlationCoefficient();
+  private final Dispersion dispersion = Dispersion.cov();
 
   @Test
   void testNoMetrics() {


### PR DESCRIPTION
`Dispersion#correlationCoefficient` 的名稱看上去裡面的實作是[相關係數(correlation coefficient)](https://zh.wikipedia.org/zh-tw/%E7%9A%AE%E5%B0%94%E9%80%8A%E7%A7%AF%E7%9F%A9%E7%9B%B8%E5%85%B3%E7%B3%BB%E6%95%B0)，但實際上是[變異係數(coefficient of variation)](https://zh.wikipedia.org/zh-tw/%E5%8F%98%E5%BC%82%E7%B3%BB%E6%95%B0)，這個 PR 把名字改正。