### PR TITLE
[COST] Normalize the return value of `ClusterCost` from `HasClusterCost#of`

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/HasClusterCost.java
+++ b/common/src/main/java/org/astraea/common/cost/HasClusterCost.java
@@ -53,9 +53,10 @@ public interface HasClusterCost extends CostFunction {
                     Collectors.toUnmodifiableMap(
                         Map.Entry::getKey,
                         e -> e.getKey().clusterCost(clusterInfo, clusterBean).value()));
+        var totalWeight = costAndWeight.values().stream().mapToDouble(x -> x).sum();
         var compositeScore =
             costAndWeight.keySet().stream()
-                .mapToDouble(cost -> costAndWeight.get(cost) * scores.get(cost))
+                .mapToDouble(cost -> scores.get(cost) * costAndWeight.get(cost) / totalWeight)
                 .sum();
 
         return new ClusterCost() {

--- a/common/src/test/java/org/astraea/common/cost/ClusterCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/ClusterCostTest.java
@@ -45,7 +45,7 @@ class ClusterCostTest {
     HasClusterCost cost2 = (c, b) -> () -> 0.8;
     var merged = HasClusterCost.of(Map.of(cost0, 1D, cost1, 2D, cost2, 2D));
     var result = merged.clusterCost(null, null).value();
-    Assertions.assertEquals(2.8, Math.round(result * 100.0) / 100.0);
+    Assertions.assertEquals(0.56, Math.round(result * 100.0) / 100.0);
   }
 
   @Test


### PR DESCRIPTION
確保 `HasClusterCost#of` 回傳的 Cost 值被依照權重標準化到 [0, 1] 的區間。

目前的 `HasClusterCost#of` 回傳的權重組合 cost function 是直接將數值乘上權重後相加，最後值會介於 [0, TotalWeight] 之間。這個數字在觀察上不太方便，如我們看到值是 `3`，我們可能因為不確定上限而無法直接聯想到這個值在整體的好壞狀況。這個 PR 多一個步驟把值壓在 [0, 1] 之間，這樣做的好處：

1. 符合 Cost Function 的設計。
2. `HasClusterCost#of` 可以串 `HasClusterCost#of`。
3. 我們知道上限是 1，如果看到 `0.3` 可以直接聯想到他在整個值域的位置。