### PR TITLE
`ClusterBean` query metrics should check all subClass

### DIFF
--- a/common/src/main/java/org/astraea/common/admin/ClusterBean.java
+++ b/common/src/main/java/org/astraea/common/admin/ClusterBean.java
@@ -60,7 +60,7 @@ public interface ClusterBean {
       public <Bean extends HasBeanObject> Stream<Bean> partitionMetrics(
           TopicPartition topicPartition, Class<Bean> metricClass) {
         return partitionCache.get().getOrDefault(topicPartition, List.of()).stream()
-            .filter(bean -> bean.getClass() == metricClass)
+            .filter(bean -> metricClass.isAssignableFrom(bean.getClass()))
             .map(metricClass::cast);
       }
 
@@ -68,7 +68,7 @@ public interface ClusterBean {
       public <Bean extends HasBeanObject> Stream<Bean> replicaMetrics(
           TopicPartitionReplica replica, Class<Bean> metricClass) {
         return replicaCache.get().getOrDefault(replica, List.of()).stream()
-            .filter(bean -> bean.getClass() == metricClass)
+            .filter(bean -> metricClass.isAssignableFrom(bean.getClass()))
             .map(metricClass::cast);
       }
 
@@ -76,7 +76,7 @@ public interface ClusterBean {
       public <Bean extends HasBeanObject> Stream<Bean> brokerTopicMetrics(
           BrokerTopic brokerTopic, Class<Bean> metricClass) {
         return brokerTopicCache.get().getOrDefault(brokerTopic, List.of()).stream()
-            .filter(bean -> bean.getClass() == metricClass)
+            .filter(bean -> metricClass.isAssignableFrom(bean.getClass()))
             .map(metricClass::cast);
       }
 

--- a/common/src/main/java/org/astraea/common/admin/ClusterBean.java
+++ b/common/src/main/java/org/astraea/common/admin/ClusterBean.java
@@ -52,7 +52,7 @@ public interface ClusterBean {
       public <Bean extends HasBeanObject> Stream<Bean> topicMetrics(
           String topic, Class<Bean> metricClass) {
         return topicCache.get().getOrDefault(topic, List.of()).stream()
-            .filter(bean -> bean.getClass() == metricClass)
+            .filter(bean -> metricClass.isAssignableFrom(bean.getClass()))
             .map(metricClass::cast);
       }
 

--- a/common/src/test/java/org/astraea/common/admin/ClusterBeanTest.java
+++ b/common/src/test/java/org/astraea/common/admin/ClusterBeanTest.java
@@ -174,8 +174,37 @@ class ClusterBeanTest {
           .flatMap(Collection::stream)
           .collect(Collectors.toUnmodifiableSet());
 
+  private interface FakeJVMBean extends HasBeanObject {}
+
   @RepeatedTest(5)
   void testMetricQuery() {
+
+    // test check class
+    FakeJVMBean cost =
+        () ->
+            new BeanObject(
+                "",
+                Map.of("type", "Log", "topic", "t", "partition", "0", "name", "Size"),
+                Map.of());
+    var testCheckClass = ClusterBean.of(Map.of(0, List.of(cost)));
+    var tm = testCheckClass.topicMetrics("t", HasBeanObject.class).collect(Collectors.toList());
+    var pm =
+        testCheckClass
+            .partitionMetrics(TopicPartition.of("t", 0), HasBeanObject.class)
+            .collect(Collectors.toList());
+    var rm =
+        testCheckClass
+            .replicaMetrics(TopicPartitionReplica.of("t", 0, 0), HasBeanObject.class)
+            .collect(Collectors.toList());
+    var bm =
+        testCheckClass
+            .brokerTopicMetrics(BrokerTopic.of(0, "t"), HasBeanObject.class)
+            .collect(Collectors.toList());
+    Assertions.assertTrue(tm.size() != 0);
+    Assertions.assertTrue(pm.size() != 0);
+    Assertions.assertTrue(rm.size() != 0);
+    Assertions.assertTrue(bm.size() != 0);
+
     // test index lookup
     var allTopicIndex =
         allMetrics.stream()


### PR DESCRIPTION
slove [comment](https://github.com/skiptests/astraea/pull/1241#discussion_r1045209694)，`ClusterBean`在query指定類別的bean時，也應該檢查該類別的subClass