### PR TITLE
Fix performance tool non throttle 

### DIFF
--- a/app/src/main/java/org/astraea/app/performance/DataGenerator.java
+++ b/app/src/main/java/org/astraea/app/performance/DataGenerator.java
@@ -20,11 +20,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -39,7 +40,7 @@ import org.astraea.common.producer.Record;
 
 public interface DataGenerator extends AbstractThread {
   static DataGenerator of(
-      BlockingQueue<List<Record<byte[], byte[]>>> queue,
+      List<ArrayBlockingQueue<List<Record<byte[], byte[]>>>> queues,
       Supplier<TopicPartition> partitionSelector,
       Performance.Argument argument) {
     var dataSupplier =
@@ -88,7 +89,7 @@ public interface DataGenerator extends AbstractThread {
 
                       // throttled data wouldn't put into the queue
                       if (records.isEmpty()) continue;
-
+                      var queue = queues.get(ThreadLocalRandom.current().nextInt(queues.size()));
                       queue.put(records);
                     }
                   } catch (InterruptedException e) {

--- a/app/src/main/java/org/astraea/app/performance/Performance.java
+++ b/app/src/main/java/org/astraea/app/performance/Performance.java
@@ -393,6 +393,9 @@ public class Performance {
             specifyPartitions.stream().distinct().collect(Collectors.toUnmodifiableList());
         return () -> selection.get(ThreadLocalRandom.current().nextInt(selection.size()));
       } else if (throttle) {
+        if (partitioner != null)
+          throw new IllegalArgumentException(
+              "--throttle can't be used in conjunction with partitioner");
         try (var admin = Admin.of(configs())) {
           final var selection =
               admin

--- a/app/src/main/java/org/astraea/app/performance/Performance.java
+++ b/app/src/main/java/org/astraea/app/performance/Performance.java
@@ -393,6 +393,8 @@ public class Performance {
             specifyPartitions.stream().distinct().collect(Collectors.toUnmodifiableList());
         return () -> selection.get(ThreadLocalRandom.current().nextInt(selection.size()));
       } else if (throttle) {
+        // TODO: The functions of throttle and select partitioner should not conflict with each
+        // other
         if (partitioner != null)
           throw new IllegalArgumentException(
               "--throttle can't be used in conjunction with partitioner");

--- a/app/src/main/java/org/astraea/app/performance/ProducerThread.java
+++ b/app/src/main/java/org/astraea/app/performance/ProducerThread.java
@@ -17,7 +17,7 @@
 package org.astraea.app.performance;
 
 import java.util.List;
-import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -34,7 +34,7 @@ import org.astraea.common.producer.Record;
 public interface ProducerThread extends AbstractThread {
 
   static List<ProducerThread> create(
-      BlockingQueue<List<Record<byte[], byte[]>>> queue,
+      List<ArrayBlockingQueue<List<Record<byte[], byte[]>>>> queues,
       int producers,
       Supplier<Producer<byte[], byte[]>> producerSupplier,
       int interdependent) {
@@ -60,6 +60,7 @@ public interface ProducerThread extends AbstractThread {
               var closeLatch = closeLatches.get(index);
               var closed = new AtomicBoolean(false);
               var producer = producerSupplier.get();
+              var queue = queues.get(index);
               executors.execute(
                   () -> {
                     try {

--- a/docs/performance_benchmark.md
+++ b/docs/performance_benchmark.md
@@ -33,7 +33,7 @@
 |       configs       | (選填) 給partitioner的設置檔。 設置格式為 "\<key1\>=\<value1\>[,\<key2\>=\<value2\>]*"。 <br />例如: "--configs broker.1001.jmx.port=14338,org.astraea.cost.ThroughputCost=1" |           none           |
 |     throughput      | (選填) 用來限制輸出資料的速度, 範例： "--throughput 2MiB/m", "--throughput 2GB" 預設值是秒 <br/>大小單位: MB, MiB, Kb etc. <br />時間單位: second(s), minute(m), hour(h), day(d) or PT expression(PT30S) |      500 GiB/second      |
 |   specify.brokers   | (選填) 指定broker的ID，送資料到指定的broker，若 broker 上有 "目標 topic 的 partition" |           none           |
-| specify.partitions  | (選填) 指定要傳送資料的 topic/partitions，多個項目之間可以用逗號隔開，注意這個選項不能和 `specify.brokers` 或 `partitioner` 一起使用 |           none           |
+| specify.partitions  | (選填) 指定要傳送資料的 topic/partitions，多個項目之間可以用逗號隔開，注意這個選項不能和 `specify.brokers` 、`throttle` 或 `partitioner` 一起使用 |           none           |
 |     report.path     | (選填) report file的檔案路徑                                 |           none           |
 |    report.format    | (選填) 選擇輸出檔案格式, 可用的格式：`csv`, `json`           |           csv            |
 |  transaction.size   | (選填) 每個transaction的records數量。若設置1以上，會使用transaction，否則都是一般write |            1             |
@@ -41,7 +41,7 @@
 |      read.idle      | (選填) 讀取端將被終止如果超過這個時間沒有讀取到新的資料      |           2秒            |
 | interdependent.size | (選填) 每幾筆 record 要發到同一個 partition。(注意：只有 Astraea Dispatcher 可以使用) |            1             |
 |       monkeys       | (選填) 設定 chaos monkey 的觸發頻率，支援 : `kill`, `add`, `unsubscribe`。<br />觸發頻率單位為 ：day, h, m, s, ms, us, ns<br />範例：`--monkeys kill:3s,add:5s` |           none           |
-|      throttle       | (選填) 用來指定 topic-partitions 的限流值<br />例如：--throttle a1-0:5MB/s,a2-0:10MB/s,a10-4:30MB/s |           none           |
+|      throttle       | (選填) 用來指定 topic-partitions 的限流值<br />例如：--throttle a1-0:5MB/s,a2-0:10MB/s,a10-4:30MB/s<br />注意此參數不可與`specify.partitions`、`specify.brokers` 或`partitioner` 一起使用 |           none           |
 
 #### 使用範例
 


### PR DESCRIPTION
此 PR 為 Performance tool 新增一個判斷式，用來判斷有沒有開啟 throttle

突然想到當初沒有測到沒加入 throttle 功能的打資料效果，發現會影響到 performance tool producers 的吞吐量，如下圖`實作throttle前`與`實作throttle後`的差異

`實作throttle前`的 Revision number: 3123a226e1073121bc1072221937af0ed3212fbe 
![throttle_bug_1](https://user-images.githubusercontent.com/90374678/210130369-d56f8ebd-d139-42c5-a1bf-d402306ab7e4.png)
測試指令:
```=bash
./start_app.sh performance --bootstrap.servers 192.168.103.171:9092,192.168.103.172:9092,192.168.103.173:9092 --topics a1,a2,a10 --producers 5 --consumers 0 --run.until 3m
```
經過確認後發現是修改 partition selector 的問題，需要加上一個判斷式來判斷有無 throttle

****

下圖為此 PR 修正後的測試 throttle 功能的數據
![throttle_fix_1](https://user-images.githubusercontent.com/90374678/210130379-7c8fa3ba-9922-416b-ba1c-aba5ced26dc2.png)
1. 沒有設置 throttle 的指令
```=bash
ACCOUNT=harryteng9527 VERSION=fix-non-throttle ./start_app.sh performance --bootstrap.servers 192.168.103.171:9092,192.168.103.172:9092 --topics a1,a2,a10 --producers 5 --consumers 0 --run.until 3m
```

2. 設置 throttle 的指令
```=bash
ACCOUNT=harryteng9527 VERSION=fix-non-throttle ./start_app.sh performance --bootstrap.servers 192.168.103.171:9092,192.168.103.172:9092 --topics a1,a2,a10 --producers 5 --consumers 0 --run.until 3m --throttle a1-0:5MB/s,a2-0:10MB/s,a2-1:20MB/s
```

下次會在更細心的檢查，不好意思
****

不過在修改此 PR 時，發現新增完 throttle 功能後，throughput 會下降，如上圖 `新增 throttle 前` 與 `未 throttle`

造成吞吐量下降的原因應該是 queue 的影響，我把目前 producers 共享一個 queue 的作法改成每個 producer 使用一個 queue 和 把目前 size 為 1000 的 queue 加大到 3000 後，發現 throughput 上升了兩倍，如下圖吞吐量數據

![image](https://user-images.githubusercontent.com/90374678/210131942-324eb376-1a8c-4604-961c-85ad92329aa0.png)

