### PR TITLE
[GUI] add health page to show the nonavailable topic/partition

### DIFF
--- a/gui/src/main/java/org/astraea/gui/tab/topic/TopicNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/topic/TopicNode.java
@@ -41,6 +41,7 @@ import org.astraea.common.admin.ConsumerGroup;
 import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.Partition;
 import org.astraea.common.admin.ProducerState;
+import org.astraea.common.admin.Topic;
 import org.astraea.common.admin.TopicConfigs;
 import org.astraea.common.metrics.broker.HasRate;
 import org.astraea.common.metrics.broker.ServerMetrics;
@@ -398,6 +399,78 @@ public class TopicNode {
         .collect(Collectors.toList());
   }
 
+  public static Node healthNode(Context context) {
+    return PaneBuilder.of()
+        .firstPart(
+            null,
+            List.of(),
+            "CHECK",
+            (argument, logger) ->
+                context
+                    .admin()
+                    .topicNames(true)
+                    .thenCompose(
+                        names ->
+                            FutureUtils.combine(
+                                context.admin().topics(names),
+                                context.admin().partitions(names),
+                                (topics, partitions) -> {
+                                  var minInSync =
+                                      topics.stream()
+                                          .collect(
+                                              Collectors.toMap(
+                                                  Topic::name,
+                                                  t ->
+                                                      t.config()
+                                                          .value(
+                                                              TopicConfigs
+                                                                  .MIN_IN_SYNC_REPLICAS_CONFIG)
+                                                          .map(Integer::parseInt)
+                                                          .orElse(1)));
+                                  var result =
+                                      new LinkedHashMap<String, List<Map<String, Object>>>();
+
+                                  var unavailablePartitions =
+                                      partitions.stream()
+                                          .filter(
+                                              p ->
+                                                  p.isr().size()
+                                                          < minInSync.getOrDefault(p.topic(), 1)
+                                                      || p.leader().isEmpty())
+                                          .map(
+                                              p -> {
+                                                var r = new LinkedHashMap<String, Object>();
+                                                r.put("topic", p.topic());
+                                                r.put("partition", p.partition());
+                                                r.put(
+                                                    "leader",
+                                                    p.leader()
+                                                        .map(n -> String.valueOf(n.id()))
+                                                        .orElse("null"));
+                                                r.put(
+                                                    "in-sync replicas",
+                                                    p.isr().stream()
+                                                        .map(n -> String.valueOf(n.id()))
+                                                        .collect(Collectors.joining(",")));
+                                                r.put(
+                                                    TopicConfigs.MIN_IN_SYNC_REPLICAS_CONFIG,
+                                                    minInSync.getOrDefault(p.topic(), 1));
+                                                r.put("readable", p.leader().isPresent());
+                                                r.put(
+                                                    "writable",
+                                                    p.leader().isPresent()
+                                                        && p.isr().size()
+                                                            >= minInSync.getOrDefault(
+                                                                p.topic(), 1));
+                                                return (Map<String, Object>) r;
+                                              })
+                                          .collect(Collectors.toList());
+                                  result.put("unavailable partitions", unavailablePartitions);
+                                  return result;
+                                })))
+        .build();
+  }
+
   public static Node of(Context context) {
     return Slide.of(
             Side.TOP,
@@ -407,6 +480,7 @@ public class TopicNode {
                 "replica", ReplicaNode.of(context),
                 "config", configNode(context),
                 "metrics", metricsNode(context),
+                "health", healthNode(context),
                 "create", createNode(context)))
         .node();
   }


### PR DESCRIPTION
<img width="1197" alt="截圖 2022-12-26 上午1 06 21" src="https://user-images.githubusercontent.com/6234750/209476458-421df521-453f-4403-9607-78f5b5b4fdc8.png">


新增可顯示健康的頁面，上圖是顯示不可讀或寫的partitions