### PR TITLE
[CONNECTOR] add source record

### DIFF
--- a/common/src/main/java/org/astraea/common/producer/Builder.java
+++ b/common/src/main/java/org/astraea/common/producer/Builder.java
@@ -82,8 +82,8 @@ public class Builder<Key, Value> {
     producer.send(
         new ProducerRecord<>(
             record.topic(),
-            record.partition(),
-            record.timestamp(),
+            record.partition().orElse(null),
+            record.timestamp().orElse(null),
             record.key(),
             record.value(),
             record.headers().stream()

--- a/connector/src/main/java/org/astraea/connector/SourceConnector.java
+++ b/connector/src/main/java/org/astraea/connector/SourceConnector.java
@@ -26,9 +26,7 @@ import org.astraea.common.VersionUtils;
 public abstract class SourceConnector extends org.apache.kafka.connect.source.SourceConnector {
   public static String TOPICS_KEY = "topics";
 
-  protected void init(Configuration configuration) {
-    // empty
-  }
+  protected abstract void init(Configuration configuration);
 
   protected abstract Class<? extends SourceTask> task();
 

--- a/connector/src/main/java/org/astraea/connector/SourceRecord.java
+++ b/connector/src/main/java/org/astraea/connector/SourceRecord.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.connector;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.astraea.common.Header;
+import org.astraea.common.admin.TopicPartition;
+import org.astraea.common.json.JsonConverter;
+import org.astraea.common.json.TypeRef;
+import org.astraea.common.producer.Record;
+
+public class SourceRecord implements Record<byte[], byte[]> {
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  private static final JsonConverter CONVERTER = JsonConverter.defaultConverter();
+
+  private final Record<byte[], byte[]> record;
+  private final Map<String, String> metadataIndex;
+  private final Map<String, String> metadata;
+
+  private SourceRecord(
+      Record<byte[], byte[]> record,
+      Map<String, String> metadataIndex,
+      Map<String, String> metadata) {
+    this.record = record;
+    this.metadataIndex = metadataIndex;
+    this.metadata = metadata;
+  }
+
+  @Override
+  public String topic() {
+    return record.topic();
+  }
+
+  @Override
+  public List<Header> headers() {
+    return record.headers();
+  }
+
+  @Override
+  public byte[] key() {
+    return record.key();
+  }
+
+  @Override
+  public byte[] value() {
+    return record.value();
+  }
+
+  @Override
+  public Optional<Long> timestamp() {
+    return record.timestamp();
+  }
+
+  @Override
+  public Optional<Integer> partition() {
+    return record.partition();
+  }
+
+  public Map<String, String> metadataIndex() {
+    return metadataIndex;
+  }
+
+  public Map<String, String> metadata() {
+    return metadata;
+  }
+
+  public static class Builder {
+
+    private final Record.Builder<byte[], byte[]> builder = Record.builder();
+    private Map<String, String> metadataIndex = Map.of();
+    private Map<String, String> metadata = Map.of();
+
+    private Builder() {}
+
+    public Builder record(Record<byte[], byte[]> record) {
+      builder.record(record);
+      return this;
+    }
+
+    public Builder key(byte[] key) {
+      builder.key(key);
+      return this;
+    }
+
+    public Builder value(byte[] value) {
+      builder.value(value);
+      return this;
+    }
+
+    public Builder topicPartition(TopicPartition topicPartition) {
+      topic(topicPartition.topic());
+      return partition(topicPartition.partition());
+    }
+
+    public Builder topic(String topic) {
+      builder.topic(topic);
+      return this;
+    }
+
+    public Builder partition(int partition) {
+      builder.partition(partition);
+      return this;
+    }
+
+    public Builder timestamp(long timestamp) {
+      builder.timestamp(timestamp);
+      return this;
+    }
+
+    public Builder headers(List<Header> headers) {
+      builder.headers(headers);
+      return this;
+    }
+
+    public Builder metadataIndex(Object metadataIndex) {
+      if (metadataIndex != null)
+        this.metadataIndex =
+            CONVERTER.fromJson(CONVERTER.toJson(metadataIndex), TypeRef.map(String.class));
+      return this;
+    }
+
+    public Builder metadata(Object metadata) {
+      if (metadata != null)
+        this.metadata = CONVERTER.fromJson(CONVERTER.toJson(metadata), TypeRef.map(String.class));
+      return this;
+    }
+
+    public SourceRecord build() {
+      return new SourceRecord(builder.build(), metadataIndex, metadata);
+    }
+  }
+}

--- a/connector/src/test/java/org/astraea/connector/SourceTest.java
+++ b/connector/src/test/java/org/astraea/connector/SourceTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.connector;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.astraea.common.Configuration;
+import org.astraea.common.Header;
+import org.astraea.common.Utils;
+import org.astraea.common.connector.ConnectorClient;
+import org.astraea.common.consumer.Consumer;
+import org.astraea.common.consumer.ConsumerConfigs;
+import org.astraea.common.producer.Record;
+import org.astraea.it.RequireSingleWorkerCluster;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SourceTest extends RequireSingleWorkerCluster {
+
+  private static final byte[] KEY = "key".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] VALUE = "value".getBytes(StandardCharsets.UTF_8);
+  private static final String HEADER_KEY = "header.name";
+  private static final byte[] HEADER_VALUE = "header.value".getBytes(StandardCharsets.UTF_8);
+
+  @Test
+  void testConsumeDataFromSource() {
+    var client = ConnectorClient.builder().url(workerUrl()).build();
+    var name = Utils.randomString();
+    var topic = Utils.randomString();
+    client
+        .createConnector(
+            name,
+            Map.of(
+                ConnectorClient.CONNECTOR_CLASS_KEY,
+                MySource.class.getName(),
+                ConnectorClient.TASK_MAX_KEY,
+                "1",
+                ConnectorClient.TOPICS_KEY,
+                topic))
+        .toCompletableFuture()
+        .join();
+
+    Utils.sleep(Duration.ofSeconds(3));
+    Assertions.assertEquals(
+        "RUNNING", client.connectorStatus(name).toCompletableFuture().join().state());
+    Assertions.assertEquals(
+        1, client.connectorStatus(name).toCompletableFuture().join().tasks().size());
+    client
+        .connectorStatus(name)
+        .toCompletableFuture()
+        .join()
+        .tasks()
+        .forEach(
+            t ->
+                Assertions.assertEquals(
+                    "RUNNING", t.state(), t.error().orElse("no error message??")));
+
+    try (var consumer =
+        Consumer.forTopics(Set.of(topic))
+            .bootstrapServers(bootstrapServers())
+            .config(
+                ConsumerConfigs.AUTO_OFFSET_RESET_CONFIG,
+                ConsumerConfigs.AUTO_OFFSET_RESET_EARLIEST)
+            .build()) {
+      var records = consumer.poll(1, Duration.ofSeconds(10));
+      Assertions.assertEquals(1, records.size());
+      Assertions.assertArrayEquals(KEY, records.get(0).key());
+      Assertions.assertArrayEquals(VALUE, records.get(0).value());
+      Assertions.assertEquals(1, records.get(0).headers().size());
+      Assertions.assertEquals(HEADER_KEY, records.get(0).headers().get(0).key());
+      Assertions.assertArrayEquals(
+          HEADER_VALUE,
+          records.get(0).headers().get(0).value(),
+          new String(records.get(0).headers().get(0).value(), StandardCharsets.UTF_8));
+    }
+  }
+
+  public static class MySource extends SourceConnector {
+
+    private Configuration configuration = Configuration.EMPTY;
+
+    @Override
+    protected void init(Configuration configuration) {
+      this.configuration = configuration;
+    }
+
+    @Override
+    protected Class<? extends SourceTask> task() {
+      return MyTask.class;
+    }
+
+    @Override
+    protected List<Configuration> takeConfiguration(int maxTasks) {
+      return IntStream.range(0, maxTasks).mapToObj(i -> configuration).collect(Collectors.toList());
+    }
+
+    @Override
+    protected List<Definition> definitions() {
+      return List.of();
+    }
+  }
+
+  public static class MyTask extends SourceTask {
+
+    private Set<String> topics = Set.of();
+    private boolean isDone = false;
+
+    @Override
+    protected void init(Configuration configuration) {
+      topics = Set.copyOf(configuration.list(ConnectorClient.TOPICS_KEY, ","));
+    }
+
+    @Override
+    protected Collection<Record<byte[], byte[]>> take() throws InterruptedException {
+      if (isDone) return List.of();
+      isDone = true;
+      return topics.stream()
+          .map(
+              t ->
+                  SourceRecord.builder()
+                      .key(KEY)
+                      .value(VALUE)
+                      .topic(t)
+                      .headers(List.of(Header.of(HEADER_KEY, HEADER_VALUE)))
+                      .build())
+          .collect(Collectors.toList());
+    }
+  }
+}

--- a/it/src/main/java/org/astraea/it/Services.java
+++ b/it/src/main/java/org/astraea/it/Services.java
@@ -78,6 +78,9 @@ public final class Services {
                       ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG,
                       "org.apache.kafka.connect.converters.ByteArrayConverter");
                   config.put(
+                      ConnectorConfig.HEADER_CONVERTER_CLASS_CONFIG,
+                      "org.apache.kafka.connect.converters.ByteArrayConverter");
+                  config.put(
                       WorkerConfig.LISTENERS_CONFIG,
                       // the worker hostname is a part of information used by restful apis.
                       // the 0.0.0.0 make all connector say that they are executed by 0.0.0.0


### PR DESCRIPTION
#870 等 connector 需要儲存外部系統的資料索引，因此我們引入 `SourceRecord`讓使用者可以存放外部系統的資訊在 kafka 內部，下一隻PR會將對應的 offset storage 暴露出來