### PR TITLE
[PERF] Remove `IOException` from performance tool method signature

### DIFF
--- a/app/src/main/java/org/astraea/app/performance/Performance.java
+++ b/app/src/main/java/org/astraea/app/performance/Performance.java
@@ -18,7 +18,6 @@ package org.astraea.app.performance;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -69,11 +68,11 @@ import org.astraea.common.producer.Record;
 /** see docs/performance_benchmark.md for man page */
 public class Performance {
   /** Used in Automation, to achieve the end of one Performance and then start another. */
-  public static void main(String[] args) throws IOException {
+  public static void main(String[] args) {
     execute(Performance.Argument.parse(new Argument(), args));
   }
 
-  public static List<String> execute(final Argument param) throws IOException {
+  public static List<String> execute(final Argument param) {
     var blockingQueues =
         IntStream.range(0, param.producers)
             .mapToObj(i -> new ArrayBlockingQueue<List<Record<byte[], byte[]>>>(3000))

--- a/app/src/main/java/org/astraea/app/performance/ReportFormat.java
+++ b/app/src/main/java/org/astraea/app/performance/ReportFormat.java
@@ -69,8 +69,7 @@ public enum ReportFormat implements EnumInfo {
       ReportFormat reportFormat,
       Path path,
       Supplier<Boolean> consumerDone,
-      Supplier<Boolean> producerDone)
-      throws IOException {
+      Supplier<Boolean> producerDone) {
     var filePath =
         FileSystems.getDefault()
             .getPath(
@@ -79,7 +78,7 @@ public enum ReportFormat implements EnumInfo {
                     + new SimpleDateFormat("yyyyMMddHHmmss").format(new Date())
                     + "."
                     + reportFormat);
-    var writer = new BufferedWriter(new FileWriter(filePath.toFile()));
+    var writer = new BufferedWriter(Utils.packException(() -> new FileWriter(filePath.toFile())));
     switch (reportFormat) {
       case CSV:
         initCSVFormat(writer, latencyAndIO());
@@ -94,7 +93,7 @@ public enum ReportFormat implements EnumInfo {
           }
         };
       case JSON:
-        writer.write("{");
+        Utils.packException(() -> writer.write("{"));
         return () -> {
           try {
             while (!(producerDone.get() && consumerDone.get())) {
@@ -110,10 +109,9 @@ public enum ReportFormat implements EnumInfo {
     }
   }
 
-  static void initCSVFormat(BufferedWriter writer, List<CSVContentElement> elements)
-      throws IOException {
+  static void initCSVFormat(BufferedWriter writer, List<CSVContentElement> elements) {
     elements.forEach(element -> Utils.packException(() -> writer.write(element.title() + ", ")));
-    writer.newLine();
+    Utils.packException(writer::newLine);
   }
 
   static void logToCSV(BufferedWriter writer, List<CSVContentElement> elements) {


### PR DESCRIPTION
* 移除 `Performance#main` 函數簽名上的 `throws IOException`
* 簡化 `Performance#execute` 中和 file writer 有關的呼叫邏輯