### PR TITLE
Change tracker print out message

### DIFF
--- a/app/src/main/java/org/astraea/app/performance/TrackerThread.java
+++ b/app/src/main/java/org/astraea/app/performance/TrackerThread.java
@@ -70,7 +70,7 @@ public interface TrackerThread extends AbstractThread {
                       .filter(d -> !Double.isNaN(d))
                       .sum()));
       System.out.printf(
-          "  error: %.1f records/second%n",
+          "  error rate: %.1f records/second%n",
           sumOfAttribute(
               ProducerMetrics.topics(mBeanClient), HasProducerTopicMetrics::recordErrorRate));
       reports.stream()


### PR DESCRIPTION
在 Intellij 執行 performance tool 時，intellij 會跳出錯誤：

![errorRate](https://user-images.githubusercontent.com/26920893/208570863-91667156-d698-44cd-ba51-4aa88089ec00.png)

其實這個是 `TrackerThread` 印出來的 `recordErrorRate`，但是 "  error: " 開頭的訊息似乎會被 intellij 當成是錯誤訊息，這裡修改 `TrackerThread` 打印出來的內容，不要讓 intellij 誤會。

---

重現方法與參數：

在 intellij 上方中間偏右的地方設定參數，然後按綠色三角形開始跑，最下方的執行結果就會跳出 `1 error`。

以下是參數

"run --args="performance --bootstrap.servers 192.168.103.185:9092 --topics simple --run.until 30s"

![2022-12-20_10-50](https://user-images.githubusercontent.com/26920893/208571347-9d2d4641-6ef1-46b5-aee2-5810d631f7b7.png)

