### PR TITLE
[PERF] Add publish e2e latency to report

### DIFF
--- a/app/src/main/java/org/astraea/app/performance/ReportFormat.java
+++ b/app/src/main/java/org/astraea/app/performance/ReportFormat.java
@@ -193,6 +193,11 @@ public enum ReportFormat implements EnumInfo {
                   CSVContentElement.create(
                       "Producer[" + i + "] average publish latency (ms)",
                       () -> Double.toString(producerReports.get(i).avgLatency())));
+              elements.add(
+                  CSVContentElement.create(
+                      "Producer[" + i + "] average e2e latency (ms)",
+                      () ->
+                          Double.toString(producerReports.get(i).e2eLatency().orElse(Double.NaN))));
             });
     IntStream.range(0, consumerReports.size())
         .forEach(


### PR DESCRIPTION
如題，增加 performance tool report 紀錄的項目。

增加  publish e2e latency 。這個數據是實際使用 `KafkaProducer` 的使用者，實際感受到的發送延遲。