### PR TITLE
[PERF] Binary search on zipfian value generating

### DIFF
--- a/common/src/test/java/org/astraea/common/DistributionTypeTest.java
+++ b/common/src/test/java/org/astraea/common/DistributionTypeTest.java
@@ -69,5 +69,14 @@ public class DistributionTypeTest {
     var distribution = DistributionType.ZIPFIAN.create(5);
     Assertions.assertTrue(distribution.get() < 5);
     Assertions.assertTrue(distribution.get() >= 0);
+
+    // The last cumulative probability should not less than 1.0
+    for (int i = 1000; i < 2000; ++i) {
+      distribution = DistributionType.ZIPFIAN.create(i);
+      for (int j = 0; j < 1000; ++j) {
+        Assertions.assertTrue(distribution.get() < i);
+        Assertions.assertTrue(distribution.get() >= 0);
+      }
+    }
   }
 }


### PR DESCRIPTION
fix #1478 

https://github.com/skiptests/astraea/pull/1485#discussion_r1100926542

與 #1485 類似，區別在於使用的是 `Collections.binarySearch()` 方法來找值，相對於 #1485 的方法 (使用 `TreeMap` 做資料結構儲存) 較為節省記憶體空間。
還需要再麻煩 @garyparrot 驗證看看。