### PR TITLE
[CONNECTOR] show task configs

### DIFF
--- a/connector/src/main/java/org/astraea/connector/perf/PerfSink.java
+++ b/connector/src/main/java/org/astraea/connector/perf/PerfSink.java
@@ -28,10 +28,9 @@ import org.astraea.connector.SinkConnector;
 import org.astraea.connector.SinkTask;
 
 public class PerfSink extends SinkConnector {
-
   static Definition FREQUENCY_DEF =
       Definition.builder()
-          .name("frequency.in.seconds")
+          .name("frequency")
           .type(Definition.Type.STRING)
           .defaultValue("300ms")
           .validator((name, value) -> Utils.toDuration(value.toString()))
@@ -61,17 +60,14 @@ public class PerfSink extends SinkConnector {
 
   public static class Task extends SinkTask {
 
-    private Duration frequency = Utils.toDuration(PerfSink.FREQUENCY_DEF.defaultValue().toString());
+    private Duration frequency = Utils.toDuration(FREQUENCY_DEF.defaultValue().toString());
 
     private volatile long lastPut = System.currentTimeMillis();
 
     @Override
     protected void init(Configuration configuration) {
       frequency =
-          configuration
-              .string(PerfSource.FREQUENCY_DEF.name())
-              .map(Utils::toDuration)
-              .orElse(frequency);
+          configuration.string(FREQUENCY_DEF.name()).map(Utils::toDuration).orElse(frequency);
     }
 
     @Override

--- a/connector/src/main/java/org/astraea/connector/perf/PerfSource.java
+++ b/connector/src/main/java/org/astraea/connector/perf/PerfSource.java
@@ -42,7 +42,7 @@ import org.astraea.connector.SourceTask;
 public class PerfSource extends SourceConnector {
   static Definition FREQUENCY_DEF =
       Definition.builder()
-          .name("frequency.in.seconds")
+          .name("frequency")
           .type(Definition.Type.STRING)
           .defaultValue("1s")
           .validator((name, value) -> Utils.toDuration(value.toString()))

--- a/gui/src/main/java/org/astraea/gui/tab/ConnectorNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/ConnectorNode.java
@@ -183,7 +183,7 @@ public class ConnectorNode {
                                 context.workerClients().values().stream()
                                     .flatMap(c -> ConnectorMetrics.taskError(c).stream())
                                     .collect(Collectors.toList())),
-                    (connectorStatuses, sourceTaskInfos, sinkTaskInfos, taskErrors) ->
+                    (connectorStatuses, sourceTaskMetrics, sinkTaskMetrics, taskErrors) ->
                         connectorStatuses.stream()
                             .flatMap(
                                 connectorStatus ->
@@ -191,7 +191,7 @@ public class ConnectorNode {
                                         .map(
                                             task -> {
                                               var map = new LinkedHashMap<String, Object>();
-                                              map.put(NAME_KEY, connectorStatus.name());
+                                              map.put(NAME_KEY, task.connectorName());
                                               map.put("id", task.id());
                                               map.put("worker id", task.workerId());
                                               map.put("state", task.state());
@@ -199,7 +199,8 @@ public class ConnectorNode {
                                                   .type()
                                                   .ifPresent(t -> map.put("type", t));
                                               task.error().ifPresent(e -> map.put("error", e));
-                                              sourceTaskInfos.stream()
+                                              map.putAll(task.configs());
+                                              sourceTaskMetrics.stream()
                                                   .filter(t -> t.taskId() == task.id())
                                                   .filter(
                                                       t ->
@@ -226,7 +227,7 @@ public class ConnectorNode {
                                                             "poll batch time (max)",
                                                             info.pollBatchMaxTimeMs());
                                                       });
-                                              sinkTaskInfos.stream()
+                                              sinkTaskMetrics.stream()
                                                   .filter(t -> t.taskId() == task.id())
                                                   .filter(
                                                       t ->


### PR DESCRIPTION
如題，同時也修正了`frequency.in.seconds`的命名問題，改成`frequency`因為使用者可以自帶單位