### PR TITLE
[PERF] make AbstractThread package-private

### DIFF
--- a/app/src/main/java/org/astraea/app/performance/AbstractThread.java
+++ b/app/src/main/java/org/astraea/app/performance/AbstractThread.java
@@ -18,7 +18,7 @@ package org.astraea.app.performance;
 
 import java.io.Closeable;
 
-public interface AbstractThread extends Closeable {
+interface AbstractThread extends Closeable {
 
   /** wait this thread to be completed. */
   void waitForDone();


### PR DESCRIPTION
在 #1481 看到誤用，因此將`AbstractThread`改成 package-private 