### PR TITLE
[BACKUP] size of exporter should be optional

### DIFF
--- a/connector/src/main/java/org/astraea/connector/backup/Exporter.java
+++ b/connector/src/main/java/org/astraea/connector/backup/Exporter.java
@@ -104,14 +104,16 @@ public class Exporter extends SinkConnector {
     private FileSystem ftpClient;
     private String topicName;
     private String path;
-    private String size;
+    private DataSize size;
 
     @Override
     protected void init(Configuration configuration) {
       this.ftpClient = FileSystem.of(configuration.requireString(SCHEMA_KEY.name()), configuration);
       this.topicName = configuration.requireString(TOPICS_KEY);
       this.path = configuration.requireString(PATH_KEY.name());
-      this.size = configuration.requireString(SIZE_KEY.name());
+      this.size =
+          DataSize.of(
+              configuration.string(SIZE_KEY.name()).orElse(SIZE_KEY.defaultValue().toString()));
     }
 
     @Override
@@ -135,7 +137,7 @@ public class Exporter extends SinkConnector {
                 });
         writer.append(record);
 
-        if (writer.size().greaterThan(DataSize.of(this.size))) {
+        if (writer.size().greaterThan(size)) {
           writers.remove(record.topicPartition()).close();
         }
       }

--- a/connector/src/test/java/org/astraea/connector/backup/ExporterTest.java
+++ b/connector/src/test/java/org/astraea/connector/backup/ExporterTest.java
@@ -16,18 +16,25 @@
  */
 package org.astraea.connector.backup;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.astraea.common.Configuration;
 import org.astraea.common.Utils;
 import org.astraea.common.backup.RecordReader;
 import org.astraea.common.connector.Config;
 import org.astraea.common.connector.ConnectorClient;
+import org.astraea.common.connector.ConnectorConfigs;
 import org.astraea.common.connector.Value;
 import org.astraea.common.consumer.Record;
+import org.astraea.common.producer.Producer;
 import org.astraea.fs.FileSystem;
 import org.astraea.it.FtpServer;
 import org.astraea.it.RequireWorkerCluster;
@@ -35,6 +42,52 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ExporterTest extends RequireWorkerCluster {
+
+  @Test
+  void testRunWithDefaultConfigs() throws IOException {
+    var topic = Utils.randomString();
+    var client = ConnectorClient.builder().url(workerUrl()).build();
+    try (var producer = Producer.of(bootstrapServers())) {
+      IntStream.range(0, 100)
+          .forEach(
+              i ->
+                  producer.send(
+                      org.astraea.common.producer.Record.builder()
+                          .topic(topic)
+                          .key(String.valueOf(i).getBytes(StandardCharsets.UTF_8))
+                          .value(String.valueOf(i).getBytes(StandardCharsets.UTF_8))
+                          .build()));
+      producer.flush();
+    }
+
+    var tmpFolder = Files.createTempDirectory("testRunWithDefaultConfigs").toString();
+    var name = Utils.randomString();
+    client
+        .createConnector(
+            name,
+            Map.of(
+                ConnectorConfigs.CONNECTOR_CLASS_KEY,
+                Exporter.class.getName(),
+                ConnectorConfigs.TOPICS_KEY,
+                topic,
+                ConnectorConfigs.TASK_MAX_KEY,
+                "1",
+                "path",
+                tmpFolder,
+                "fs.schema",
+                "local"))
+        .toCompletableFuture()
+        .join();
+
+    Utils.sleep(Duration.ofSeconds(3));
+
+    var status = client.connectorStatus(name).toCompletableFuture().join();
+    Assertions.assertEquals("RUNNING", status.state());
+    Assertions.assertNotEquals(0, status.tasks().size());
+    status
+        .tasks()
+        .forEach(t -> Assertions.assertEquals("RUNNING", t.state(), t.error().orElse("")));
+  }
 
   @Test
   void testRequiredConfigs() {


### PR DESCRIPTION
kafka connector 並不會主動匯入 default value，因此我們在解析參數的時候要自行取得 default value 