### PR TITLE
Fix flaky ExporterTest#testFtpSinkTaskIntervalWith2Writers

### DIFF
--- a/connector/src/test/java/org/astraea/connector/backup/ExporterTest.java
+++ b/connector/src/test/java/org/astraea/connector/backup/ExporterTest.java
@@ -312,6 +312,7 @@ public class ExporterTest {
         Assertions.assertEquals(record.timestamp(), records1.timestamp());
         Assertions.assertEquals(record.offset(), records1.offset());
       }
+      task.close();
     }
   }
 
@@ -380,13 +381,13 @@ public class ExporterTest {
               .build();
 
       task.put(List.of(record1));
-      Utils.sleep(Duration.ofMillis(50));
+      Utils.sleep(Duration.ofMillis(500));
 
       task.put(List.of(record2));
-      Utils.sleep(Duration.ofMillis(600));
+      Utils.sleep(Duration.ofMillis(1000));
 
       task.put(List.of(record3));
-      Utils.sleep(Duration.ofMillis(600));
+      Utils.sleep(Duration.ofMillis(1000));
 
       Assertions.assertEquals(
           2, fs.listFolders("/" + String.join("/", fileSize, topicName)).size());
@@ -418,6 +419,7 @@ public class ExporterTest {
                   Assertions.assertEquals(record.offset(), sinkRecord.offset());
                 }
               });
+      task.close();
     }
   }
 }


### PR DESCRIPTION
fix #1432 

目前推測可能因為中間睡眠的時間太短，在處理完 `record 1,2` 這兩筆後 間隔 `record 3` 可能不超過 100ms，因此沒有將檔案分割開來。

目前先將中間的睡眠時間拉長，並在每個 `task` 的最後把 `task` 關閉，因為在本機連續測試時，最後沒有將 `task` 關閉可能會導致中間某次因其他原因失敗。

當下在本機上面跑過百次沒有出現這狀況，因此先試試看這個錯誤到底是不是因為這個導致的