### PR TITLE
[WEB] Provide extra failure information from Balancer response

### DIFF
--- a/app/src/main/java/org/astraea/app/web/BalancerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BalancerHandler.java
@@ -188,6 +188,7 @@ class BalancerHandler implements Handler {
                           .orElse(List.of());
                   var report =
                       new Report(
+                          bestPlan.solution().isPresent(),
                           bestPlan.initialClusterCost().value(),
                           bestPlan.solution().map(p -> p.proposalClusterCost().value()),
                           request.algorithmConfig.clusterCostFunction().toString(),
@@ -563,7 +564,7 @@ class BalancerHandler implements Handler {
   }
 
   static class Report implements Response {
-    // initial cost might be unavailable due to unable to evaluate cost function
+    final boolean isPlanGenerated;
     final double cost;
 
     // don't generate new cost if there is no best plan
@@ -574,11 +575,13 @@ class BalancerHandler implements Handler {
     final List<MigrationCost> migrationCosts;
 
     Report(
+        boolean isPlanGenerated,
         double initialCost,
         Optional<Double> newCost,
         String function,
         List<Change> changes,
         List<MigrationCost> migrationCosts) {
+      this.isPlanGenerated = isPlanGenerated;
       this.cost = initialCost;
       this.newCost = newCost;
       this.function = function;

--- a/app/src/main/java/org/astraea/app/web/BalancerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BalancerHandler.java
@@ -574,7 +574,6 @@ class BalancerHandler implements Handler {
     final String function;
     final List<Change> changes;
     final List<MigrationCost> migrationCosts;
-    // TODO: test this field
     final String description;
 
     Report(

--- a/app/src/main/java/org/astraea/app/web/BalancerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BalancerHandler.java
@@ -417,7 +417,6 @@ class BalancerHandler implements Handler {
                             && !executedPlans.get(lastExecutionId.get()).isDone())
                           throw new IllegalStateException(
                               "There is another on-going rebalance: " + lastExecutionId.get());
-                        // TODO: test this behavior
                         // the plan exists but no plan generated
                         if (thePlanInfo.associatedPlan.asProposalPlan().isEmpty())
                           throw new IllegalStateException(

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -110,7 +110,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
       var report = progress.report;
       Assertions.assertNotNull(progress.id);
       Assertions.assertNotEquals(0, report.changes.size());
-      Assertions.assertTrue(report.cost.get() >= report.newCost.get());
+      Assertions.assertTrue(report.cost >= report.newCost.get());
       // "before" should record size
       report.changes.forEach(
           c ->
@@ -125,7 +125,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
       report.changes.stream()
           .flatMap(c -> c.after.stream())
           .forEach(p -> Assertions.assertEquals(Optional.empty(), p.size));
-      Assertions.assertTrue(report.cost.get() >= report.newCost.get());
+      Assertions.assertTrue(report.cost >= report.newCost.get());
       var sizeMigration =
           report.migrationCosts.stream()
               .filter(x -> x.name.equals(BalancerHandler.MOVED_SIZE))
@@ -160,7 +160,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
           report.changes.stream().map(x -> x.topic).allMatch(allowedTopics::contains),
           "Only allowed topics been altered");
       Assertions.assertTrue(
-          report.cost.get() >= report.newCost.get(),
+          report.cost >= report.newCost.get(),
           "The proposed plan should has better score then the current one");
       var sizeMigration =
           report.migrationCosts.stream()
@@ -294,7 +294,8 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                       .clusterInfo(admin.topicNames(false).toCompletableFuture().join())
                       .toCompletableFuture()
                       .join(),
-                  Duration.ofSeconds(3)));
+                  Duration.ofSeconds(3))
+              .asProposalPlan());
 
       // test move cost predicate
       Assertions.assertEquals(
@@ -312,7 +313,8 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                       .clusterInfo(admin.topicNames(false).toCompletableFuture().join())
                       .toCompletableFuture()
                       .join(),
-                  Duration.ofSeconds(3)));
+                  Duration.ofSeconds(3))
+              .asProposalPlan());
     }
   }
 
@@ -1148,7 +1150,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
     }
 
     @Override
-    public Optional<Plan> offer(ClusterInfo<Replica> currentClusterInfo, Duration timeout) {
+    public Plan offer(ClusterInfo<Replica> currentClusterInfo, Duration timeout) {
       offerCallbacks.forEach(Runnable::run);
       offerCallbacks.clear();
       return super.offer(currentClusterInfo, timeout);

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -297,7 +297,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                       .toCompletableFuture()
                       .join(),
                   Duration.ofSeconds(3))
-              .asProposalPlan());
+              .solution());
 
       // test move cost predicate
       Assertions.assertEquals(
@@ -316,7 +316,7 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
                       .toCompletableFuture()
                       .join(),
                   Duration.ofSeconds(3))
-              .asProposalPlan());
+              .solution());
     }
   }
 
@@ -385,8 +385,6 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
       Assertions.assertNotNull(progress.report.function);
       Assertions.assertEquals(0, progress.report.changes.size(), "No proposal");
       Assertions.assertEquals(0, progress.report.migrationCosts.size(), "No proposal");
-      Assertions.assertNotNull(
-          progress.report.description, "It should stated why no proposal available");
       Assertions.assertNull(progress.exception, "No exception occurred during this process");
       Assertions.assertInstanceOf(
           IllegalStateException.class,

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -388,6 +388,20 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
       Assertions.assertNotNull(
           progress.report.description, "It should stated why no proposal available");
       Assertions.assertNull(progress.exception, "No exception occurred during this process");
+      Assertions.assertInstanceOf(
+          IllegalStateException.class,
+          Assertions.assertThrows(
+                  CompletionException.class,
+                  () ->
+                      handler
+                          .put(
+                              Channel.ofRequest(
+                                  JsonConverter.defaultConverter()
+                                      .toJson(Map.of("id", progress.id))))
+                          .toCompletableFuture()
+                          .join())
+              .getCause(),
+          "Cannot execute a plan with no proposal available");
     }
   }
 

--- a/common/src/main/java/org/astraea/common/balancer/Balancer.java
+++ b/common/src/main/java/org/astraea/common/balancer/Balancer.java
@@ -96,7 +96,7 @@ public interface Balancer {
 
   class Plan {
     final ClusterCost initialClusterCost;
-    final String description;
+    final Solution solution;
 
     /**
      * The {@link ClusterCost} score of the original {@link ClusterInfo} when this plan is start
@@ -106,27 +106,21 @@ public interface Balancer {
       return initialClusterCost;
     }
 
-    public Optional<ProposalPlan> asProposalPlan() {
-      return Optional.of(this)
-          .filter(me -> me instanceof ProposalPlan)
-          .map(me -> (ProposalPlan) me);
+    public Optional<Solution> solution() {
+      return Optional.ofNullable(solution);
     }
 
-    /**
-     * @return a String metadata information stated by the Balancer implementation, it might provide
-     *     some insight about this plan.
-     */
-    public Optional<String> description() {
-      return Optional.ofNullable(description);
+    public Plan(ClusterCost initialClusterCost) {
+      this(initialClusterCost, null);
     }
 
-    public Plan(ClusterCost initialClusterCost, String description) {
+    public Plan(ClusterCost initialClusterCost, Solution solution) {
       this.initialClusterCost = initialClusterCost;
-      this.description = description;
+      this.solution = solution;
     }
   }
 
-  class ProposalPlan extends Plan {
+  class Solution {
 
     final ClusterInfo<Replica> proposal;
     final ClusterCost proposalClusterCost;
@@ -145,21 +139,8 @@ public interface Balancer {
       return moveCost;
     }
 
-    public ProposalPlan(
-        ClusterInfo<Replica> proposal,
-        ClusterCost initialClusterCost,
-        ClusterCost proposalClusterCost,
-        MoveCost moveCost) {
-      this(proposal, initialClusterCost, proposalClusterCost, moveCost, null);
-    }
-
-    public ProposalPlan(
-        ClusterInfo<Replica> proposal,
-        ClusterCost initialClusterCost,
-        ClusterCost proposalClusterCost,
-        MoveCost moveCost,
-        String description) {
-      super(initialClusterCost, description);
+    public Solution(
+        ClusterCost proposalClusterCost, MoveCost moveCost, ClusterInfo<Replica> proposal) {
       this.proposal = proposal;
       this.proposalClusterCost = proposalClusterCost;
       this.moveCost = moveCost;

--- a/common/src/main/java/org/astraea/common/balancer/algorithms/GreedyBalancer.java
+++ b/common/src/main/java/org/astraea/common/balancer/algorithms/GreedyBalancer.java
@@ -90,7 +90,7 @@ public class GreedyBalancer implements Balancer {
     final var executionTime = timeout.toMillis();
     Supplier<Boolean> moreRoom =
         () -> System.currentTimeMillis() - start < executionTime && loop.getAndDecrement() > 0;
-    BiFunction<ClusterInfo<Replica>, ClusterCost, Optional<Balancer.ProposalPlan>> next =
+    BiFunction<ClusterInfo<Replica>, ClusterCost, Optional<Solution>> next =
         (currentAllocation, currentCost) ->
             allocationTweaker
                 .generate(currentAllocation)
@@ -99,12 +99,10 @@ public class GreedyBalancer implements Balancer {
                     newAllocation -> {
                       var newClusterInfo =
                           ClusterInfo.update(currentClusterInfo, newAllocation::replicas);
-                      return new Balancer.ProposalPlan(
-                          newAllocation,
-                          initialCost,
+                      return new Solution(
                           clusterCostFunction.clusterCost(newClusterInfo, metrics),
                           moveCostFunction.moveCost(currentClusterInfo, newClusterInfo, metrics),
-                          "");
+                          newAllocation);
                     })
                 .filter(
                     plan ->
@@ -113,7 +111,7 @@ public class GreedyBalancer implements Balancer {
                 .findFirst();
     var currentCost = initialCost;
     var currentAllocation = ClusterInfo.masked(currentClusterInfo, config.topicFilter());
-    var currentPlan = Optional.<Balancer.ProposalPlan>empty();
+    var currentSolution = Optional.<Solution>empty();
 
     // register JMX
     var currentIteration = new LongAdder();
@@ -133,12 +131,10 @@ public class GreedyBalancer implements Balancer {
       currentMinCost.accumulate(currentCost.value());
       var newPlan = next.apply(currentAllocation, currentCost);
       if (newPlan.isEmpty()) break;
-      currentPlan = newPlan;
-      currentCost = currentPlan.get().proposalClusterCost();
-      currentAllocation = currentPlan.get().proposal();
+      currentSolution = newPlan;
+      currentCost = currentSolution.get().proposalClusterCost();
+      currentAllocation = currentSolution.get().proposal();
     }
-    return currentPlan
-        .map(proposalPlan -> (Plan) proposalPlan)
-        .orElse(new Plan(initialCost, "Unable to find a better log allocation"));
+    return new Plan(initialCost, currentSolution.orElse(null));
   }
 }

--- a/common/src/test/java/org/astraea/common/balancer/BalancerAlgorithmTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerAlgorithmTest.java
@@ -93,6 +93,7 @@ public class BalancerAlgorithmTest extends RequireBrokerCluster {
                       .toCompletableFuture()
                       .join(),
                   Duration.ofSeconds(5))
+              .asProposalPlan()
               .get();
 
       var plan =
@@ -105,6 +106,7 @@ public class BalancerAlgorithmTest extends RequireBrokerCluster {
                       .toCompletableFuture()
                       .join(),
                   Duration.ofSeconds(5))
+              .asProposalPlan()
               .get();
 
       Assertions.assertTrue(

--- a/common/src/test/java/org/astraea/common/balancer/BalancerAlgorithmTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerAlgorithmTest.java
@@ -93,7 +93,7 @@ public class BalancerAlgorithmTest extends RequireBrokerCluster {
                       .toCompletableFuture()
                       .join(),
                   Duration.ofSeconds(5))
-              .asProposalPlan()
+              .solution()
               .get();
 
       var plan =
@@ -106,7 +106,7 @@ public class BalancerAlgorithmTest extends RequireBrokerCluster {
                       .toCompletableFuture()
                       .join(),
                   Duration.ofSeconds(5))
-              .asProposalPlan()
+              .solution()
               .get();
 
       Assertions.assertTrue(

--- a/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
@@ -121,7 +121,7 @@ class BalancerTest extends RequireBrokerCluster {
                       .toCompletableFuture()
                       .join(),
                   Duration.ofSeconds(10))
-              .asProposalPlan()
+              .solution()
               .orElseThrow();
       new StraightPlanExecutor()
           .run(admin, plan.proposal(), Duration.ofSeconds(10))
@@ -175,7 +175,7 @@ class BalancerTest extends RequireBrokerCluster {
                       .config(Configuration.of(Map.of("iteration", "500")))
                       .build())
               .offer(clusterInfo, Duration.ofSeconds(3))
-              .asProposalPlan()
+              .solution()
               .get()
               .proposal();
 
@@ -240,7 +240,7 @@ class BalancerTest extends RequireBrokerCluster {
                               .toCompletableFuture()
                               .join(),
                           Duration.ofSeconds(3))
-                      .asProposalPlan()
+                      .solution()
                       .get()
                       .proposal());
       Utils.sleep(Duration.ofMillis(1000));
@@ -323,7 +323,7 @@ class BalancerTest extends RequireBrokerCluster {
               throw new NoSufficientMetricsException(
                   costFunction,
                   Duration.ofMillis(sampleTimeMs - (System.currentTimeMillis() - startMs)));
-            return new ProposalPlan(currentClusterInfo, () -> 0, () -> 0, MoveCost.EMPTY);
+            return new Plan(() -> 0, new Solution(() -> 0, MoveCost.EMPTY, currentClusterInfo));
           }
         };
 

--- a/common/src/test/java/org/astraea/common/balancer/algorithms/GreedyBalancerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/algorithms/GreedyBalancerTest.java
@@ -69,7 +69,7 @@ class GreedyBalancerTest {
           .forEach(
               run -> {
                 var plan = balancer.offer(clusterInfo, Duration.ofMillis(300));
-                Assertions.assertTrue(plan.isPresent());
+                Assertions.assertTrue(plan.asProposalPlan().isPresent());
                 var bean =
                     Assertions.assertDoesNotThrow(
                         () ->

--- a/common/src/test/java/org/astraea/common/balancer/algorithms/GreedyBalancerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/algorithms/GreedyBalancerTest.java
@@ -69,7 +69,7 @@ class GreedyBalancerTest {
           .forEach(
               run -> {
                 var plan = balancer.offer(clusterInfo, Duration.ofMillis(300));
-                Assertions.assertTrue(plan.asProposalPlan().isPresent());
+                Assertions.assertTrue(plan.solution().isPresent());
                 var bean =
                     Assertions.assertDoesNotThrow(
                         () ->

--- a/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
@@ -161,12 +161,12 @@ class NetworkCostTest {
                     .build())
             .offer(testcase.clusterInfo(), Duration.ofSeconds(1));
 
-    Assertions.assertTrue(newPlan.asProposalPlan().isPresent());
+    Assertions.assertTrue(newPlan.solution().isPresent());
     System.out.println("Initial cost: " + newPlan.initialClusterCost().value());
-    System.out.println("New cost: " + newPlan.asProposalPlan().get().proposalClusterCost().value());
+    System.out.println("New cost: " + newPlan.solution().get().proposalClusterCost().value());
     Assertions.assertTrue(
         newPlan.initialClusterCost().value()
-            > newPlan.asProposalPlan().get().proposalClusterCost().value());
+            > newPlan.solution().get().proposalClusterCost().value());
   }
 
   @Test

--- a/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
@@ -161,11 +161,12 @@ class NetworkCostTest {
                     .build())
             .offer(testcase.clusterInfo(), Duration.ofSeconds(1));
 
-    Assertions.assertTrue(newPlan.isPresent());
-    System.out.println("Initial cost: " + newPlan.get().initialClusterCost().value());
-    System.out.println("New cost: " + newPlan.get().proposalClusterCost().value());
+    Assertions.assertTrue(newPlan.asProposalPlan().isPresent());
+    System.out.println("Initial cost: " + newPlan.initialClusterCost().value());
+    System.out.println("New cost: " + newPlan.asProposalPlan().get().proposalClusterCost().value());
     Assertions.assertTrue(
-        newPlan.get().initialClusterCost().value() > newPlan.get().proposalClusterCost().value());
+        newPlan.initialClusterCost().value()
+            > newPlan.asProposalPlan().get().proposalClusterCost().value());
   }
 
   @Test

--- a/docs/web_server/web_api_balancer_chinese.md
+++ b/docs/web_server/web_api_balancer_chinese.md
@@ -154,7 +154,7 @@ JSON Response 範例
     "isPlanGenerated": true,
     "cost": 0.04948716593053935,
     "newCost": 0.04948716593053935,
-    "function": "WeightCompositeClusterCost[{\"org.astraea.common.cost.NetworkIngressCost@36835e87\" weight 1.0}, {\"org.astraea.common.cost.NetworkEgressCost@2d87f4d3\" weight 1.0}]",
+    "function": "WeightCompositeClusterCost[{\"org.astraea.common.cost.ReplicaSizeCost@36835e87\" weight 1.0}, {\"org.astraea.common.cost.ReplicaLeaderCost@2d87f4d3\" weight 1.0}]",
     "changes": [
       {
         "topic": "__consumer_offsets",

--- a/docs/web_server/web_api_balancer_chinese.md
+++ b/docs/web_server/web_api_balancer_chinese.md
@@ -30,12 +30,11 @@ curl -X POST http://localhost:8001/balancer \
       "balancer": "org.astraea.common.balancer.algorithms.GreedyBalancer",
       "balancerConfig": {
         "shuffle.tweaker.min.step": "1",
-        "shuffle.tweaker.max.step": "30",
-        "iteration": "10000"
+        "shuffle.tweaker.max.step": "5"
       },
       "costWeights": [
-        { "cost":  "org.astraea.common.cost.ReplicaSizeCost", "weight":  3},
-        { "cost":  "org.astraea.common.cost.ReplicaLeaderCost", "weight":  2}
+        { "cost": "org.astraea.common.cost.ReplicaSizeCost", "weight": 1 },
+        { "cost": "org.astraea.common.cost.ReplicaLeaderCost", "weight": 1 }
       ],
       "maxMigratedSize": "300MB",
       "maxMigratedLeader": "3"
@@ -125,8 +124,9 @@ JSON Response 範例
   1. 搜尋負載平衡計劃的過程中發生錯誤 (此情境下 `generated` 會是 `false`)
   2. 執行負載平衡計劃的過程中發生錯誤 (此情境下 `scheduled` 會是 `true` 但 `done` 為 `false`)
 * `info`: 此負載平衡計劃的詳細資訊，如果此計劃還沒生成，則此欄位會是 `null`
-  * `cost`: 目前叢集的成本 (越高越不好)
-  * `newCost`: 評估後比較好的成本 (<= `cost`)
+  * `isPlanGenerated`: 表示計劃是否成功生成，如果此欄位為 `false` 代表 Balancer 實作無法找到更好的計劃
+  * `cost`: 目前叢集的分數 (越高越不好)
+  * `newCost`: 提出的新計劃之分數，當計劃沒有成功生成時，此欄位會是 `null`
   * `function`: 用來評估品質的方法
   * `changes`: 新的 partitions 配置
     * `topic`: topic 名稱
@@ -151,9 +151,10 @@ JSON Response 範例
   "scheduled": true,
   "done": true,
   "info": {
+    "isPlanGenerated": true,
     "cost": 0.04948716593053935,
     "newCost": 0.04948716593053935,
-    "function": "ReplicaLeaderCost",
+    "function": "WeightCompositeClusterCost[{\"org.astraea.common.cost.NetworkIngressCost@36835e87\" weight 1.0}, {\"org.astraea.common.cost.NetworkEgressCost@2d87f4d3\" weight 1.0}]",
     "changes": [
       {
         "topic": "__consumer_offsets",

--- a/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
@@ -59,7 +59,7 @@ import org.astraea.gui.text.TextInput;
 
 public class BalancerNode {
 
-  static final AtomicReference<Balancer.Plan> LAST_PLAN = new AtomicReference<>();
+  static final AtomicReference<Balancer.ProposalPlan> LAST_PLAN = new AtomicReference<>();
   static final String TOPIC_NAME_KEY = "topic";
   private static final String PARTITION_KEY = "partition";
   private static final String MAX_MIGRATE_LOG_SIZE = "total max migrate log size";
@@ -88,7 +88,7 @@ public class BalancerNode {
     }
   }
 
-  static List<Map<String, Object>> costResult(Balancer.Plan plan) {
+  static List<Map<String, Object>> costResult(Balancer.ProposalPlan plan) {
     var map = new HashMap<Integer, LinkedHashMap<String, Object>>();
 
     BiConsumer<String, Map<Integer, ?>> process =
@@ -112,7 +112,7 @@ public class BalancerNode {
   }
 
   static List<Map<String, Object>> assignmentResult(
-      ClusterInfo<Replica> clusterInfo, Balancer.Plan plan) {
+      ClusterInfo<Replica> clusterInfo, Balancer.ProposalPlan plan) {
     return ClusterInfo.findNonFulfilledAllocation(clusterInfo, plan.proposal()).stream()
         .map(
             tp -> {
@@ -223,10 +223,11 @@ public class BalancerNode {
                 })
             .thenApply(
                 entry -> {
-                  entry.getValue().ifPresent(LAST_PLAN::set);
+                  entry.getValue().asProposalPlan().ifPresent(LAST_PLAN::set);
                   var result =
                       entry
                           .getValue()
+                          .asProposalPlan()
                           .map(
                               plan ->
                                   Map.of(

--- a/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/BalancerNode.java
@@ -59,7 +59,7 @@ import org.astraea.gui.text.TextInput;
 
 public class BalancerNode {
 
-  static final AtomicReference<Balancer.ProposalPlan> LAST_PLAN = new AtomicReference<>();
+  static final AtomicReference<Balancer.Solution> LAST_PLAN = new AtomicReference<>();
   static final String TOPIC_NAME_KEY = "topic";
   private static final String PARTITION_KEY = "partition";
   private static final String MAX_MIGRATE_LOG_SIZE = "total max migrate log size";
@@ -88,7 +88,7 @@ public class BalancerNode {
     }
   }
 
-  static List<Map<String, Object>> costResult(Balancer.ProposalPlan plan) {
+  static List<Map<String, Object>> costResult(Balancer.Solution plan) {
     var map = new HashMap<Integer, LinkedHashMap<String, Object>>();
 
     BiConsumer<String, Map<Integer, ?>> process =
@@ -112,12 +112,12 @@ public class BalancerNode {
   }
 
   static List<Map<String, Object>> assignmentResult(
-      ClusterInfo<Replica> clusterInfo, Balancer.ProposalPlan plan) {
-    return ClusterInfo.findNonFulfilledAllocation(clusterInfo, plan.proposal()).stream()
+      ClusterInfo<Replica> clusterInfo, Balancer.Solution solution) {
+    return ClusterInfo.findNonFulfilledAllocation(clusterInfo, solution.proposal()).stream()
         .map(
             tp -> {
               var previousAssignments = clusterInfo.replicas(tp);
-              var newAssignments = plan.proposal().replicas(tp);
+              var newAssignments = solution.proposal().replicas(tp);
               var result = new LinkedHashMap<String, Object>();
               result.put(TOPIC_NAME_KEY, tp.topic());
               result.put(PARTITION_KEY, tp.partition());
@@ -223,11 +223,11 @@ public class BalancerNode {
                 })
             .thenApply(
                 entry -> {
-                  entry.getValue().asProposalPlan().ifPresent(LAST_PLAN::set);
+                  entry.getValue().solution().ifPresent(LAST_PLAN::set);
                   var result =
                       entry
                           .getValue()
-                          .asProposalPlan()
+                          .solution()
                           .map(
                               plan ->
                                   Map.of(

--- a/gui/src/test/java/org/astraea/gui/tab/BalancerNodeTest.java
+++ b/gui/src/test/java/org/astraea/gui/tab/BalancerNodeTest.java
@@ -156,11 +156,10 @@ class BalancerNodeTest extends RequireBrokerCluster {
     var results =
         BalancerNode.assignmentResult(
             beforeClusterInfo,
-            new Balancer.ProposalPlan(
-                ClusterInfo.of(allNodes, afterReplicas),
+            new Balancer.Solution(
                 new ReplicaLeaderCost().clusterCost(beforeClusterInfo, ClusterBean.EMPTY),
-                new ReplicaLeaderCost().clusterCost(beforeClusterInfo, ClusterBean.EMPTY),
-                MoveCost.EMPTY));
+                MoveCost.EMPTY,
+                ClusterInfo.of(allNodes, afterReplicas)));
     Assertions.assertEquals(results.size(), 1);
     Assertions.assertEquals(results.get(0).get("topic"), topic);
     Assertions.assertEquals(results.get(0).get("partition"), 0);

--- a/gui/src/test/java/org/astraea/gui/tab/BalancerNodeTest.java
+++ b/gui/src/test/java/org/astraea/gui/tab/BalancerNodeTest.java
@@ -156,7 +156,7 @@ class BalancerNodeTest extends RequireBrokerCluster {
     var results =
         BalancerNode.assignmentResult(
             beforeClusterInfo,
-            new Balancer.Plan(
+            new Balancer.ProposalPlan(
                 ClusterInfo.of(allNodes, afterReplicas),
                 new ReplicaLeaderCost().clusterCost(beforeClusterInfo, ClusterBean.EMPTY),
                 new ReplicaLeaderCost().clusterCost(beforeClusterInfo, ClusterBean.EMPTY),


### PR DESCRIPTION
Resolve #1308.

```json
{
  "done": false,
  "generated": true,
  "id": "4110d2b7-d7b4-42ec-8527-aee453d0e33e",
  "report": {
    "function": "WeightCompositeClusterCost[{\"org.astraea.common.cost.ReplicaLeaderCost@5f041d67\" weight 1.0}, {\"org.astraea.common.cost.ReplicaSizeCost@5d0bc877\" weight 1.0}]"
  },
  "scheduled": false
}
```

現在 Balancer Web API 遇到找不到更好計劃的情況時，`GET /balancer/{id}` 回傳的結果看起來像上面的 json，內容沒有太多關於計劃沒生出來的提示，使用者看到可能會很混淆。會造成這個的主要原因是 `Balancer#offer` 回傳 `Optional<Balancer.Plan>`，由於 Optional 的存在我們基本上不知道為什麼計劃沒辦法被生成出來，也不清楚目前叢集的 `ClusterCost` 分數(initial cluster cost)，基本上 initial cluster cost 就算找不到更好的計劃也可以計算出來，但因為 `Optional` 的關係這個資訊只有在計劃真的計算出來時才能提供（最早 BalancerHandler 的設計是儘管找不到更好的計劃，也能提供 initial cost，但因為 `Balancer#retryOffer` 的 PR，這個計算 initial cost 的邏輯被迫從 Handler 移動到 Balancer 界面裡面，因此這個訊息被迫和 `Balancer.Plan` 綁定）。

這個 PR 做下面的修正

1. `Balancer#offer()` 和 `Balancer#retryOffer` 現在直接回傳 `Balancer.Plan`
2. `Balancer.Plan` 只剩下 initial cost 和一個新字串 `description` 兩個欄位
3. `Balancer.Plan#description` 是這個計劃的 metadata 字串，由 Balancer 的實作填寫，這個資訊會放到 Report 中
4. 新增一個物件 `Balancer.ProposalPlan`，他繼承 `Balancer.Plan`，多了三個欄位: proposed cost, proposed cluster, move cost

然後順便修正了一個 bug

* 儘管 Balance Plan 沒有計算出 Proposal，我們也能執行他，只是什麼事情都不會發生，現在修改行為成：嘗試執行沒有 proposal 的計劃會丟出 `IllegalStateException`。

下面是新的沒產生可用計劃的 `GET /balancer/{id}` 回應

```json
{
  "done": false,
  "generated": true,
  "id": "3352599c-edd7-4552-b61b-989dce709483",
  "report": {
    "cost": 1,
    "description": "Unable to find a better log allocation",
    "function": "WeightCompositeClusterCost[{\"org.astraea.app.web.BalancerHandlerTest$IncreasingCost@3f6177f8\" weight 1.0}]"
  },
  "scheduled": false
}
```