### PR TITLE
[COST] Rewrite `ReplicaNumberCost#clusterCost`

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/ClusterCost.java
+++ b/common/src/main/java/org/astraea/common/cost/ClusterCost.java
@@ -20,7 +20,17 @@ package org.astraea.common.cost;
 public interface ClusterCost {
 
   /**
-   * @return cost of cluster
+   * The cost score of a Kafka cluster. This value represents the idealness of a Kafka cluster in
+   * terms of a specific performance aspect.
+   *
+   * <p>This value should be bounded between the range of [0, 1]. The value of 0 represents the
+   * Kafka cluster is in the best condition regarding the specific performance aspect. And 1
+   * represents the opposite(worst condition). Given two cost numbers `a` and `b` from two different
+   * cluster states `A` and `B`, if a < b then we can state that cluster state A is better than
+   * cluster state B in terms of the specific performance aspect.
+   *
+   * @return a number represents the idealness of a cluster state in terms of specific performance
+   *     aspect.
    */
   double value();
 }

--- a/common/src/main/java/org/astraea/common/cost/ReplicaNumberCost.java
+++ b/common/src/main/java/org/astraea/common/cost/ReplicaNumberCost.java
@@ -87,6 +87,11 @@ public class ReplicaNumberCost implements HasClusterCost, HasMoveCost {
     // complete balance
     if (max - min == 0) return () -> 0;
     // complete balance in terms of integer
+    // The following case will trigger if the number of replicas is not integer times of brokers.
+    // For example: allocate 4 replicas to 3 brokers. The ideal placement state will be (2,1,1),
+    // (1,2,1) or (1,1,2). All these cases should be considered as optimal solution since the number
+    // of replica must be integer. And this case will be trigger if the (max - min) equals 1. If
+    // such case is detected, return 0 as the optimal state of this cost function was found.
     if (max - min == 1) return () -> 0;
     return () -> (double) (max - min) / (totalReplicas);
   }


### PR DESCRIPTION
原先的 `ReplicaNumberCost#clusterCost` 實作，他的函數值域是 [0, Long.MAX]，數值本身的含義是 max broker replica number 和 min number 的差異，這個數字本身不適合 Balancer 框架使用，因為他的值域和其他 CostFunction 不一樣（不是[0,1]），這使得他的權重會便得很難調配。

這個 PR 把他的實作的值域改成 [0, 1]，數值含義是負載不平衡的比例