### PR TITLE
[COST][DISPATCHER] add NodeSizeCost to balance broker data size

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/NodeSizeCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NodeSizeCost.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.cost;
+
+import java.util.stream.Collectors;
+import org.astraea.common.admin.ClusterBean;
+import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.admin.NodeInfo;
+import org.astraea.common.admin.Replica;
+
+public class NodeSizeCost implements HasBrokerCost {
+  @Override
+  public BrokerCost brokerCost(ClusterInfo clusterInfo, ClusterBean clusterBean) {
+    var result =
+        clusterInfo.nodes().stream()
+            .collect(
+                Collectors.toMap(
+                    NodeInfo::id,
+                    n -> clusterInfo.replicaStream(n.id()).mapToDouble(Replica::size).sum()));
+    return () -> result;
+  }
+}

--- a/common/src/main/java/org/astraea/common/partitioner/StrictCostDispatcher.java
+++ b/common/src/main/java/org/astraea/common/partitioner/StrictCostDispatcher.java
@@ -119,8 +119,9 @@ public class StrictCostDispatcher extends Dispatcher {
 
   synchronized void tryToUpdateRoundRobin(ClusterInfo clusterInfo) {
     if (System.currentTimeMillis() >= timeToUpdateRoundRobin) {
-      var cost = costToScore(costFunction.brokerCost(clusterInfo, metricCollector.clusterBean()));
-      var roundRobin = RoundRobin.smooth(cost);
+      var roundRobin =
+          RoundRobin.smooth(
+              costToScore(costFunction.brokerCost(clusterInfo, metricCollector.clusterBean())));
       var ids =
           clusterInfo.nodes().stream().map(NodeInfo::id).collect(Collectors.toUnmodifiableSet());
       // TODO: make ROUND_ROBIN_LENGTH configurable ???

--- a/common/src/test/java/org/astraea/common/partitioner/StrictCostDispatcherTest.java
+++ b/common/src/test/java/org/astraea/common/partitioner/StrictCostDispatcherTest.java
@@ -258,6 +258,19 @@ public class StrictCostDispatcherTest {
   }
 
   @Test
+  void testInvalidCostToScore() {
+    Assertions.assertEquals(1, StrictCostDispatcher.costToScore(() -> Map.of(1, 100D)).size());
+    Assertions.assertEquals(
+        2, StrictCostDispatcher.costToScore(() -> Map.of(1, 100D, 2, 100D)).size());
+    var score = StrictCostDispatcher.costToScore(() -> Map.of(1, 100D, 2, 0D));
+    Assertions.assertNotEquals(0, score.size());
+    Assertions.assertTrue(score.get(2) > score.get(1));
+    StrictCostDispatcher.costToScore(() -> Map.of(1, -133D, 2, 100D))
+        .values()
+        .forEach(v -> Assertions.assertTrue(v > 0));
+  }
+
+  @Test
   void testRoundRobinLease() {
     try (var dispatcher = new StrictCostDispatcher()) {
 


### PR DESCRIPTION
新增一個簡單的成本估計用來平衡節點之間的資料量，同時也修正 score 會出現0的例外狀況