### PR TITLE
Disable data-directory migration

### DIFF
--- a/app/src/main/java/org/astraea/app/web/BalancerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BalancerHandler.java
@@ -85,11 +85,11 @@ class BalancerHandler implements Handler {
   private final Duration sampleInterval = Duration.ofSeconds(1);
 
   BalancerHandler(Admin admin) {
-    this(admin, (ignore) -> Optional.empty(), new StraightPlanExecutor());
+    this(admin, (ignore) -> Optional.empty(), new StraightPlanExecutor(true));
   }
 
   BalancerHandler(Admin admin, Function<Integer, Optional<Integer>> jmxPortMapper) {
-    this(admin, jmxPortMapper, new StraightPlanExecutor());
+    this(admin, jmxPortMapper, new StraightPlanExecutor(true));
   }
 
   BalancerHandler(Admin admin, RebalancePlanExecutor executor) {
@@ -554,7 +554,10 @@ class BalancerHandler implements Handler {
   static class Placement {
 
     final int brokerId;
-    final String directory;
+
+    // temporarily disable data-directory migration, there are some Kafka bug related to it.
+    // see https://github.com/skiptests/astraea/issues/1325#issue-1506582838
+    @JsonIgnore final String directory;
 
     final Optional<Long> size;
 

--- a/common/src/main/java/org/astraea/common/cost/NetworkCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NetworkCost.java
@@ -48,6 +48,9 @@ import org.astraea.common.metrics.collector.Fetcher;
  *   <li>The network egress data rate of each partition is constant, it won't fluctuate over time.
  *   <li>No consumer or consumer group attempts to subscribe or read a subset of partitions. It must
  *       subscribe to the whole topic.
+ *   <li>This cost function relies on fifteen-minute rate metrics. To run two rebalance plans one by
+ *       one, make sure there is a 15 minute interval between the generation of next plan and the
+ *       execution of previous plan
  *   <li>This implementation assumes consumer won't fetch data from the closest replica. That is,
  *       every consumer fetches data from the leader(which is the default behavior of Kafka). For
  *       more detail about consumer rack awareness or how consumer can fetch data from the closest

--- a/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
@@ -123,7 +123,7 @@ class BalancerTest extends RequireBrokerCluster {
                   Duration.ofSeconds(10))
               .solution()
               .orElseThrow();
-      new StraightPlanExecutor()
+      new StraightPlanExecutor(true)
           .run(admin, plan.proposal(), Duration.ofSeconds(10))
           .toCompletableFuture()
           .join();

--- a/docs/web_server/web_api_balancer_chinese.md
+++ b/docs/web_server/web_api_balancer_chinese.md
@@ -135,9 +135,9 @@ JSON Response 範例
     * `partition`: partition id
     * `before`: 原本的配置
       * `brokerId`: 有掌管 replica 的節點 id
-      * `directory`: replica 存在資料的路徑
       * `size`: replica 在硬碟上的資料大小
     * `after`: 比較好的配置
+      * `brokerId`: 有掌管 replica 的節點 id
   * `migrations`: 計算搬移計畫的成本
     * `function`: 用來評估成本的演算法
     * `totalCost`: 各個broker的成本總和

--- a/docs/web_server/web_api_balancer_chinese.md
+++ b/docs/web_server/web_api_balancer_chinese.md
@@ -158,38 +158,16 @@ JSON Response 範例
   "plan": {
     "changes": [
       {
-        "topic": "__consumer_offsets",
-        "partition": 40,
-        "before": [
-          {
-            "brokerId": 1006,
-            "directory": "/tmp/log-folder-0",
-            "size": 1234
-          }
-        ],
-        "after": [
-          {
-            "brokerId": 1002,
-            "directory": "/tmp/log-folder-0"
-          }
-        ]
+        "topic": "example_topic",
+        "partition": 0,
+        "before": [ { "brokerId": 1006, "size": 2048 } ],
+        "after": [ { "brokerId": 1002 } ]
       },
       {
-        "topic": "__consumer_offsets",
-        "partition": 44,
-        "before": [
-          {
-            "brokerId": 1003,
-            "directory": "/tmp/log-folder-0",
-            "size": 12355
-          }
-        ],
-        "after": [
-          {
-            "brokerId": 1001,
-            "directory": "/tmp/log-folder-2"
-          }
-        ]
+        "topic": "example_topic",
+        "partition": 1,
+        "before": [ { "brokerId": 1003, "size": 1024 } ],
+        "after": [ { "brokerId": 1004 } ]
       }
     ]
   }


### PR DESCRIPTION
Context: #1325

目前 Kafka 的實作在面對 Data-Directory 的搬移時有機會觸發節點內部的實作錯誤，導致搬移卡住不結束。這個情況會使 Web Service 無法做其他計劃的生成或執行。這個 PR 暫時移除實作內的 Data-Directory Migration 行為