### PR TITLE
Return empty map instead of error when fetching producer states from …

### DIFF
--- a/common/src/main/java/org/astraea/common/admin/AdminImpl.java
+++ b/common/src/main/java/org/astraea/common/admin/AdminImpl.java
@@ -570,6 +570,17 @@ class AdminImpl implements Admin {
                                 .map(TopicPartition::to)
                                 .collect(Collectors.toUnmodifiableList()))
                         .all())
+                    .exceptionally(
+                        e -> {
+                          // supported version: 2.8.0
+                          // https://issues.apache.org/jira/browse/KAFKA-12238
+                          if (e instanceof UnsupportedVersionException
+                              || e.getCause() instanceof UnsupportedVersionException)
+                            return Map.of();
+
+                          if (e instanceof RuntimeException) throw (RuntimeException) e;
+                          throw new RuntimeException(e);
+                        })
                     .thenApply(
                         ps ->
                             ps.entrySet().stream()

--- a/gui/src/main/java/org/astraea/gui/tab/topic/TopicNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/topic/TopicNode.java
@@ -384,8 +384,10 @@ public class TopicNode {
                   .ifPresent(t -> result.put("max timestamp", t));
               result.put(
                   "number of consumer group", topicGroups.getOrDefault(topic, Set.of()).size());
-              result.put(
-                  "number of producer id", topicProducers.getOrDefault(topic, Set.of()).size());
+              // producer states is supported by kafka 2.8.0+
+              if (!topicProducers.isEmpty())
+                result.put(
+                    "number of producer id", topicProducers.getOrDefault(topic, Set.of()).size());
               ps.stream()
                   .flatMap(p -> p.replicas().stream())
                   .collect(Collectors.groupingBy(NodeInfo::id))


### PR DESCRIPTION
當目標kafka版本老舊時則返回空集合 (producer states)