### PR TITLE
[DISPATCHER] create Admin for all dispatcher to fetch full cluster info

### DIFF
--- a/common/src/main/java/org/astraea/common/partitioner/StrictCostDispatcher.java
+++ b/common/src/main/java/org/astraea/common/partitioner/StrictCostDispatcher.java
@@ -72,7 +72,7 @@ public class StrictCostDispatcher extends Dispatcher {
 
   volatile long timeToUpdateRoundRobin = -1;
 
-  void tryToUpdateFetcher(ClusterInfo<ReplicaInfo> clusterInfo) {
+  void tryToUpdateFetcher(ClusterInfo<? extends ReplicaInfo> clusterInfo) {
     // register new nodes to metric collector
     costFunction
         .fetcher()
@@ -96,7 +96,7 @@ public class StrictCostDispatcher extends Dispatcher {
 
   @Override
   public int partition(
-      String topic, byte[] key, byte[] value, ClusterInfo<ReplicaInfo> clusterInfo) {
+      String topic, byte[] key, byte[] value, ClusterInfo<? extends ReplicaInfo> clusterInfo) {
     var partitionLeaders = clusterInfo.replicaLeaders(topic);
     // just return first partition if there is no available partitions
     if (partitionLeaders.isEmpty()) return 0;
@@ -119,7 +119,7 @@ public class StrictCostDispatcher extends Dispatcher {
     return candidate.get((int) (Math.random() * candidate.size())).partition();
   }
 
-  synchronized void tryToUpdateRoundRobin(ClusterInfo<ReplicaInfo> clusterInfo) {
+  synchronized void tryToUpdateRoundRobin(ClusterInfo<? extends ReplicaInfo> clusterInfo) {
     if (System.currentTimeMillis() >= timeToUpdateRoundRobin) {
       var roundRobin =
           RoundRobin.smooth(
@@ -206,5 +206,6 @@ public class StrictCostDispatcher extends Dispatcher {
   @Override
   public void close() {
     metricCollector.close();
+    super.close();
   }
 }

--- a/common/src/main/java/org/astraea/common/partitioner/smooth/SmoothWeightRoundRobin.java
+++ b/common/src/main/java/org/astraea/common/partitioner/smooth/SmoothWeightRoundRobin.java
@@ -110,7 +110,8 @@ public final class SmoothWeightRoundRobin {
    *
    * @return the preferred ID
    */
-  public synchronized int getAndChoose(String topic, ClusterInfo<ReplicaInfo> clusterInfo) {
+  public synchronized int getAndChoose(
+      String topic, ClusterInfo<? extends ReplicaInfo> clusterInfo) {
     // TODO Update brokerID with ClusterInfo frequency.
     var brokerID =
         brokersIDofTopic.computeIfAbsent(

--- a/common/src/test/java/org/astraea/common/partitioner/DispatcherTest.java
+++ b/common/src/test/java/org/astraea/common/partitioner/DispatcherTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.security.Key;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -51,6 +52,84 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 public class DispatcherTest extends RequireSingleBrokerCluster {
+
+  @Test
+  void testNoTopicInCachedClusterInfo() {
+    var topicName = Utils.randomString();
+    var count = new AtomicInteger(0);
+    try (var dispatcher =
+        new Dispatcher() {
+          @Override
+          public int partition(
+              String topic,
+              byte[] key,
+              byte[] value,
+              ClusterInfo<? extends ReplicaInfo> clusterInfo) {
+            Assertions.assertNotNull(clusterInfo);
+            return 0;
+          }
+
+          @Override
+          boolean tryToUpdate(String topic) {
+            if (topic != null) Assertions.assertEquals(topicName, topic);
+            var rval = super.tryToUpdate(topic);
+            if (rval) count.incrementAndGet();
+            return rval;
+          }
+        }) {
+
+      dispatcher.configure(Map.of(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers()));
+
+      // the topic is nonexistent in cluster, so it always request to update cluster info
+      Assertions.assertEquals(
+          0,
+          dispatcher.partition(topicName, "xx", new byte[0], "xx", new byte[0], Cluster.empty()));
+      Assertions.assertEquals(2, count.get());
+      Assertions.assertEquals(
+          0,
+          dispatcher.partition(topicName, "xx", new byte[0], "xx", new byte[0], Cluster.empty()));
+      Assertions.assertEquals(3, count.get());
+
+      // create the topic
+      dispatcher.admin.creator().topic(topicName).run().toCompletableFuture().join();
+      Utils.sleep(Duration.ofSeconds(2));
+      Assertions.assertEquals(
+          0,
+          dispatcher.partition(topicName, "xx", new byte[0], "xx", new byte[0], Cluster.empty()));
+      Assertions.assertEquals(4, count.get());
+
+      // ok, the topic exists now, and it should not request to update
+      Utils.sleep(Duration.ofSeconds(2));
+      Assertions.assertEquals(
+          0,
+          dispatcher.partition(topicName, "xx", new byte[0], "xx", new byte[0], Cluster.empty()));
+      Assertions.assertEquals(4, count.get());
+    }
+  }
+
+  @Test
+  void testUpdateClusterInfo() {
+
+    try (var dispatcher =
+        new Dispatcher() {
+          @Override
+          public int partition(
+              String topic,
+              byte[] key,
+              byte[] value,
+              ClusterInfo<? extends ReplicaInfo> clusterInfo) {
+            Assertions.assertNotNull(clusterInfo);
+            return 0;
+          }
+        }) {
+
+      dispatcher.configure(Map.of(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers()));
+      Assertions.assertNotNull(dispatcher.admin);
+      Utils.sleep(Duration.ofSeconds(3));
+      Assertions.assertNotEquals(0, dispatcher.clusterInfo.nodes().size());
+    }
+  }
+
   @Test
   void testNullKey() {
     var count = new AtomicInteger();
@@ -58,7 +137,10 @@ public class DispatcherTest extends RequireSingleBrokerCluster {
         new Dispatcher() {
           @Override
           public int partition(
-              String topic, byte[] key, byte[] value, ClusterInfo<ReplicaInfo> clusterInfo) {
+              String topic,
+              byte[] key,
+              byte[] value,
+              ClusterInfo<? extends ReplicaInfo> clusterInfo) {
             Assertions.assertNull(key);
             Assertions.assertNull(value);
             count.incrementAndGet();
@@ -76,26 +158,6 @@ public class DispatcherTest extends RequireSingleBrokerCluster {
     Assertions.assertEquals(1, count.get());
     dispatcher.partition(
         "t", null, null, null, null, new Cluster("aa", List.of(), List.of(), Set.of(), Set.of()));
-    Assertions.assertEquals(2, count.get());
-  }
-
-  @Test
-  void testClusterCache() {
-    var dispatcher =
-        new Dispatcher() {
-          @Override
-          public int partition(
-              String topic, byte[] key, byte[] value, ClusterInfo<ReplicaInfo> clusterInfo) {
-            return 0;
-          }
-        };
-    dispatcher.configure(Map.of());
-    var initialCount = Dispatcher.CLUSTER_CACHE.size();
-    var cluster = new Cluster("aa", List.of(), List.of(), Set.of(), Set.of());
-    dispatcher.partition("topic", "a", new byte[0], "v", new byte[0], cluster);
-    Assertions.assertEquals(initialCount + 1, Dispatcher.CLUSTER_CACHE.size());
-    dispatcher.partition("topic", "a", new byte[0], "v", new byte[0], cluster);
-    Assertions.assertEquals(initialCount + 1, Dispatcher.CLUSTER_CACHE.size());
   }
 
   @RepeatedTest(5)


### PR DESCRIPTION
這隻 PR 將 `Admin` 整合到 `Dispatcher` 裡面，如此下游的 Dispatcher 可以確保收到“完整"的 ClusterInfo，如此之後各個成本都可以統一面對 `Replica`