### PR TITLE
[DISPATCHER] change Dispatcher from interface to abstract class

### DIFF
--- a/common/src/main/java/org/astraea/common/partitioner/StrictCostDispatcher.java
+++ b/common/src/main/java/org/astraea/common/partitioner/StrictCostDispatcher.java
@@ -51,7 +51,7 @@ import org.astraea.common.metrics.collector.MetricCollector;
  * and its weight. For example,
  * `org.astraea.cost.ThroughputCost=1,org.astraea.cost.broker.BrokerOutputCost=1`.
  */
-public class StrictCostDispatcher implements Dispatcher {
+public class StrictCostDispatcher extends Dispatcher {
   static final int ROUND_ROBIN_LENGTH = 400;
 
   public static final String JMX_PORT = "jmx.port";
@@ -204,7 +204,7 @@ public class StrictCostDispatcher implements Dispatcher {
   }
 
   @Override
-  public void doClose() {
+  public void close() {
     metricCollector.close();
   }
 }


### PR DESCRIPTION
這隻 PR 將 `Dispatcher` 改成 `abstract class`，這樣做的目的如下：

1. `Dispatcher` 將提供更多基礎設施（例如定時同步 ClusterInfo)，改成 abstract class 可以包存該些資訊在上層類別
2. 可以給予我們更強大的限制來阻擋 kafka 的內容暴露到下層