### PR TITLE
fix flaky BalancerHandlerTest#testTopics

### DIFF
--- a/app/src/main/java/org/astraea/app/web/BalancerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BalancerHandler.java
@@ -202,7 +202,7 @@ class BalancerHandler implements Handler {
   }
 
   private static List<MigrationCost> migrationCosts(MoveCost cost) {
-    return List.of(
+    return Stream.of(
             new MigrationCost(
                 CHANGED_REPLICAS,
                 cost.changedReplicaCount().entrySet().stream()
@@ -221,7 +221,6 @@ class BalancerHandler implements Handler {
                     .collect(
                         Collectors.toMap(
                             e -> String.valueOf(e.getKey()), e -> (double) e.getValue().bytes()))))
-        .stream()
         .filter(m -> !m.brokerCosts.isEmpty())
         .collect(Collectors.toList());
   }

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -71,7 +71,6 @@ import org.astraea.common.producer.Producer;
 import org.astraea.common.producer.Record;
 import org.astraea.it.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -71,6 +71,7 @@ import org.astraea.common.producer.Producer;
 import org.astraea.common.producer.Record;
 import org.astraea.it.RequireBrokerCluster;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -175,7 +176,10 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
               .findFirst()
               .get();
       Assertions.assertNotEquals(0, sizeMigration.brokerCosts.size());
-      sizeMigration.brokerCosts.values().forEach(v -> Assertions.assertNotEquals(0D, v));
+      Assertions.assertNotEquals(
+          0,
+          sizeMigration.brokerCosts.values().stream().filter(v -> v > 0).count(),
+          "report.cost: " + report.cost + " report.newCost.get(): " + report.newCost.get());
     }
   }
 


### PR DESCRIPTION
現在 move cost 固定會出幾個面向的報告，當選擇的 cost function 不支援該項報告時，就可能產生某個報告會有 0 的結果，因此這隻PR將測試改成“一定會有一項報告會有不為0的數值"

resolve #1318