### PR TITLE
[COST] Fix `NetworkCost` raises an exception when some brokers have no replica

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/NetworkCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NetworkCost.java
@@ -39,6 +39,7 @@ import org.astraea.common.metrics.broker.HasRate;
 import org.astraea.common.metrics.broker.LogMetrics;
 import org.astraea.common.metrics.broker.ServerMetrics;
 import org.astraea.common.metrics.collector.MetricSensor;
+import org.astraea.common.metrics.platform.HostMetrics;
 
 /**
  * This cost function calculate the load balance score in terms of network ingress or network
@@ -169,6 +170,7 @@ public abstract class NetworkCost implements HasClusterCost {
     return Optional.of(
         (client, clusterBean) ->
             Stream.of(
+                    List.of(HostMetrics.jvmMemory(client)),
                     ServerMetrics.Topic.BYTES_IN_PER_SEC.fetch(client),
                     ServerMetrics.Topic.BYTES_OUT_PER_SEC.fetch(client),
                     LogMetrics.Log.SIZE.fetch(client))

--- a/common/src/main/java/org/astraea/common/cost/NetworkCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NetworkCost.java
@@ -141,8 +141,7 @@ public abstract class NetworkCost implements HasClusterCost {
                           }
                         },
                         Collectors.summingDouble(x -> x))));
-    // the above logic doesn't consider broker with no replica, the following statement put those
-    // broker into the map
+    // add the brokers having no replicas into map
     clusterInfo.nodes().stream()
         .filter(node -> !brokerRate.containsKey(node))
         .forEach(node -> brokerRate.put(node, 0.0));
@@ -262,11 +261,11 @@ public abstract class NetworkCost implements HasClusterCost {
     }
   }
 
-  public static class NetworkClusterCost implements ClusterCost {
+  static class NetworkClusterCost implements ClusterCost {
     final double score;
     final Map<NodeInfo, Double> brokerRate;
 
-    public NetworkClusterCost(double score, Map<NodeInfo, Double> brokerRate) {
+    NetworkClusterCost(double score, Map<NodeInfo, Double> brokerRate) {
       this.score = score;
       this.brokerRate = brokerRate;
     }

--- a/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
@@ -421,6 +421,28 @@ class NetworkCostTest {
     System.out.println("False test: " + counting.get(false));
   }
 
+  @Test
+  void testZeroReplicaBroker() {
+    var testcase = new LargeTestCase(1, 1, 0);
+    var beans = testcase.clusterBean();
+    var cluster = testcase.clusterInfo();
+    var scaledCluster =
+        ClusterInfoBuilder.builder(cluster)
+            .addNode(Set.of(4321))
+            .addFolders(Map.of(4321, Set.of("/folder")))
+            .build();
+    var node = scaledCluster.node(4321);
+
+    var costI =
+        (NetworkCost.NetworkClusterCost) new NetworkIngressCost().clusterCost(scaledCluster, beans);
+    Assertions.assertEquals(2, costI.brokerRate.size());
+    Assertions.assertEquals(0.0, costI.brokerRate.get(node));
+    var costE =
+        (NetworkCost.NetworkClusterCost) new NetworkEgressCost().clusterCost(scaledCluster, beans);
+    Assertions.assertEquals(2, costE.brokerRate.size());
+    Assertions.assertEquals(0.0, costE.brokerRate.get(node));
+  }
+
   interface TestCase {
 
     ClusterInfo clusterInfo();


### PR DESCRIPTION
修正兩個 `NetworkCost` 的 bug

* `NetworkCost` 的統計結果中沒有考慮到沒有 replica 的 broker，導致後面統計時會忽略完全空負載的節點。
* `NetworkCost` 的 MetricSensor，針對沒有 replica 的 broker 不會撈回任何 metrics，導致 `NetworkCost#noMetricCheck` 認為還沒有至少一個階段的 metrics 被完全索取而拒絕計算。修正方法為現在刻意撈取 `JmxMemory`，這個 metric 在沒有 replica 的 broker 上也能撈得到。