### PR TITLE
Treat no partition load metric as zero load in `NetworkCost`

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/NetworkCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NetworkCost.java
@@ -55,6 +55,19 @@ public abstract class NetworkCost implements HasClusterCost {
 
   abstract ServerMetrics.Topic useMetric();
 
+  void noMetricCheck(ClusterBean clusterBean) {
+    var noMetricBrokers =
+        clusterBean.all().entrySet().stream()
+            .filter(e -> e.getValue().size() == 0)
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toUnmodifiableList());
+    if (!noMetricBrokers.isEmpty())
+      throw new NoSufficientMetricsException(
+          this,
+          Duration.ofSeconds(1),
+          "The following broker has no metric available: " + noMetricBrokers);
+  }
+
   void updateCurrentCluster(
       ClusterInfo<Replica> clusterInfo,
       ClusterBean clusterBean,
@@ -75,6 +88,7 @@ public abstract class NetworkCost implements HasClusterCost {
 
   @Override
   public ClusterCost clusterCost(ClusterInfo<Replica> clusterInfo, ClusterBean clusterBean) {
+    noMetricCheck(clusterBean);
     updateCurrentCluster(clusterInfo, clusterBean, currentCluster);
 
     var dataRate = estimateRate(currentCluster.get(), clusterBean, useMetric());
@@ -123,6 +137,10 @@ public abstract class NetworkCost implements HasClusterCost {
                 Collectors.mapping(Map.Entry::getValue, Collectors.toUnmodifiableList())));
   }
 
+  /**
+   * Estimate the produce load for each partition. If a partition have no load metric in
+   * ClusterBean, it will be considered as zero produce load.
+   */
   Map<TopicPartition, Long> estimateRate(
       ClusterInfo<? extends Replica> clusterInfo,
       ClusterBean clusterBean,
@@ -139,10 +157,8 @@ public abstract class NetworkCost implements HasClusterCost {
                           .filter(bean -> bean.type().equals(metric))
                           .max(Comparator.comparingLong(HasBeanObject::createdTimestamp))
                           .map(HasRate::fifteenMinuteRate)
-                          .orElseThrow(
-                              () ->
-                                  new NoSufficientMetricsException(
-                                      this, Duration.ofSeconds(1), "No metric for " + bt));
+                          // no load metric for this partition, treat as zero load
+                          .orElse(0.0);
               if (Double.isNaN(totalShare) || totalShare < 0)
                 throw new NoSufficientMetricsException(
                     this,

--- a/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
@@ -186,6 +186,50 @@ class NetworkCostTest {
     testOptimization(costFunction, testCase);
   }
 
+  @Test
+  void testZeroBandwidth() {
+    // if a partition has no produce/fetch occur, it won't have a BytesInPerSec or BytesOutPerSec
+    // metric entry on the remote Kafka MBeanServer. To work around this we should treat them as
+    // zero partition ingress/egress instead of complaining no metric available.
+    var cluster =
+        ClusterInfoBuilder.builder()
+            .addNode(Set.of(1, 2, 3))
+            .addFolders(Map.of(1, Set.of("/folder0", "/folder1")))
+            .addFolders(Map.of(2, Set.of("/folder0", "/folder1")))
+            .addFolders(Map.of(3, Set.of("/folder0", "/folder1")))
+            .addTopic("Pipeline", 10, (short) 2)
+            .build();
+    var beans =
+        ClusterBean.of(
+            Map.of(
+                1, List.of(noise(5566)),
+                2, List.of(noise(5566)),
+                3, List.of(noise(5566))));
+    Assertions.assertDoesNotThrow(
+        () -> ingressCost().clusterCost(cluster, beans),
+        "Metric sampled but no load value, treat as zero load");
+    Assertions.assertDoesNotThrow(
+        () -> egressCost().clusterCost(cluster, beans),
+        "Metric sampled but no load value, treat as zero load");
+    Assertions.assertEquals(0, ingressCost().clusterCost(cluster, beans).value());
+    Assertions.assertEquals(0, egressCost().clusterCost(cluster, beans).value());
+
+    Assertions.assertThrows(
+        NoSufficientMetricsException.class,
+        () ->
+            ingressCost()
+                .clusterCost(
+                    cluster, ClusterBean.of(Map.of(1, List.of(), 2, List.of(), 3, List.of()))),
+        "Should raise a exception since we don't know if first sample is performed or not");
+    Assertions.assertThrows(
+        NoSufficientMetricsException.class,
+        () ->
+            egressCost()
+                .clusterCost(
+                    cluster, ClusterBean.of(Map.of(1, List.of(), 2, List.of(), 3, List.of()))),
+        "Should raise a exception since we don't know if first sample is performed or not");
+  }
+
   interface TestCase {
 
     ClusterInfo<Replica> clusterInfo();


### PR DESCRIPTION
Resolve #1327 