### PR TITLE
[CONNECTOR] add task configs

### DIFF
--- a/common/src/main/java/org/astraea/common/connector/ConnectorClient.java
+++ b/common/src/main/java/org/astraea/common/connector/ConnectorClient.java
@@ -47,8 +47,6 @@ public interface ConnectorClient {
 
   CompletionStage<Set<String>> connectorNames();
 
-  CompletionStage<ConnectorInfo> connectorInfo(String name);
-
   CompletionStage<ConnectorStatus> connectorStatus(String name);
 
   CompletionStage<ConnectorInfo> createConnector(String name, Map<String, String> config);
@@ -61,7 +59,7 @@ public interface ConnectorClient {
 
   CompletionStage<List<PluginInfo>> plugins();
 
-  default CompletionStage<Boolean> waitConnectorInfo(
+  default CompletionStage<Boolean> waitConnector(
       String connectName, Predicate<ConnectorStatus> predicate, Duration timeout) {
     return Utils.loop(
         () ->

--- a/common/src/main/java/org/astraea/common/connector/ConnectorStatus.java
+++ b/common/src/main/java/org/astraea/common/connector/ConnectorStatus.java
@@ -48,8 +48,8 @@ public class ConnectorStatus {
     this.state = state;
     this.workerId = workerId;
     this.type = type;
-    this.configs = configs;
-    this.tasks = tasks;
+    this.configs = Map.copyOf(configs);
+    this.tasks = List.copyOf(tasks);
   }
 
   public String name() {

--- a/common/src/main/java/org/astraea/common/connector/TaskStatus.java
+++ b/common/src/main/java/org/astraea/common/connector/TaskStatus.java
@@ -16,23 +16,39 @@
  */
 package org.astraea.common.connector;
 
+import java.util.Map;
 import java.util.Optional;
 
 /** this is not a kind of json response from kafka. */
 public class TaskStatus {
 
+  private final String connectorName;
   private final int id;
   private final String state;
 
   private final String workerId;
 
+  private final Map<String, String> configs;
+
   private final Optional<String> error;
 
-  TaskStatus(int id, String state, String workerId, Optional<String> error) {
+  TaskStatus(
+      String connectorName,
+      int id,
+      String state,
+      String workerId,
+      Map<String, String> configs,
+      Optional<String> error) {
+    this.connectorName = connectorName;
     this.id = id;
     this.state = state;
     this.workerId = workerId;
+    this.configs = Map.copyOf(configs);
     this.error = error;
+  }
+
+  public String connectorName() {
+    return connectorName;
   }
 
   public int id() {
@@ -45,6 +61,10 @@ public class TaskStatus {
 
   public String workerId() {
     return workerId;
+  }
+
+  public Map<String, String> configs() {
+    return configs;
   }
 
   public Optional<String> error() {

--- a/connector/src/test/java/org/astraea/connector/ConnectorTest.java
+++ b/connector/src/test/java/org/astraea/connector/ConnectorTest.java
@@ -82,7 +82,7 @@ public class ConnectorTest extends RequireWorkerCluster {
     // wait for sync
     Utils.sleep(Duration.ofSeconds(3));
     Assertions.assertEquals(
-        3, client.connectorInfo(name).toCompletableFuture().join().tasks().size());
+        3, client.connectorStatus(name).toCompletableFuture().join().tasks().size());
 
     client.deleteConnector(name).toCompletableFuture().join();
     Utils.sleep(Duration.ofSeconds(3));


### PR DESCRIPTION
`connectorStatus`回傳的`task`中現在會攜帶`configs`，除此之外，這隻PR也移除了`connectorInfo`因為它完全可以被`connectorStatus`取代