### PR TITLE
[DISPATCHER] reduce the overhead of collecting leader info

### DIFF
--- a/app/src/main/java/org/astraea/app/performance/ProducerThread.java
+++ b/app/src/main/java/org/astraea/app/performance/ProducerThread.java
@@ -27,11 +27,22 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.astraea.common.Utils;
+import org.astraea.common.metrics.MBeanRegister;
+import org.astraea.common.metrics.Sensor;
+import org.astraea.common.metrics.stats.Avg;
 import org.astraea.common.partitioner.Dispatcher;
 import org.astraea.common.producer.Producer;
 import org.astraea.common.producer.Record;
 
 public interface ProducerThread extends AbstractThread {
+
+  String DOMAIN_NAME = "org.astraea";
+  String TYPE_PROPERTY = "type";
+
+  String TYPE_VALUE = "producer";
+
+  String AVG_PROPERTY = "avg";
+  String ID_PROPERTY = "client-id";
 
   static List<ProducerThread> create(
       List<ArrayBlockingQueue<List<Record<byte[], byte[]>>>> queues,
@@ -61,6 +72,14 @@ public interface ProducerThread extends AbstractThread {
               var closed = new AtomicBoolean(false);
               var producer = producerSupplier.get();
               var queue = queues.get(index);
+              var sensor = Sensor.builder().addStat(AVG_PROPERTY, Avg.of()).build();
+              // export the custom jmx for report thread
+              MBeanRegister.local()
+                  .domainName(DOMAIN_NAME)
+                  .property(TYPE_PROPERTY, TYPE_VALUE)
+                  .property(ID_PROPERTY, producer.clientId())
+                  .attribute(AVG_PROPERTY, Double.class, () -> sensor.measure(AVG_PROPERTY))
+                  .register();
               executors.execute(
                   () -> {
                     try {
@@ -75,7 +94,18 @@ public interface ProducerThread extends AbstractThread {
                           Dispatcher.beginInterdependent(producer);
                           interdependentCounter += data.size();
                         }
-                        if (data != null) producer.send(data);
+                        var now = System.currentTimeMillis();
+                        if (data != null)
+                          producer
+                              .send(data)
+                              .forEach(
+                                  f ->
+                                      f.whenComplete(
+                                          (r, e) -> {
+                                            if (e == null)
+                                              sensor.record(
+                                                  (double) (System.currentTimeMillis() - now));
+                                          }));
 
                         // End interdependent
                         if (interdependent > 1 && interdependentCounter >= interdependent) {

--- a/app/src/main/java/org/astraea/app/performance/Report.java
+++ b/app/src/main/java/org/astraea/app/performance/Report.java
@@ -96,24 +96,18 @@ public interface Report {
 
                   @Override
                   public Optional<Double> e2eLatency() {
-                    try {
-                      return Optional.ofNullable(
-                              MBeanClient.local()
-                                  .queryBean(
-                                      BeanQuery.builder()
-                                          .domainName(ProducerThread.DOMAIN_NAME)
-                                          .property(
-                                              ProducerThread.TYPE_PROPERTY,
-                                              ProducerThread.TYPE_VALUE)
-                                          .property(ProducerThread.ID_PROPERTY, m.clientId())
-                                          .build())
-                                  .attributes()
-                                  .get(ProducerThread.AVG_PROPERTY))
-                          .map(v -> (double) v);
-                    } catch (Exception e) {
-                      e.printStackTrace();
-                      return Optional.empty();
-                    }
+                    return Optional.ofNullable(
+                            MBeanClient.local()
+                                .queryBean(
+                                    BeanQuery.builder()
+                                        .domainName(ProducerThread.DOMAIN_NAME)
+                                        .property(
+                                            ProducerThread.TYPE_PROPERTY, ProducerThread.TYPE_VALUE)
+                                        .property(ProducerThread.ID_PROPERTY, m.clientId())
+                                        .build())
+                                .attributes()
+                                .get(ProducerThread.AVG_PROPERTY))
+                        .map(v -> (double) v);
                   }
 
                   @Override

--- a/app/src/main/java/org/astraea/app/performance/TrackerThread.java
+++ b/app/src/main/java/org/astraea/app/performance/TrackerThread.java
@@ -79,6 +79,12 @@ public interface TrackerThread extends AbstractThread {
           .mapToDouble(Report::avgLatency)
           .average()
           .ifPresent(i -> System.out.printf("  publish average latency: %.3f ms%n", i));
+      reports.stream()
+          .flatMap(r -> r.e2eLatency().stream())
+          .mapToDouble(v -> v)
+          .filter(v -> !Double.isNaN(v))
+          .average()
+          .ifPresent(i -> System.out.printf("  publish e2e-average latency: %.3f ms%n", i));
       for (int i = 0; i < reports.size(); ++i) {
         System.out.printf(
             "  producer[%d] average throughput: %s%n",

--- a/common/src/main/java/org/astraea/common/metrics/stats/Avg.java
+++ b/common/src/main/java/org/astraea/common/metrics/stats/Avg.java
@@ -33,7 +33,7 @@ public class Avg {
 
       @Override
       public synchronized Double measure() {
-        if (counter == 0) throw new RuntimeException("Nothing to measure");
+        if (counter == 0) return Double.NaN;
         return accumulator / counter;
       }
     };

--- a/common/src/main/java/org/astraea/common/metrics/stats/Max.java
+++ b/common/src/main/java/org/astraea/common/metrics/stats/Max.java
@@ -17,9 +17,14 @@
 package org.astraea.common.metrics.stats;
 
 public class Max<V extends Comparable<V>> implements Stat<V> {
+
+  public static <V extends Comparable<V>> Max<V> of() {
+    return new Max<>();
+  }
+
   private V max;
 
-  public Max() {
+  private Max() {
     max = null;
   }
 

--- a/common/src/test/java/org/astraea/common/metrics/stats/AvgTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/stats/AvgTest.java
@@ -32,9 +32,9 @@ public class AvgTest {
   }
 
   @Test
-  void testException() {
+  void testNan() {
     var stat = Avg.of();
-    Assertions.assertThrows(RuntimeException.class, stat::measure);
+    Assertions.assertEquals(Double.NaN, stat.measure());
   }
 
   @Test

--- a/common/src/test/java/org/astraea/common/metrics/stats/MaxTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/stats/MaxTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 public class MaxTest {
   @Test
   void testMax() {
-    var stat = new Max<Integer>();
+    var stat = Max.<Integer>of();
     stat.record(39);
     stat.record(20);
     stat.record(103);
@@ -32,7 +32,7 @@ public class MaxTest {
 
   @Test
   void testException() {
-    var stat = new Max<Integer>();
+    var stat = Max.<Integer>of();
     Assertions.assertThrows(RuntimeException.class, stat::measure);
   }
 }

--- a/common/src/test/java/org/astraea/common/partitioner/DispatcherTest.java
+++ b/common/src/test/java/org/astraea/common/partitioner/DispatcherTest.java
@@ -53,56 +53,6 @@ import org.junit.jupiter.api.Test;
 public class DispatcherTest extends RequireSingleBrokerCluster {
 
   @Test
-  void testNoTopicInCachedClusterInfo() {
-    var topicName = Utils.randomString();
-    var count = new AtomicInteger(0);
-    try (var dispatcher =
-        new Dispatcher() {
-          @Override
-          public int partition(String topic, byte[] key, byte[] value, ClusterInfo clusterInfo) {
-            Assertions.assertNotNull(clusterInfo);
-            return 0;
-          }
-
-          @Override
-          boolean tryToUpdate(String topic) {
-            if (topic != null) Assertions.assertEquals(topicName, topic);
-            var rval = super.tryToUpdate(topic);
-            if (rval) count.incrementAndGet();
-            return rval;
-          }
-        }) {
-
-      dispatcher.configure(Map.of(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers()));
-
-      // the topic is nonexistent in cluster, so it always request to update cluster info
-      Assertions.assertEquals(
-          0,
-          dispatcher.partition(topicName, "xx", new byte[0], "xx", new byte[0], Cluster.empty()));
-      Assertions.assertEquals(2, count.get());
-      Assertions.assertEquals(
-          0,
-          dispatcher.partition(topicName, "xx", new byte[0], "xx", new byte[0], Cluster.empty()));
-      Assertions.assertEquals(3, count.get());
-
-      // create the topic
-      dispatcher.admin.creator().topic(topicName).run().toCompletableFuture().join();
-      Utils.sleep(Duration.ofSeconds(2));
-      Assertions.assertEquals(
-          0,
-          dispatcher.partition(topicName, "xx", new byte[0], "xx", new byte[0], Cluster.empty()));
-      Assertions.assertEquals(4, count.get());
-
-      // ok, the topic exists now, and it should not request to update
-      Utils.sleep(Duration.ofSeconds(2));
-      Assertions.assertEquals(
-          0,
-          dispatcher.partition(topicName, "xx", new byte[0], "xx", new byte[0], Cluster.empty()));
-      Assertions.assertEquals(4, count.get());
-    }
-  }
-
-  @Test
   void testUpdateClusterInfo() {
 
     try (var dispatcher =


### PR DESCRIPTION
#1403 後的幾個效能修正：

1. leader 的資訊很常被使用，因此快取起來
2. 更新 ClusterInfo 的時機改成用`nano`計算，避免在 ms 層級會同時觸發多個更新
3. producer thread 新增 e2e 延遲的統計，這個路徑包含使用 producer buffer/partitioner 的延遲