### PR TITLE
Provide descriptive text in `HasClusterCost#of()#toString()`

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/CostFunction.java
+++ b/common/src/main/java/org/astraea/common/cost/CostFunction.java
@@ -37,6 +37,9 @@ import org.astraea.common.metrics.collector.MetricSensor;
  * {@link NoSufficientMetricsException} from the calculation logic of {@link HasBrokerCost} or
  * {@link HasClusterCost}. This serves as a hint to the caller that it needs newer metrics and
  * please retry later.
+ *
+ * <p>Also, it is recommended to override {@link Object#toString()} to provide the descriptive text
+ * along the cost function instance. This information might be shown on some user interfaces.
  */
 public interface CostFunction {
 

--- a/common/src/main/java/org/astraea/common/cost/HasClusterCost.java
+++ b/common/src/main/java/org/astraea/common/cost/HasClusterCost.java
@@ -17,8 +17,10 @@
 package org.astraea.common.cost;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import org.astraea.common.admin.ClusterBean;
 import org.astraea.common.admin.ClusterInfo;
@@ -61,6 +63,21 @@ public interface HasClusterCost extends CostFunction {
       @Override
       public Collection<MetricSensor> sensors() {
         return sensors;
+      }
+
+      @Override
+      public String toString() {
+        BiFunction<HasClusterCost, Double, String> descriptiveName =
+            (cost, value) -> "{\"" + cost.toString() + "\" weight " + value + "}";
+        return "WeightCompositeClusterCost["
+            + costAndWeight.entrySet().stream()
+                .sorted(
+                    Comparator.<Map.Entry<HasClusterCost, Double>>comparingDouble(
+                            Map.Entry::getValue)
+                        .reversed())
+                .map(e -> descriptiveName.apply(e.getKey(), e.getValue()))
+                .collect(Collectors.joining(", "))
+            + "]";
       }
     };
   }

--- a/common/src/test/java/org/astraea/common/cost/ClusterCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/ClusterCostTest.java
@@ -18,7 +18,11 @@ package org.astraea.common.cost;
 
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
+import org.astraea.common.admin.ClusterBean;
+import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.admin.Replica;
 import org.astraea.common.metrics.MBeanClient;
 import org.astraea.common.metrics.broker.LogMetrics;
 import org.astraea.common.metrics.broker.ServerMetrics;
@@ -67,5 +71,65 @@ class ClusterCostTest extends RequireSingleBrokerCluster {
                         .properties()
                         .get("name")
                         .equals(ServerMetrics.ReplicaManager.LEADER_COUNT.metricName())));
+  }
+
+  @Test
+  void testToString() {
+    var randomName0 = "CostFunction_" + Utils.randomString();
+    var randomName1 = "CostFunction_" + Utils.randomString();
+    var randomName2 = "CostFunction_" + Utils.randomString();
+    var cost0 =
+        new HasClusterCost() {
+          @Override
+          public ClusterCost clusterCost(
+              ClusterInfo<Replica> clusterInfo, ClusterBean clusterBean) {
+            return null;
+          }
+
+          @Override
+          public String toString() {
+            return randomName0;
+          }
+        };
+    var cost1 =
+        new HasClusterCost() {
+          @Override
+          public ClusterCost clusterCost(
+              ClusterInfo<Replica> clusterInfo, ClusterBean clusterBean) {
+            return null;
+          }
+
+          @Override
+          public String toString() {
+            return randomName1;
+          }
+        };
+    var cost2 =
+        new HasClusterCost() {
+          @Override
+          public ClusterCost clusterCost(
+              ClusterInfo<Replica> clusterInfo, ClusterBean clusterBean) {
+            return null;
+          }
+
+          @Override
+          public String toString() {
+            return randomName2;
+          }
+        };
+    var compositeCost =
+        HasClusterCost.of(
+            Map.of(
+                cost0, 1.0,
+                cost1, 2.0,
+                cost2, 3.0));
+
+    System.out.println(compositeCost);
+    Assertions.assertTrue(compositeCost.toString().contains(randomName0));
+    Assertions.assertTrue(compositeCost.toString().contains(randomName1));
+    Assertions.assertTrue(compositeCost.toString().contains(randomName2));
+    Assertions.assertTrue(compositeCost.toString().contains("1.0"));
+    Assertions.assertTrue(compositeCost.toString().contains("2.0"));
+    Assertions.assertTrue(compositeCost.toString().contains("3.0"));
   }
 }


### PR DESCRIPTION
Resolve #1134.

現在 BalancerHandler 吐出來的 function 欄位都是 HasClusterCost 預設的 toString 內容，目前裡面的資訊不包含優化算法的細節，這個 PR 嘗試 override `HasClusterCost#of()` 吐出來的 `Object#toString()`，在裡面提供一些和優化目標有關的文字資訊。

如 `WeightCompositeClusterCost[{"org.astraea.common.cost.ReplicaLeaderCost@24b03118" weight 1.0}, {"org.astraea.common.cost.ReplicaSizeCost@4324ac4e" weight 1.0}]`

## Balancer Post Request

```
http://localhost:8001/balancer/ff897675-d061-431e-9255-ea6b28256249
POST http://localhost:8001/balancer
Content-Type: application/json

{
  "timeout": "10s",
  "balancer": "org.astraea.common.balancer.algorithms.GreedyBalancer",
  "balancer-config": {
    "shuffle.plan.generator.min.step": "1",
    "shuffle.plan.generator.max.step": "5"
  },
  "costWeights": [
    {
      "cost": "org.astraea.common.cost.ReplicaLeaderCost",
      "weight": 1
    },
    {
      "cost": "org.astraea.common.cost.ReplicaSizeCost",
      "weight": 1
    }
  ]
}
```

## Response

```
HTTP/1.1 200 OK
Date: Mon, 12 Dec 2022 11:41:25 GMT
Content-type: application/json; charset=UTF-8
Content-length: 19363

{
  "done": false,
  "generated": true,
  "id": "ff897675-d061-431e-9255-ea6b28256249",
  "report": {
    "changes": [ ... ],
    "cost": 0.22413838563096217,
    "function": "WeightCompositeClusterCost[{\"org.astraea.common.cost.ReplicaLeaderCost@24b03118\" weight 1.0}, {\"org.astraea.common.cost.ReplicaSizeCost@4324ac4e\" weight 1.0}]",
    "migrationCosts": [ ... ],
    "newCost": 0.024531386580982893
  },
  "scheduled": false
}
Response file saved.
> 2022-12-12T194125.200.json

Response code: 200 (OK); Time: 19ms (19 ms); Content length: 19363 bytes (19.36 kB)
```