### PR TITLE
[PERF] add throughput to PerfSource

### DIFF
--- a/common/src/main/java/org/astraea/common/Utils.java
+++ b/common/src/main/java/org/astraea/common/Utils.java
@@ -23,6 +23,7 @@ import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -31,6 +32,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
@@ -381,6 +383,13 @@ public final class Utils {
               // reset debounce for retry
               return loop(supplier, remaining, debounce, debounce);
             });
+  }
+
+  public static <T> Collection<List<T>> chunk(Collection<T> input, int numberOfChunks) {
+    var counter = new AtomicInteger(0);
+    return input.stream()
+        .collect(Collectors.groupingBy(s -> counter.getAndIncrement() % numberOfChunks))
+        .values();
   }
 
   private Utils() {}

--- a/common/src/main/java/org/astraea/common/metrics/stats/Rate.java
+++ b/common/src/main/java/org/astraea/common/metrics/stats/Rate.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.metrics.stats;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/** By contrast to {@link Avg}, {@link Rate} measure the value by time instead of "count". */
+public interface Rate extends Stat<Long> {
+  /**
+   * @param unit of rate
+   * @return sum of recorded values / (time of last record - start time)
+   */
+  static Rate of(TimeUnit unit) {
+    return new Rate() {
+      private final long start = System.currentTimeMillis();
+      private volatile long last = System.currentTimeMillis();
+      private final AtomicLong sum = new AtomicLong();
+
+      @Override
+      public void record(Long value) {
+        sum.addAndGet(value);
+        last = System.currentTimeMillis();
+      }
+
+      @Override
+      public Long measure() {
+        var diff = last - start;
+        if (diff <= 0) return 0L;
+        return (long) (sum.doubleValue() / unit.convert(diff, TimeUnit.MILLISECONDS));
+      }
+    };
+  }
+}

--- a/common/src/test/java/org/astraea/common/UtilsTest.java
+++ b/common/src/test/java/org/astraea/common/UtilsTest.java
@@ -33,6 +33,26 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class UtilsTest {
 
   @Test
+  void testChunk() {
+    var input = List.of("a", "b", "c", "d");
+
+    var output = List.copyOf(Utils.chunk(input, 1));
+    Assertions.assertEquals(1, output.size());
+    Assertions.assertEquals(input, output.get(0));
+
+    var output2 = List.copyOf(Utils.chunk(input, 2));
+    Assertions.assertEquals(2, output2.size());
+    Assertions.assertEquals(List.of("a", "c"), output2.get(0));
+    Assertions.assertEquals(List.of("b", "d"), output2.get(1));
+
+    var output3 = List.copyOf(Utils.chunk(input, 3));
+    Assertions.assertEquals(3, output3.size(), output3.toString());
+    Assertions.assertEquals(List.of("a", "d"), output3.get(0));
+    Assertions.assertEquals(List.of("b"), output3.get(1));
+    Assertions.assertEquals(List.of("c"), output3.get(2));
+  }
+
+  @Test
   void testHandleException() {
     var executionRuntimeException =
         Assertions.assertThrows(

--- a/connector/src/test/java/org/astraea/connector/perf/PerfSourceTest.java
+++ b/connector/src/test/java/org/astraea/connector/perf/PerfSourceTest.java
@@ -40,6 +40,23 @@ import org.junit.jupiter.api.Test;
 public class PerfSourceTest extends RequireSingleWorkerCluster {
 
   @Test
+  void testTaskConfiguration() {
+    var s = new PerfSource();
+    var config = Configuration.of(Map.of(PerfSource.SPECIFY_PARTITIONS_DEF.name(), "0,1,2,3"));
+    s.init(config, MetadataStorage.EMPTY);
+    var configs = s.takeConfiguration(10);
+    Assertions.assertEquals(4, configs.size());
+    Assertions.assertEquals(
+        0, configs.get(0).requireInteger(PerfSource.SPECIFY_PARTITIONS_DEF.name()));
+    Assertions.assertEquals(
+        1, configs.get(1).requireInteger(PerfSource.SPECIFY_PARTITIONS_DEF.name()));
+    Assertions.assertEquals(
+        2, configs.get(2).requireInteger(PerfSource.SPECIFY_PARTITIONS_DEF.name()));
+    Assertions.assertEquals(
+        3, configs.get(3).requireInteger(PerfSource.SPECIFY_PARTITIONS_DEF.name()));
+  }
+
+  @Test
   void testDefaultConfig() {
     var name = Utils.randomString();
     var client = ConnectorClient.builder().url(workerUrl()).build();
@@ -75,12 +92,38 @@ public class PerfSourceTest extends RequireSingleWorkerCluster {
   }
 
   @Test
-  void testFrequency() {
-    testConfig(PerfSource.FREQUENCY_DEF.name(), "a");
+  void testThroughput() {
+    testConfig(PerfSource.THROUGHPUT_DEF.name(), "a");
     Assertions.assertThrows(
         IllegalArgumentException.class,
-        () -> PerfSource.FREQUENCY_DEF.validator().accept("aa", "bbb"));
-    Assertions.assertDoesNotThrow(() -> PerfSource.FREQUENCY_DEF.validator().accept("aa", "10s"));
+        () -> PerfSource.THROUGHPUT_DEF.validator().accept("aa", "bbb"));
+    Assertions.assertDoesNotThrow(() -> PerfSource.THROUGHPUT_DEF.validator().accept("aa", "10Kb"));
+
+    var name = Utils.randomString();
+    var topicName = Utils.randomString();
+    var client = ConnectorClient.builder().url(workerUrl()).build();
+    client
+        .createConnector(
+            name,
+            Map.of(
+                ConnectorConfigs.CONNECTOR_CLASS_KEY,
+                PerfSource.class.getName(),
+                ConnectorConfigs.TASK_MAX_KEY,
+                "1",
+                ConnectorConfigs.TOPICS_KEY,
+                topicName,
+                PerfSource.THROUGHPUT_DEF.name(),
+                "0Byte"))
+        .toCompletableFuture()
+        .join();
+
+    Utils.sleep(Duration.ofSeconds(3));
+
+    try (var admin = Admin.of(bootstrapServers())) {
+      // no records due to throughput is defined by 0Byte
+      Assertions.assertFalse(
+          admin.topicNames(false).toCompletableFuture().join().contains(topicName));
+    }
   }
 
   @Test
@@ -304,7 +347,7 @@ public class PerfSourceTest extends RequireSingleWorkerCluster {
     task.init(Configuration.of(Map.of(ConnectorConfigs.TOPICS_KEY, "a")), MetadataStorage.EMPTY);
     Assertions.assertNotNull(task.rand);
     Assertions.assertNotNull(task.topics);
-    Assertions.assertNotNull(task.frequency);
+    Assertions.assertNotNull(task.throughput);
     Assertions.assertNotNull(task.keySelector);
     Assertions.assertNotNull(task.keySizeGenerator);
     Assertions.assertNotNull(task.keys);


### PR DESCRIPTION
如題，現在`PerfSource`支援`throughput`限制輸出資料的速率，這可以搭配`specify.partitions`來設定各個 partitions的輸出速度