### PR TITLE
[COST] Provide descriptive `toString()` implementation for weight composite function

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/HasClusterCost.java
+++ b/common/src/main/java/org/astraea/common/cost/HasClusterCost.java
@@ -67,8 +67,8 @@ public interface HasClusterCost extends CostFunction {
           @Override
           public String toString() {
             Bi3Function<HasClusterCost, Double, Double, String> descriptiveName =
-                (cost, score, weight) ->
-                    "{\"" + cost.toString() + "\" cost " + score + " weight " + weight + "}";
+                (function, cost, weight) ->
+                    "{\"" + function.toString() + "\" cost " + cost + " weight " + weight + "}";
             return "WeightCompositeClusterCost["
                 + costAndWeight.entrySet().stream()
                     .sorted(

--- a/common/src/main/java/org/astraea/common/cost/HasClusterCost.java
+++ b/common/src/main/java/org/astraea/common/cost/HasClusterCost.java
@@ -24,6 +24,7 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import org.astraea.common.admin.ClusterBean;
 import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.function.Bi3Function;
 import org.astraea.common.metrics.collector.Fetcher;
 import org.astraea.common.metrics.collector.MetricSensor;
 
@@ -46,12 +47,42 @@ public interface HasClusterCost extends CostFunction {
     return new HasClusterCost() {
       @Override
       public ClusterCost clusterCost(ClusterInfo clusterInfo, ClusterBean clusterBean) {
-        var cost =
+        var scores =
             costAndWeight.entrySet().stream()
-                .mapToDouble(
-                    cw -> cw.getKey().clusterCost(clusterInfo, clusterBean).value() * cw.getValue())
+                .collect(
+                    Collectors.toUnmodifiableMap(
+                        Map.Entry::getKey,
+                        e -> e.getKey().clusterCost(clusterInfo, clusterBean).value()));
+        var compositeScore =
+            costAndWeight.keySet().stream()
+                .mapToDouble(cost -> costAndWeight.get(cost) * scores.get(cost))
                 .sum();
-        return () -> cost;
+
+        return new ClusterCost() {
+          @Override
+          public double value() {
+            return compositeScore;
+          }
+
+          @Override
+          public String toString() {
+            Bi3Function<HasClusterCost, Double, Double, String> descriptiveName =
+                (cost, score, weight) ->
+                    "{\"" + cost.toString() + "\" cost " + score + " weight " + weight + "}";
+            return "WeightCompositeClusterCost["
+                + costAndWeight.entrySet().stream()
+                    .sorted(
+                        Comparator.<Map.Entry<HasClusterCost, Double>>comparingDouble(
+                                Map.Entry::getValue)
+                            .reversed())
+                    .map(
+                        e ->
+                            descriptiveName.apply(e.getKey(), scores.get(e.getKey()), e.getValue()))
+                    .collect(Collectors.joining(", "))
+                + "] = "
+                + compositeScore;
+          }
+        };
       }
 
       @Override
@@ -68,7 +99,7 @@ public interface HasClusterCost extends CostFunction {
       public String toString() {
         BiFunction<HasClusterCost, Double, String> descriptiveName =
             (cost, value) -> "{\"" + cost.toString() + "\" weight " + value + "}";
-        return "WeightCompositeClusterCost["
+        return "WeightCompositeClusterCostFunction["
             + costAndWeight.entrySet().stream()
                 .sorted(
                     Comparator.<Map.Entry<HasClusterCost, Double>>comparingDouble(


### PR DESCRIPTION
給 `HasClusterCost#of()` 回傳的 CostFunction 所回傳的 `ClusterCost` 提供一個可讀性高的 `Object#toString()` 實作。如此一來能夠看到比較細緻的 Cost 組合資訊，如：

```java
var plan = balancer.offer(clusterInfo, Duration.ofSeconds(10));
System.out.println(plan.solution().get().proposalClusterCost());
```

```
WeightCompositeClusterCost[{"org.astraea.common.cost.ReplicaNumberCost@73035e27" cost 1.0 weight 3.0}, {"org.astraea.common.cost.NetworkIngressCost@64c64813" cost 6.107885824866958E-5 weight 1.0}, {"org.astraea.common.cost.NetworkEgressCost@3ecf72fd" cost 6.107885824866958E-5 weight 1.0}] = 3.0001221577164974
```