### PR TITLE
[COST] make sure all brokers have cost

### DIFF
--- a/common/src/main/java/org/astraea/common/admin/ClusterBean.java
+++ b/common/src/main/java/org/astraea/common/admin/ClusterBean.java
@@ -47,7 +47,8 @@ public interface ClusterBean {
               () ->
                   allBeans.entrySet().stream()
                       .collect(
-                          Collectors.toMap(Map.Entry::getKey, e -> List.copyOf(e.getValue()))));
+                          Collectors.toUnmodifiableMap(
+                              Map.Entry::getKey, e -> List.copyOf(e.getValue()))));
 
       @Override
       public Map<Integer, Collection<HasBeanObject>> all() {

--- a/common/src/main/java/org/astraea/common/admin/ClusterBean.java
+++ b/common/src/main/java/org/astraea/common/admin/ClusterBean.java
@@ -17,7 +17,6 @@
 package org.astraea.common.admin;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -32,7 +31,7 @@ import org.astraea.common.metrics.HasBeanObject;
 public interface ClusterBean {
   ClusterBean EMPTY = ClusterBean.of(Map.of());
 
-  static ClusterBean of(Map<Integer, Collection<HasBeanObject>> allBeans) {
+  static ClusterBean of(Map<Integer, ? extends Collection<? extends HasBeanObject>> allBeans) {
     return new ClusterBean() {
       final Lazy<Map<String, List<HasBeanObject>>> topicCache =
           Lazy.of(() -> map((id, bean) -> bean.topicIndex()));
@@ -43,9 +42,16 @@ public interface ClusterBean {
       final Lazy<Map<BrokerTopic, List<HasBeanObject>>> brokerTopicCache =
           Lazy.of(() -> map((id, bean) -> bean.brokerTopicIndex(id)));
 
+      final Lazy<Map<Integer, Collection<HasBeanObject>>> all =
+          Lazy.of(
+              () ->
+                  allBeans.entrySet().stream()
+                      .collect(
+                          Collectors.toMap(Map.Entry::getKey, e -> List.copyOf(e.getValue()))));
+
       @Override
       public Map<Integer, Collection<HasBeanObject>> all() {
-        return Collections.unmodifiableMap(allBeans);
+        return all.get();
       }
 
       @Override

--- a/common/src/main/java/org/astraea/common/cost/NodeMetricsCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NodeMetricsCost.java
@@ -18,11 +18,13 @@ package org.astraea.common.cost;
 
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.astraea.common.admin.ClusterBean;
 import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.metrics.client.HasNodeMetrics;
 import org.astraea.common.metrics.client.producer.ProducerMetrics;
 import org.astraea.common.metrics.collector.Fetcher;
@@ -32,24 +34,36 @@ public abstract class NodeMetricsCost implements HasBrokerCost {
   @Override
   public BrokerCost brokerCost(ClusterInfo clusterInfo, ClusterBean clusterBean) {
     var result =
-        clusterBean.all().values().stream()
-            .flatMap(Collection::stream)
-            .filter(b -> b instanceof HasNodeMetrics)
-            .map(b -> (HasNodeMetrics) b)
-            .filter(b -> !Double.isNaN(value(b)))
-            .collect(Collectors.groupingBy(HasNodeMetrics::brokerId))
-            .entrySet()
-            .stream()
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey,
-                    e ->
-                        e.getValue().stream()
-                            .sorted(
-                                Comparator.comparing(HasNodeMetrics::createdTimestamp).reversed())
-                            .limit(1)
-                            .mapToDouble(this::value)
-                            .sum()));
+        new HashMap<>(
+            clusterBean.all().values().stream()
+                .flatMap(Collection::stream)
+                .filter(b -> b instanceof HasNodeMetrics)
+                .map(b -> (HasNodeMetrics) b)
+                .filter(b -> !Double.isNaN(value(b)))
+                .collect(Collectors.groupingBy(HasNodeMetrics::brokerId))
+                .entrySet()
+                .stream()
+                .collect(
+                    Collectors.toMap(
+                        Map.Entry::getKey,
+                        e ->
+                            e.getValue().stream()
+                                .sorted(
+                                    Comparator.comparing(HasNodeMetrics::createdTimestamp)
+                                        .reversed())
+                                .limit(1)
+                                .mapToDouble(this::value)
+                                .sum())));
+    // Set max cost for the nodes having no metrics
+    result.values().stream()
+        .mapToDouble(v -> v)
+        .max()
+        .ifPresent(
+            max ->
+                clusterInfo.nodes().stream()
+                    .map(NodeInfo::id)
+                    .filter(id -> !result.containsKey(id))
+                    .forEach(id -> result.put(id, max)));
     return () -> result;
   }
 

--- a/common/src/test/java/org/astraea/common/cost/NodeMetricsCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NodeMetricsCostTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.cost;
+
+import java.time.Duration;
+import java.util.stream.Collectors;
+import org.astraea.common.Utils;
+import org.astraea.common.admin.Admin;
+import org.astraea.common.admin.ClusterBean;
+import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.client.HasNodeMetrics;
+import org.astraea.common.metrics.client.producer.ProducerMetrics;
+import org.astraea.common.producer.Producer;
+import org.astraea.common.producer.Record;
+import org.astraea.it.Service;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class NodeMetricsCostTest {
+
+  private static final Service SERVICE = Service.builder().numberOfBrokers(3).build();
+
+  @AfterAll
+  static void closeService() {
+    SERVICE.close();
+  }
+
+  @Test
+  void testAllBrokersHaveCost() {
+    var topic = Utils.randomString();
+    try (var admin = Admin.of(SERVICE.bootstrapServers());
+        var producer = Producer.of(SERVICE.bootstrapServers())) {
+      admin.creator().topic(topic).numberOfPartitions(3).run().toCompletableFuture().join();
+      Utils.sleep(Duration.ofSeconds(2));
+      producer.send(
+          Record.builder()
+              .topic(topic)
+              .partition(0)
+              .key(new byte[100])
+              .value(new byte[100])
+              .build());
+      producer.flush();
+      var function = new NodeLatencyCost();
+
+      var cost =
+          function.brokerCost(
+              admin
+                  .clusterInfo(admin.topicNames(false).toCompletableFuture().join())
+                  .toCompletableFuture()
+                  .join(),
+              ClusterBean.of(
+                  ProducerMetrics.nodes(MBeanClient.local()).stream()
+                      .collect(Collectors.groupingBy(HasNodeMetrics::brokerId))));
+      Assertions.assertEquals(3, cost.value().size());
+      // only 1 node has latency metrics, so all costs are equal
+      Assertions.assertEquals(1, cost.value().values().stream().distinct().count());
+
+      // produce to another node to make another "latency"
+      producer.send(
+          Record.builder()
+              .topic(topic)
+              .partition(1)
+              .key(new byte[100])
+              .value(new byte[100])
+              .build());
+
+      var cost2 =
+          function.brokerCost(
+              admin
+                  .clusterInfo(admin.topicNames(false).toCompletableFuture().join())
+                  .toCompletableFuture()
+                  .join(),
+              ClusterBean.of(
+                  ProducerMetrics.nodes(MBeanClient.local()).stream()
+                      .collect(Collectors.groupingBy(HasNodeMetrics::brokerId))));
+      Assertions.assertEquals(3, cost2.value().size());
+      // only 2 node has latency metrics. The other cost is equal to "max cost"
+      Assertions.assertEquals(2, cost2.value().values().stream().distinct().count());
+    }
+  }
+}


### PR DESCRIPTION
基於`node`的成本會在節點沒有對應指標時回傳“空”的成本，這會導致該節點無法被納入評估，因此這隻PR賦予所有“沒有指標”的節點最基本的分數 - max cost，代表該些節點也應該被考慮，但不是最佳優先