### PR TITLE
[COMMON] Implementation of `Admin#declarePreferredDataFolders(Map)`

### DIFF
--- a/common/src/main/java/org/astraea/common/admin/Admin.java
+++ b/common/src/main/java/org/astraea/common/admin/Admin.java
@@ -283,12 +283,22 @@ public interface Admin extends AutoCloseable {
   CompletionStage<Void> moveToFolders(Map<TopicPartitionReplica, String> assignments);
 
   /**
-   * Move the replica to the specific data folder at their corresponding broker. If the specified
-   * replica doesn't exist, then declare the data folder as a preferred data folder. That being
-   * said, once the replica is moved to this broker, it will use this folder as its data folder.
-   * Instead of following the Kafka implementation detail to decide which folder it should use.
+   * Declare the desired data folder for the designated partition at a specific broker.
+   *
+   * <p>When a partition is being placed to a broker. The Kafka implementation picks a data folder
+   * to store this partition. This API allows you to demand which data folder a partition should use
+   * when the Kafka internal is making this decision. This API can come in handy when you want to
+   * place a replica in a specific data folder under a specific broker in one go. One way to do this
+   * is: use this method to declare preferred data folder at specific broker for the partition. Then
+   * use {@link Admin#moveToBrokers(Map)} to trigger the actual movement for that partition.
+   *
+   * <p>This API should not trigger an actual data folder movement. To perform a folder-to-folder
+   * movement under the same broker. Use {@link Admin#moveToFolders(Map)} instead. Although this API
+   * might accidentally trigger a data folder movement when there is another Kafka admin client
+   * changing the state of the cluster. To avoid such problem, one should ensure there is no other
+   * client manipulating the state of the cluster, chen calling this method.
    */
-  CompletionStage<Void> moveOrSetPreferredFolders(Map<TopicPartitionReplica, String> assignments);
+  CompletionStage<Void> declarePreferredDataFolders(Map<TopicPartitionReplica, String> assignments);
 
   /**
    * Perform preferred leader election for the specified topic/partitions. Let the first replica(the

--- a/common/src/main/java/org/astraea/common/admin/Admin.java
+++ b/common/src/main/java/org/astraea/common/admin/Admin.java
@@ -283,20 +283,15 @@ public interface Admin extends AutoCloseable {
   CompletionStage<Void> moveToFolders(Map<TopicPartitionReplica, String> assignments);
 
   /**
-   * Declare the desired data folder for the designated partition at a specific broker.
+   * Declare the preferred data folder for the designated partition at a specific broker.
    *
-   * <p>When a partition is being placed to a broker. The Kafka implementation picks a data folder
-   * to store this partition. This API allows you to demand which data folder a partition should use
-   * when the Kafka internal is making this decision. This API can come in handy when you want to
-   * place a replica in a specific data folder under a specific broker in one go. One way to do this
-   * is: use this method to declare preferred data folder at specific broker for the partition. Then
-   * use {@link Admin#moveToBrokers(Map)} to trigger the actual movement for that partition.
+   * <p>Preferred data folder is the data folder a partition will use when it is being placed on the
+   * specific broker({@link Admin#moveToBrokers(Map)}). This API won't trigger a folder-to-folder
+   * replica movement. To Perform folder-to-folder movement, consider use {@link
+   * Admin#moveToFolders(Map)}.
    *
-   * <p>This API should not trigger an actual data folder movement. To perform a folder-to-folder
-   * movement under the same broker. Use {@link Admin#moveToFolders(Map)} instead. Although this API
-   * might accidentally trigger a data folder movement when there is another Kafka admin client
-   * changing the state of the cluster. To avoid such problem, one should ensure there is no other
-   * client manipulating the state of the cluster, chen calling this method.
+   * <p>This API is not transactional. It won't work properly when there are concurrent changes to
+   * the cluster state.
    */
   CompletionStage<Void> declarePreferredDataFolders(Map<TopicPartitionReplica, String> assignments);
 

--- a/common/src/main/java/org/astraea/common/admin/Admin.java
+++ b/common/src/main/java/org/astraea/common/admin/Admin.java
@@ -283,6 +283,14 @@ public interface Admin extends AutoCloseable {
   CompletionStage<Void> moveToFolders(Map<TopicPartitionReplica, String> assignments);
 
   /**
+   * Move the replica to the specific data folder at their corresponding broker. If the specified
+   * replica doesn't exist, then declare the data folder as a preferred data folder. That being
+   * said, once the replica is moved to this broker, it will use this folder as its data folder.
+   * Instead of following the Kafka implementation detail to decide which folder it should use.
+   */
+  CompletionStage<Void> moveOrSetPreferredFolders(Map<TopicPartitionReplica, String> assignments);
+
+  /**
    * Perform preferred leader election for the specified topic/partitions. Let the first replica(the
    * preferred leader) in the partition replica list becomes the leader of its corresponding
    * topic/partition. Noted that the first replica(the preferred leader) must be in-sync state.

--- a/common/src/main/java/org/astraea/common/admin/Admin.java
+++ b/common/src/main/java/org/astraea/common/admin/Admin.java
@@ -290,8 +290,8 @@ public interface Admin extends AutoCloseable {
    * replica movement. To Perform folder-to-folder movement, consider use {@link
    * Admin#moveToFolders(Map)}.
    *
-   * <p>This API is not transactional. It won't work properly when there are concurrent changes to
-   * the cluster state.
+   * <p>This API is not transactional. It may alter folders if the target broker has out-of-date
+   * metadata or running reassignments
    */
   CompletionStage<Void> declarePreferredDataFolders(Map<TopicPartitionReplica, String> assignments);
 

--- a/common/src/main/java/org/astraea/common/admin/AdminImpl.java
+++ b/common/src/main/java/org/astraea/common/admin/AdminImpl.java
@@ -1004,12 +1004,8 @@ class AdminImpl implements Admin {
                     "Fail to expect a ReplicaNotAvailableException return from the API. "
                         + "A data folder movement might just triggered. "
                         + "Is there another Admin Client manipulating the cluster state?");
-              if (e instanceof CompletionException) {
-                if (e.getCause() instanceof ReplicaNotAvailableException) return null;
-                else {
-                  throw (RuntimeException) e.getCause();
-                }
-              }
+              if (e instanceof CompletionException
+                  && (e.getCause()) instanceof ReplicaNotAvailableException) return null;
               throw (RuntimeException) e;
             });
   }

--- a/common/src/main/java/org/astraea/common/balancer/executor/StraightPlanExecutor.java
+++ b/common/src/main/java/org/astraea/common/balancer/executor/StraightPlanExecutor.java
@@ -59,7 +59,24 @@ public class StraightPlanExecutor implements RebalancePlanExecutor {
                 tps.stream()
                     .flatMap(tp -> logAllocation.replicas(tp).stream())
                     .collect(Collectors.toList()))
-        // step 1: move replicas to specify brokers
+        // step.1 move replicas to specify folders or declare preferred folders
+        .thenCompose(
+            replicas ->
+                CompletableFuture.supplyAsync(
+                    () -> {
+                      // temporarily disable data-directory migration, there are some Kafka bug
+                      // related to it.
+                      // see https://github.com/skiptests/astraea/issues/1325#issue-1506582838
+                      if (!disableDataDirectoryMigration) {
+                        admin.moveOrSetPreferredFolders(
+                            replicas.stream()
+                                .collect(
+                                    Collectors.toMap(
+                                        Replica::topicPartitionReplica, Replica::path)));
+                      }
+                      return replicas;
+                    }))
+        // step 2: move replicas to designated brokers
         .thenCompose(
             replicas ->
                 admin
@@ -72,44 +89,10 @@ public class StraightPlanExecutor implements RebalancePlanExecutor {
                                     Collectors.mapping(
                                         r -> r.nodeInfo().id(), Collectors.toList()))))
                     .thenApply(ignored -> replicas))
-        // step 2: wait replicas get reassigned
-        .thenCompose(
-            replicas ->
-                admin
-                    .waitCluster(
-                        logAllocation.topics(),
-                        clusterInfo ->
-                            clusterInfo
-                                .topicPartitionReplicas()
-                                .containsAll(logAllocation.topicPartitionReplicas()),
-                        timeout,
-                        5)
-                    .thenApply(
-                        done -> {
-                          if (!done)
-                            throw new IllegalStateException(
-                                "Failed to move "
-                                    + replicas.stream()
-                                        .map(Replica::topicPartitionReplica)
-                                        .collect(Collectors.toSet()));
-                          return replicas;
-                        }))
-        // step.3 move replicas to specify folders
-        .thenCompose(
-            replicas -> {
-              // temporarily disable data-directory migration, there are some Kafka bug related to
-              // it.
-              // see https://github.com/skiptests/astraea/issues/1325#issue-1506582838
-              if (disableDataDirectoryMigration) return CompletableFuture.completedFuture(null);
-              else
-                return admin.moveToFolders(
-                    replicas.stream()
-                        .collect(Collectors.toMap(Replica::topicPartitionReplica, Replica::path)));
-            })
-        // step.4 wait replicas get synced
+        // step.3 wait replicas get synced
         .thenCompose(
             replicas -> admin.waitReplicasSynced(logAllocation.topicPartitionReplicas(), timeout))
-        // step.5 re-elect leaders
+        // step.4 re-elect leaders
         .thenCompose(
             topicPartitions ->
                 admin

--- a/common/src/test/java/org/astraea/common/admin/AdminTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AdminTest.java
@@ -30,12 +30,15 @@ import java.util.SortedSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.errors.LogDirNotFoundException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.astraea.common.DataRate;
 import org.astraea.common.Utils;
@@ -408,6 +411,111 @@ public class AdminTest {
 
       var newReplica = newReplicas.get(0);
       Assertions.assertEquals(idAndFolder.get(newReplica.nodeInfo().id()), newReplica.path());
+    }
+  }
+
+  @Test
+  void testMoveToPreferredFolder() {
+    try (var admin = Admin.of(SERVICE.bootstrapServers())) {
+      var topicName = Utils.randomString();
+      var thePartition = TopicPartition.of(topicName, 0);
+      var folders1 = List.copyOf(SERVICE.dataFolders().get(1));
+      // arrange: Test Preferred Declaration
+      admin
+          .creator()
+          .topic(topicName)
+          .numberOfPartitions(1)
+          .numberOfReplicas((short) 1)
+          .run()
+          .toCompletableFuture()
+          .join();
+      admin
+          .moveToBrokers(Map.of(TopicPartition.of(topicName, 0), List.of(0)))
+          .toCompletableFuture()
+          .join();
+      Utils.sleep(Duration.ofSeconds(1));
+
+      // act
+      var info0 = admin.clusterInfo(Set.of(topicName)).toCompletableFuture().join();
+      var original = info0.replicas(thePartition).get(0).path();
+      var dest = folders1.get(ThreadLocalRandom.current().nextInt(folders1.size()));
+      admin
+          .moveOrSetPreferredFolders(Map.of(TopicPartitionReplica.of(topicName, 0, 1), dest))
+          .toCompletableFuture()
+          .join();
+      Utils.sleep(Duration.ofSeconds(1));
+
+      // assert no actual movement until actual movement
+      var info1 = admin.clusterInfo(Set.of(topicName)).toCompletableFuture().join();
+      Assertions.assertEquals(1, info1.replicas(thePartition).size());
+      Assertions.assertEquals(original, info1.replicas(thePartition).get(0).path());
+
+      // act
+      admin.moveToBrokers(Map.of(thePartition, List.of(1))).toCompletableFuture().join();
+      Utils.sleep(Duration.ofSeconds(1));
+
+      // assert actual movement
+      var info = admin.clusterInfo(Set.of(topicName)).toCompletableFuture().join();
+      Assertions.assertEquals(1, info.replicas(thePartition).size());
+      Assertions.assertEquals(dest, info.replicas(thePartition).get(0).path());
+    }
+  }
+
+  @Test
+  void testMoveToPreferredFoldersException() {
+    try (Admin admin = Admin.of(SERVICE.bootstrapServers())) {
+      var topic = Utils.randomString();
+      admin
+          .creator()
+          .topic(topic)
+          .numberOfPartitions(1)
+          .numberOfReplicas((short) 1)
+          .run()
+          .toCompletableFuture()
+          .join();
+      Assertions.assertDoesNotThrow(
+          () -> admin.moveOrSetPreferredFolders(Map.of()).toCompletableFuture().join());
+      SERVICE
+          .dataFolders()
+          .forEach(
+              (broker, folders) ->
+                  folders.forEach(
+                      folder ->
+                          Assertions.assertDoesNotThrow(
+                              () ->
+                                  admin
+                                      .moveOrSetPreferredFolders(
+                                          Map.of(
+                                              TopicPartitionReplica.of(topic, 0, broker), folder))
+                                      .toCompletableFuture()
+                                      .join(),
+                              "Declaration or movement should not raise a exception")));
+      Assertions.assertInstanceOf(
+          LogDirNotFoundException.class,
+          Assertions.assertThrows(
+                  CompletionException.class,
+                  () ->
+                      admin
+                          .moveOrSetPreferredFolders(
+                              Map.of(TopicPartitionReplica.of(topic, 0, 0), "/no/such/folder"))
+                          .toCompletableFuture()
+                          .join())
+              .getCause(),
+          "Normal exception still propagated");
+      Assertions.assertInstanceOf(
+          UnknownTopicOrPartitionException.class,
+          Assertions.assertThrows(
+                  CompletionException.class,
+                  () ->
+                      admin
+                          .moveOrSetPreferredFolders(
+                              Map.of(
+                                  TopicPartitionReplica.of("NO_TOPIC" + Utils.randomString(), 0, 0),
+                                  SERVICE.dataFolders().get(0).iterator().next()))
+                          .toCompletableFuture()
+                          .join())
+              .getCause(),
+          "Normal exception still propagated");
     }
   }
 

--- a/common/src/test/java/org/astraea/common/admin/AdminTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AdminTest.java
@@ -518,7 +518,10 @@ public class AdminTest {
                   () ->
                       admin
                           .declarePreferredDataFolders(
-                              Map.of(TopicPartitionReplica.of(topic, 0, 1), "/no/such/folder"))
+                              Map.ofEntries(
+                                  Map.entry(
+                                      TopicPartitionReplica.of(topic, 0, 1), "/no/such/folder"),
+                                  Map.entry(TopicPartitionReplica.of(topic, 0, 0), folders.get(2))))
                           .toCompletableFuture()
                           .join())
               .getCause(),

--- a/common/src/test/java/org/astraea/common/admin/AdminTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AdminTest.java
@@ -478,6 +478,7 @@ public class AdminTest {
           .moveToBrokers(Map.of(TopicPartition.of(topic, 0), List.of(1)))
           .toCompletableFuture()
           .join();
+      Utils.sleep(Duration.ofSeconds(1));
       admin
           .declarePreferredDataFolders(
               Map.of(TopicPartitionReplica.of(topic, 0, 0), folders.get(0)))


### PR DESCRIPTION
Context: https://github.com/skiptests/astraea/issues/1393#issuecomment-1382656937

這個 PR 新增 `Admin#moveOrSetPreferredFolders()`，這個函數嘗試移動給定的 replica 到特定的 data folder，如果給定的 replica 不存在於特定的節點，則在該節點宣告 preferred data folder，當該 replica 在未來被移動到的那個節點時，將會直接採用當初指定的 preferred data folder 儲存資料，而非交由 Kafka 的實作細節決定儲存的 data folder。

這個 PR 順便修正 `StraightPlanExecutor` 的邏輯，在開始 broker to broker 的 replica movement 之前，會先透過這個 API 觸發 folder to folder 和 preferred data dir 的宣告。理論上這樣做可以多少減少一些 #1325 問題觸發的方式