### PR TITLE
Make `NetworkCost` replication bandwidth aware

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/NetworkCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NetworkCost.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.astraea.common.EnumInfo;
 import org.astraea.common.admin.BrokerTopic;
 import org.astraea.common.admin.ClusterBean;
 import org.astraea.common.admin.ClusterInfo;
@@ -172,7 +173,9 @@ public abstract class NetworkCost implements HasClusterCost {
                           .orElseThrow(
                               () ->
                                   new NoSufficientMetricsException(
-                                      this, Duration.ofSeconds(1), "No metric for " + bt));
+                                      this,
+                                      Duration.ofSeconds(1),
+                                      "No " + metric.metricName() + " for " + bt));
               if (Double.isNaN(totalShare) || totalShare < 0)
                 throw new NoSufficientMetricsException(
                     this,
@@ -203,8 +206,13 @@ public abstract class NetworkCost implements HasClusterCost {
     throw new NoSufficientMetricsException(this, Duration.ofSeconds(1), reason);
   }
 
-  enum BandwidthType {
+  enum BandwidthType implements EnumInfo {
     Ingress,
-    Egress
+    Egress;
+
+    @Override
+    public String alias() {
+      return name();
+    }
   }
 }

--- a/common/src/main/java/org/astraea/common/cost/NetworkCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NetworkCost.java
@@ -210,9 +210,18 @@ public abstract class NetworkCost implements HasClusterCost {
     Ingress,
     Egress;
 
+    static BandwidthType ofAlias(String alias) {
+      return EnumInfo.ignoreCaseEnum(BandwidthType.class, alias);
+    }
+
     @Override
     public String alias() {
       return name();
+    }
+
+    @Override
+    public String toString() {
+      return alias();
     }
   }
 }

--- a/common/src/main/java/org/astraea/common/cost/NetworkEgressCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NetworkEgressCost.java
@@ -16,15 +16,12 @@
  */
 package org.astraea.common.cost;
 
-import org.astraea.common.metrics.broker.ServerMetrics;
-
 /**
  * A cost function to evaluate cluster load balance score in terms of message egress data rate. See
  * {@link NetworkCost} for further detail.
  */
 public class NetworkEgressCost extends NetworkCost {
-  @Override
-  ServerMetrics.Topic useMetric() {
-    return ServerMetrics.Topic.BYTES_OUT_PER_SEC;
+  public NetworkEgressCost() {
+    super(BandwidthType.Egress);
   }
 }

--- a/common/src/main/java/org/astraea/common/cost/NetworkIngressCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NetworkIngressCost.java
@@ -16,15 +16,12 @@
  */
 package org.astraea.common.cost;
 
-import org.astraea.common.metrics.broker.ServerMetrics;
-
 /**
  * A cost function to evaluate cluster load balance score in terms of message ingress data rate. See
  * {@link NetworkCost} for further detail.
  */
 public class NetworkIngressCost extends NetworkCost {
-  @Override
-  ServerMetrics.Topic useMetric() {
-    return ServerMetrics.Topic.BYTES_IN_PER_SEC;
+  public NetworkIngressCost() {
+    super(BandwidthType.Ingress);
   }
 }

--- a/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
@@ -184,7 +184,7 @@ class NetworkCostTest {
   }
 
   @Test
-  void testIngressWithFollowerReplica() {
+  void testReplicationAware() {
     var base =
         ClusterInfoBuilder.builder()
             .addNode(Set.of(1, 2, 3))

--- a/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
@@ -230,7 +230,7 @@ class NetworkCostTest {
                     List.of(
                         bandwidth(ServerMetrics.Topic.BYTES_IN_PER_SEC, "Rain", 100),
                         bandwidth(ServerMetrics.Topic.BYTES_OUT_PER_SEC, "Rain", 300)),
-                2, List.of(),
+                2, List.of(noise(5566)),
                 3,
                     List.of(
                         bandwidth(ServerMetrics.Topic.BYTES_IN_PER_SEC, "Drop", 80),


### PR DESCRIPTION
Resolve #1326.

讓 `NetworkCost` 把 follower replica 造成的流量納入考量。

![image](https://user-images.githubusercontent.com/39105714/209189593-5d757795-e17e-48ea-8ee5-4fc2e1cccfd8.png)

* 黃色線是所有節點的網路卡看到的流量之平均
* 綠色線是所有節點的 BytesInPerSec + ReplicationBytesInPerSec 之平均
* 藍色線是 CostFunction 預計會看到的，所有節點的輸入流量 之平均

黃色線和綠色線之間有一個微妙約 20 MB/s 的差異，這個差異可能是來自 Protocol 的額外資料開銷，這部分應該是沒辦法直接用 JMX metrics 取得

## 測試

1. 兩個 Topic，各 100 個 Partition, Replication Factor 2，依照 Kafka 創建 topic 的邏輯擺放。
2. Partition 輸入流量速率固定
3. Partition 的流量依照 Zipfian 分配

![image](https://user-images.githubusercontent.com/39105714/209189174-809fa35c-26ee-4c86-a466-d12f032c6b9d.png)

上圖中的 `BrokerIngress` 和 `BrokerEgress` 是各節點的 `BytesInPerSec + ReplicationBytesInPerSec`

上圖的 Max-min time series 是各時間點最大流量和最小流量的差異，因為線太多、加上現在的情境複雜很難把流量都聚集成一條線，所以用他反映負載有沒有比較集中