### PR TITLE
[CONNECTOR] add metadata storage to source connector

### DIFF
--- a/connector/src/main/java/org/astraea/connector/MetadataStorage.java
+++ b/connector/src/main/java/org/astraea/connector/MetadataStorage.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.connector;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+import org.astraea.common.json.JsonConverter;
+
+public interface MetadataStorage {
+
+  JsonConverter CONVERTER = JsonConverter.defaultConverter();
+
+  static MetadataStorage of(OffsetStorageReader reader) {
+    return index -> {
+      var v = reader.offset(index);
+      if (v == null) return Map.of();
+      return v.entrySet().stream()
+          .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> e.getValue().toString()));
+    };
+  }
+
+  Map<String, String> metadata(Map<String, String> index);
+}

--- a/connector/src/main/java/org/astraea/connector/SourceConnector.java
+++ b/connector/src/main/java/org/astraea/connector/SourceConnector.java
@@ -26,7 +26,7 @@ import org.astraea.common.VersionUtils;
 public abstract class SourceConnector extends org.apache.kafka.connect.source.SourceConnector {
   public static String TOPICS_KEY = "topics";
 
-  protected abstract void init(Configuration configuration);
+  protected abstract void init(Configuration configuration, MetadataStorage storage);
 
   protected abstract Class<? extends SourceTask> task();
 
@@ -41,7 +41,7 @@ public abstract class SourceConnector extends org.apache.kafka.connect.source.So
   // -------------------------[final]-------------------------//
   @Override
   public final void start(Map<String, String> props) {
-    init(Configuration.of(props));
+    init(Configuration.of(props), MetadataStorage.of(context().offsetStorageReader()));
   }
 
   @Override

--- a/connector/src/main/java/org/astraea/connector/SourceRecord.java
+++ b/connector/src/main/java/org/astraea/connector/SourceRecord.java
@@ -21,8 +21,6 @@ import java.util.Map;
 import java.util.Optional;
 import org.astraea.common.Header;
 import org.astraea.common.admin.TopicPartition;
-import org.astraea.common.json.JsonConverter;
-import org.astraea.common.json.TypeRef;
 import org.astraea.common.producer.Record;
 
 public class SourceRecord implements Record<byte[], byte[]> {
@@ -30,8 +28,6 @@ public class SourceRecord implements Record<byte[], byte[]> {
   public static Builder builder() {
     return new Builder();
   }
-
-  private static final JsonConverter CONVERTER = JsonConverter.defaultConverter();
 
   private final Record<byte[], byte[]> record;
   private final Map<String, String> metadataIndex;
@@ -132,16 +128,13 @@ public class SourceRecord implements Record<byte[], byte[]> {
       return this;
     }
 
-    public Builder metadataIndex(Object metadataIndex) {
-      if (metadataIndex != null)
-        this.metadataIndex =
-            CONVERTER.fromJson(CONVERTER.toJson(metadataIndex), TypeRef.map(String.class));
+    public Builder metadataIndex(Map<String, String> metadataIndex) {
+      this.metadataIndex = metadataIndex;
       return this;
     }
 
-    public Builder metadata(Object metadata) {
-      if (metadata != null)
-        this.metadata = CONVERTER.fromJson(CONVERTER.toJson(metadata), TypeRef.map(String.class));
+    public Builder metadata(Map<String, String> metadata) {
+      this.metadata = metadata;
       return this;
     }
 

--- a/connector/src/main/java/org/astraea/connector/perf/PerfSource.java
+++ b/connector/src/main/java/org/astraea/connector/perf/PerfSource.java
@@ -24,6 +24,7 @@ import org.astraea.common.DataSize;
 import org.astraea.common.DistributionType;
 import org.astraea.common.Utils;
 import org.astraea.connector.Definition;
+import org.astraea.connector.MetadataStorage;
 import org.astraea.connector.SourceConnector;
 import org.astraea.connector.SourceTask;
 
@@ -73,7 +74,7 @@ public class PerfSource extends SourceConnector {
   private Configuration config;
 
   @Override
-  protected void init(Configuration configuration) {
+  protected void init(Configuration configuration, MetadataStorage storage) {
     this.config = configuration;
   }
 

--- a/connector/src/test/java/org/astraea/connector/ConnectorTest.java
+++ b/connector/src/test/java/org/astraea/connector/ConnectorTest.java
@@ -91,7 +91,7 @@ public class ConnectorTest extends RequireWorkerCluster {
     private static final AtomicInteger CLOSE_COUNT = new AtomicInteger(0);
 
     @Override
-    protected void init(Configuration configuration) {
+    protected void init(Configuration configuration, MetadataStorage storage) {
       INIT_COUNT.incrementAndGet();
     }
 


### PR DESCRIPTION
source connector 可以將額外的資訊存放在另一個 topic 中，可以用來標注“來源端”的額外資訊，例如紀錄某個來源端的資料已經讀取到哪個位置