### PR TITLE
Fix `BalancerHandlerTest#testNoReport`

### DIFF
--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -415,10 +415,8 @@ public class BalancerHandlerTest extends RequireBrokerCluster {
       Assertions.assertEquals(GreedyBalancer.class.getName(), progress.config.balancer);
       Assertions.assertEquals(BalancerHandler.PlanPhase.Searched, progress.phase, "search done");
       Assertions.assertNotNull(progress.exception, "hint about no plan found");
-      Assertions.assertTrue(progress.plan.newCost.isEmpty(), "No proposal");
       Assertions.assertNotNull(progress.config.function);
-      Assertions.assertEquals(0, progress.plan.changes.size(), "No proposal");
-      Assertions.assertEquals(0, progress.plan.migrationCosts.size(), "No proposal");
+      Assertions.assertNull(progress.plan, "no proposal");
       Assertions.assertInstanceOf(
           IllegalStateException.class,
           Assertions.assertThrows(


### PR DESCRIPTION
Context #1335 

一個測試有問題，應該等最後一個 commit 的測試跑完再按合併...

https://github.com/skiptests/astraea/actions/runs/3787179796/jobs/6438738489#step:5:897

```
BalancerHandlerTest > testNoReport() FAILED
    java.lang.NullPointerException
        at org.astraea.app.web.BalancerHandlerTest.testNoReport(BalancerHandlerTest.java:418)
```