### PR TITLE
[WEB] Fix the placement output order of `Change#before` and `Change#after`

### DIFF
--- a/app/src/main/java/org/astraea/app/web/BalancerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BalancerHandler.java
@@ -470,7 +470,8 @@ class BalancerHandler implements Handler {
                           .stream()
                           // have to compare by isLeader instead of isPreferredLeader.
                           // since the leadership is what affects the direction of traffic load.
-                          // Any bandwidth related cost function should calculate load by leadership instead of preferred leadership
+                          // Any bandwidth related cost function should calculate load by leadership
+                          // instead of preferred leadership
                           .sorted(Comparator.comparing(Replica::isLeader).reversed())
                           .map(replica -> Map.entry(replica.nodeInfo().id(), replica.path()))
                           .collect(Collectors.toUnmodifiableList());


### PR DESCRIPTION
Resolve #1320

`BalancerHandler.Change` 的 before/after 輸出順序有一定的規則，第一個 element 必須要是 Partition 的 Preferred Leader。這個 PR 新增這個排序規則還有寫測試確保這個行為。