### PR TITLE
[CONNECTOR][GUI] fetch connector type from /status API

### DIFF
--- a/common/src/main/java/org/astraea/common/connector/Builder.java
+++ b/common/src/main/java/org/astraea/common/connector/Builder.java
@@ -175,6 +175,7 @@ public class Builder {
                                     status.name,
                                     status.connector.state,
                                     status.connector.worker_id,
+                                    status.type,
                                     config,
                                     status.tasks.stream()
                                         .map(
@@ -253,6 +254,10 @@ public class Builder {
     private String name;
 
     private KafkaConnector connector;
+
+    // The type is always null before kafka 2.0.2
+    // see https://issues.apache.org/jira/browse/KAFKA-7253
+    private Optional<String> type = Optional.empty();
 
     private List<KafkaTaskStatus> tasks;
   }

--- a/common/src/main/java/org/astraea/common/connector/ConnectorStatus.java
+++ b/common/src/main/java/org/astraea/common/connector/ConnectorStatus.java
@@ -18,6 +18,7 @@ package org.astraea.common.connector;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /** this is not a kind of json response from kafka. */
 public class ConnectorStatus {
@@ -28,6 +29,10 @@ public class ConnectorStatus {
 
   private final String workerId;
 
+  // The type is always null before kafka 2.0.2
+  // see https://issues.apache.org/jira/browse/KAFKA-7253
+  private final Optional<String> type;
+
   private final Map<String, String> configs;
 
   private final List<TaskStatus> tasks;
@@ -36,11 +41,13 @@ public class ConnectorStatus {
       String name,
       String state,
       String workerId,
+      Optional<String> type,
       Map<String, String> configs,
       List<TaskStatus> tasks) {
     this.name = name;
     this.state = state;
     this.workerId = workerId;
+    this.type = type;
     this.configs = configs;
     this.tasks = tasks;
   }
@@ -55,6 +62,10 @@ public class ConnectorStatus {
 
   public String workerId() {
     return workerId;
+  }
+
+  public Optional<String> type() {
+    return type;
   }
 
   public Map<String, String> configs() {

--- a/common/src/test/java/org/astraea/common/connector/ConnectorClientTest.java
+++ b/common/src/test/java/org/astraea/common/connector/ConnectorClientTest.java
@@ -185,6 +185,7 @@ class ConnectorClientTest extends RequireWorkerCluster {
     var status = connectorClient.connectorStatus(connectorName).toCompletableFuture().join();
     assertEquals(connectorName, status.name());
     assertEquals("RUNNING", status.state());
+    assertEquals("source", status.type().get());
     assertEquals(2, status.tasks().size());
     assertNotEquals(0, status.configs().size());
     status.tasks().forEach(t -> assertEquals("RUNNING", t.state()));

--- a/gui/src/main/java/org/astraea/gui/tab/ConnectorNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/ConnectorNode.java
@@ -171,6 +171,9 @@ public class ConnectorNode {
                                               map.put("id", task.id());
                                               map.put("worker id", task.workerId());
                                               map.put("state", task.state());
+                                              connectorStatus
+                                                  .type()
+                                                  .ifPresent(t -> map.put("type", t));
                                               task.error().ifPresent(e -> map.put("error", e));
                                               sourceTaskInfos.stream()
                                                   .filter(t -> t.taskId() == task.id())


### PR DESCRIPTION
如題，不過該欄位在先前的 kafka 是一個 bug (總是 null），因此我們將該欄位宣告成 `Optional<String>`