### PR TITLE
[TEST] fix the potential bug of broker leak

### DIFF
--- a/it/src/main/java/org/astraea/it/Services.java
+++ b/it/src/main/java/org/astraea/it/Services.java
@@ -194,7 +194,7 @@ public final class Services {
 
       @Override
       public void close() {
-        IntStream.range(0, brokers.size() - 1).forEach(this::close);
+        Set.copyOf(brokers.keySet()).forEach(this::close);
       }
 
       @Override


### PR DESCRIPTION
related to #435

如果總共有3個 brokers，分別是0,1,2，當測試中提前關閉了`1`後，陣列中的brokers會剩下0,2，但在走訪時我們會是呼叫關閉0,1，這樣會導致broker=2的並不會被關閉