### PR TITLE
[HDFS] simplify/fix start_hadoop.sh for OSX

### DIFF
--- a/docker/start_hadoop.sh
+++ b/docker/start_hadoop.sh
@@ -200,7 +200,7 @@ function startNamenode() {
 # ===================================[datanode]===================================
 
 function startDatanode() {
-  local container_name=namenode-$HADOOP_PORT
+  local container_name=datanode-$HADOOP_PORT
 
   rejectProperty dfs.datanode.address $HDFS_SITE_XML
   rejectProperty dfs.datanode.use.datanode.hostname $HDFS_SITE_XML


### PR DESCRIPTION
`sed`在不同的shell會有不同的用法，例如下方就是在OSX執行腳本時會出現的錯誤

```
sed: 1: "/tmp/13805-hdfs.xml": invalid command code 1
```

這隻PR改成通通都用`echo`，並且避免出現很寬的行數