### PR TITLE
[ETL] enable to recursive looking for source path

### DIFF
--- a/docker/start_etl.sh
+++ b/docker/start_etl.sh
@@ -99,6 +99,8 @@ function runContainer() {
       --master $master \
       /tmp/astraea-etl.jar \
       "$propertiesPath"
+
+    echo "application web: http:$ADDRESS:$ui_port"
   else
     echo "$master is unsupported"
     exit 1

--- a/etl/src/main/scala/org/astraea/etl/ReadStreams.scala
+++ b/etl/src/main/scala/org/astraea/etl/ReadStreams.scala
@@ -36,6 +36,7 @@ object ReadStreams {
       columns: Seq[DataColumn]
   ): DataFrameOp = {
     val df = session.readStream
+      .option("recursiveFileLookup", "true")
       .option("cleanSource", "delete")
       .schema(schema(columns))
       .csv(source)


### PR DESCRIPTION
如題，允許探索多階層的目錄，同時在腳本中印出 application web 位址