### PR TITLE
[DISPATCHER] enable null key and null value

### DIFF
--- a/common/src/main/java/org/astraea/common/partitioner/Dispatcher.java
+++ b/common/src/main/java/org/astraea/common/partitioner/Dispatcher.java
@@ -143,8 +143,8 @@ public interface Dispatcher extends Partitioner {
     var target =
         partition(
             topic,
-            keyBytes == null ? new byte[0] : keyBytes,
-            valueBytes == null ? new byte[0] : valueBytes,
+            keyBytes,
+            valueBytes,
             CLUSTER_CACHE.computeIfAbsent(cluster, ignored -> ClusterInfo.of(cluster)));
     interdependent.targetPartitions = target;
     return target;

--- a/common/src/test/java/org/astraea/common/partitioner/DispatcherTest.java
+++ b/common/src/test/java/org/astraea/common/partitioner/DispatcherTest.java
@@ -59,8 +59,8 @@ public class DispatcherTest extends RequireSingleBrokerCluster {
           @Override
           public int partition(
               String topic, byte[] key, byte[] value, ClusterInfo<ReplicaInfo> clusterInfo) {
-            Assertions.assertEquals(0, Objects.requireNonNull(key).length);
-            Assertions.assertEquals(0, Objects.requireNonNull(value).length);
+            Assertions.assertNull(key);
+            Assertions.assertNull(value);
             count.incrementAndGet();
             return 0;
           }


### PR DESCRIPTION
考量`null`在 kafka 的特殊地位，我們不應該隨意將`null`轉換成 empty array