### PR TITLE
[BALANCER] Implementation of `BalancerBenchmark`

### DIFF
--- a/app/src/main/java/org/astraea/balancer/bench/BalancerBenchmark.java
+++ b/app/src/main/java/org/astraea/balancer/bench/BalancerBenchmark.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.balancer.bench;
+
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.DoubleSummaryStatistics;
+import java.util.LongSummaryStatistics;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.astraea.common.admin.ClusterBean;
+import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.balancer.Balancer;
+import org.astraea.common.balancer.algorithms.AlgorithmConfig;
+import org.astraea.common.cost.ClusterCost;
+import org.astraea.common.cost.MoveCost;
+
+public final class BalancerBenchmark {
+
+  /**
+   * Execute a balancer multiple times with fixed input. Return the statistical information of this
+   * experiment.
+   */
+  public static ExperimentBuilder experiment() {
+    return new ExperimentBuilderImpl();
+  }
+
+  /**
+   * Execute a balancer once, and profile the proposed cost value change during this process. This
+   * experiment tool aims to provide a fine-grain level look at the balancer internal improvement
+   * over time.
+   */
+  public static CostProfilingBuilder costProfiling() {
+    return new CostProfilingImpl();
+  }
+
+  public interface ExperimentBuilder extends BalancerProblemBuilder<ExperimentBuilder> {
+
+    ExperimentBuilder setExperimentTrials(int trials);
+
+    CompletableFuture<ExperimentResult> start();
+  }
+
+  public interface CostProfilingBuilder extends BalancerProblemBuilder<CostProfilingBuilder> {
+    CompletableFuture<CostProfilingResult> start();
+  }
+
+  public interface BalancerProblemBuilder<T extends BalancerProblemBuilder<T>> {
+    T setBalancer(Balancer balancer);
+
+    T setClusterInfo(ClusterInfo clusterInfo);
+
+    T setClusterBean(ClusterBean clusterBean);
+
+    T setExecutionTimeout(Duration timeout);
+
+    T setAlgorithmConfig(AlgorithmConfig algorithmConfig);
+  }
+
+  public interface ExperimentResult {
+
+    ClusterCost initial();
+
+    Set<ClusterCost> costs();
+
+    int trials();
+
+    default Optional<ClusterCost> bestCost() {
+      return costs().stream().min(Comparator.comparingDouble(ClusterCost::value));
+    }
+
+    default OptionalDouble mean() {
+      return costs().stream().mapToDouble(ClusterCost::value).average();
+    }
+
+    default DoubleSummaryStatistics costSummary() {
+      return costs().stream().mapToDouble(ClusterCost::value).summaryStatistics();
+    }
+
+    default OptionalDouble variance() {
+      if (costs().isEmpty()) return OptionalDouble.empty();
+
+      var summary = costs().stream().mapToDouble(ClusterCost::value).summaryStatistics();
+      var mean = summary.getAverage();
+      return costs().stream()
+          .mapToDouble(ClusterCost::value)
+          .map(x -> (x - mean) * (x - mean))
+          .average();
+    }
+  }
+
+  public interface CostProfilingResult {
+
+    ClusterCost initial();
+
+    Optional<Balancer.Solution> solution();
+
+    Map<Long, ClusterCost> costTimeSeries();
+
+    Map<Long, MoveCost> moveCostTimeSeries();
+
+    Duration executionTime();
+
+    LongSummaryStatistics clusterCostProcessingTimeNs();
+
+    LongSummaryStatistics moveCostProcessingTimeNs();
+  }
+}

--- a/app/src/main/java/org/astraea/balancer/bench/CostProfilingImpl.java
+++ b/app/src/main/java/org/astraea/balancer/bench/CostProfilingImpl.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.balancer.bench;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.LongSummaryStatistics;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import org.astraea.common.admin.ClusterBean;
+import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.balancer.Balancer;
+import org.astraea.common.balancer.algorithms.AlgorithmConfig;
+import org.astraea.common.cost.ClusterCost;
+import org.astraea.common.cost.HasClusterCost;
+import org.astraea.common.cost.HasMoveCost;
+import org.astraea.common.cost.MoveCost;
+import org.astraea.common.metrics.collector.MetricSensor;
+
+class CostProfilingImpl implements BalancerBenchmark.CostProfilingBuilder {
+  private Balancer balancer;
+  private ClusterInfo clusterInfo;
+  private ClusterBean clusterBean;
+  private AlgorithmConfig config;
+  private Duration timeout;
+
+  @Override
+  public BalancerBenchmark.CostProfilingBuilder setBalancer(Balancer balancer) {
+    this.balancer = balancer;
+    return this;
+  }
+
+  @Override
+  public BalancerBenchmark.CostProfilingBuilder setClusterInfo(ClusterInfo clusterInfo) {
+    this.clusterInfo = clusterInfo;
+    return this;
+  }
+
+  @Override
+  public BalancerBenchmark.CostProfilingBuilder setClusterBean(ClusterBean clusterBean) {
+    this.clusterBean = clusterBean;
+    return this;
+  }
+
+  @Override
+  public BalancerBenchmark.CostProfilingBuilder setExecutionTimeout(Duration timeout) {
+    this.timeout = timeout;
+    return this;
+  }
+
+  @Override
+  public BalancerBenchmark.CostProfilingBuilder setAlgorithmConfig(
+      AlgorithmConfig algorithmConfig) {
+    this.config = algorithmConfig;
+    return this;
+  }
+
+  @Override
+  public CompletableFuture<BalancerBenchmark.CostProfilingResult> start() {
+    final var costFunction = config.clusterCostFunction();
+    final var costTimeSeries = new ConcurrentHashMap<Long, ClusterCost>();
+    final var clusterCostProcessingTimeNs = new LongSummaryStatistics();
+    final var moveCostFunction = config.moveCostFunction();
+    final var moveCostTimeSeries = new ConcurrentHashMap<Long, MoveCost>();
+    final var moveCostProcessingTimeNs = new LongSummaryStatistics();
+    final var newConfig =
+        AlgorithmConfig.builder(config)
+            .clusterCost(
+                new HasClusterCost() {
+                  @Override
+                  public ClusterCost clusterCost(ClusterInfo clusterInfo, ClusterBean clusterBean) {
+                    final var start = System.nanoTime();
+                    final var clusterCost = costFunction.clusterCost(clusterInfo, clusterBean);
+                    final var stop = System.nanoTime();
+                    costTimeSeries.put(stop, clusterCost);
+                    clusterCostProcessingTimeNs.accept((stop - start));
+                    return clusterCost;
+                  }
+
+                  @Override
+                  public Optional<MetricSensor> metricSensor() {
+                    return costFunction.metricSensor();
+                  }
+
+                  @Override
+                  public String toString() {
+                    return costFunction.toString();
+                  }
+                })
+            .moveCost(
+                new HasMoveCost() {
+                  @Override
+                  public MoveCost moveCost(
+                      ClusterInfo before, ClusterInfo after, ClusterBean clusterBean) {
+                    final var start = System.nanoTime();
+                    final var moveCost = moveCostFunction.moveCost(before, after, clusterBean);
+                    final var stop = System.nanoTime();
+                    moveCostTimeSeries.put(stop, moveCost);
+                    moveCostProcessingTimeNs.accept((stop - start));
+                    return moveCost;
+                  }
+
+                  @Override
+                  public Optional<MetricSensor> metricSensor() {
+                    return moveCostFunction.metricSensor();
+                  }
+
+                  @Override
+                  public String toString() {
+                    return moveCostFunction.toString();
+                  }
+                })
+            .build();
+
+    return CompletableFuture.supplyAsync(
+        () -> {
+          var initial = costFunction.clusterCost(clusterInfo, clusterBean);
+          var executionStart = System.nanoTime();
+          var plan = balancer.offer(clusterInfo, clusterBean, timeout, newConfig);
+          var executionStop = System.nanoTime();
+
+          return new BalancerBenchmark.CostProfilingResult() {
+            @Override
+            public ClusterCost initial() {
+              return initial;
+            }
+
+            @Override
+            public Optional<Balancer.Solution> solution() {
+              return plan.solution();
+            }
+
+            @Override
+            public Map<Long, ClusterCost> costTimeSeries() {
+              return Collections.unmodifiableMap(costTimeSeries);
+            }
+
+            @Override
+            public Map<Long, MoveCost> moveCostTimeSeries() {
+              return Collections.unmodifiableMap(moveCostTimeSeries);
+            }
+
+            @Override
+            public Duration executionTime() {
+              return Duration.ofNanos(executionStop - executionStart);
+            }
+
+            @Override
+            public LongSummaryStatistics clusterCostProcessingTimeNs() {
+              return new LongSummaryStatistics(
+                  clusterCostProcessingTimeNs.getCount(),
+                  clusterCostProcessingTimeNs.getMin(),
+                  clusterCostProcessingTimeNs.getMax(),
+                  clusterCostProcessingTimeNs.getSum());
+            }
+
+            @Override
+            public LongSummaryStatistics moveCostProcessingTimeNs() {
+              return new LongSummaryStatistics(
+                  moveCostProcessingTimeNs.getCount(),
+                  moveCostProcessingTimeNs.getMin(),
+                  moveCostProcessingTimeNs.getMax(),
+                  moveCostProcessingTimeNs.getSum());
+            }
+          };
+        });
+  }
+}

--- a/app/src/main/java/org/astraea/balancer/bench/ExperimentBuilderImpl.java
+++ b/app/src/main/java/org/astraea/balancer/bench/ExperimentBuilderImpl.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.balancer.bench;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Collectors;
+import org.astraea.common.admin.ClusterBean;
+import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.balancer.Balancer;
+import org.astraea.common.balancer.algorithms.AlgorithmConfig;
+import org.astraea.common.cost.ClusterCost;
+
+class ExperimentBuilderImpl implements BalancerBenchmark.ExperimentBuilder {
+  private Balancer balancer;
+  private ClusterInfo clusterInfo;
+  private ClusterBean clusterBean;
+  private AlgorithmConfig config;
+  private Duration timeout;
+  private int trials;
+
+  @Override
+  public ExperimentBuilderImpl setBalancer(Balancer balancer) {
+    this.balancer = balancer;
+    return this;
+  }
+
+  @Override
+  public ExperimentBuilderImpl setClusterInfo(ClusterInfo clusterInfo) {
+    this.clusterInfo = clusterInfo;
+    return this;
+  }
+
+  @Override
+  public ExperimentBuilderImpl setClusterBean(ClusterBean clusterBean) {
+    this.clusterBean = clusterBean;
+    return this;
+  }
+
+  @Override
+  public ExperimentBuilderImpl setExecutionTimeout(Duration timeout) {
+    this.timeout = timeout;
+    return this;
+  }
+
+  @Override
+  public ExperimentBuilderImpl setAlgorithmConfig(AlgorithmConfig algorithmConfig) {
+    this.config = algorithmConfig;
+    return this;
+  }
+
+  public BalancerBenchmark.ExperimentBuilder setExperimentTrials(int trials) {
+    this.trials = trials;
+    return this;
+  }
+
+  public CompletableFuture<BalancerBenchmark.ExperimentResult> start() {
+    final var trials = this.trials;
+    final var initial = config.clusterCostFunction().clusterCost(clusterInfo, clusterBean);
+    final var results = new ConcurrentLinkedQueue<ClusterCost>();
+    return CompletableFuture.supplyAsync(
+        () -> {
+          for (int i = 0; i < trials; i++) {
+            balancer
+                .offer(clusterInfo, clusterBean, timeout, config)
+                .solution()
+                .map(Balancer.Solution::proposalClusterCost)
+                .ifPresent(results::add);
+          }
+          final var res = results.stream().collect(Collectors.toUnmodifiableSet());
+          return new BalancerBenchmark.ExperimentResult() {
+            @Override
+            public ClusterCost initial() {
+              return initial;
+            }
+
+            @Override
+            public Set<ClusterCost> costs() {
+              return res;
+            }
+
+            @Override
+            public int trials() {
+              return trials;
+            }
+          };
+        });
+  }
+}


### PR DESCRIPTION
這個 PR 實作一些工具能夠用來測試 Balancer 的優化效能和行為：

* `BalancerBenchmark.experiment()`，給固定的輸入 (Cluster, Bean, Config, Timeout)，重複跑 Balancer n 次，做統計。
  * 主要用途為觀察 Balancer 每次跑出來的結果有沒有一致
  * 如果有很大幅度的變動，那也許是存在困在 Local Minimum 跳不出來的現象
* `BalancerBenchmark.costProfiling()`，能夠監控 Balancer 優化過程中，提出的新 Cluster 的分數變動。
  * 可以看到比較細微的，Balancer 內部的進步過程

下面這段程式碼建立一個情境，有 3 個節點的 Cluster，擴充節點數量到 9 個節點，在給定最多 30 個 Leader 被影響的限制下找計劃，執行時間 30 秒，然後對這個優化問題套用 Cost Profiling。

<details> 
<summary>Source code</summary>

```java 
public class Ignore {
  public static void main(String[] args) {
    var testcase = BalancerTestcase.scaledCluster(3, 9, 0);
    var result =
        BalancerBenchmark.costProfiling()
            .setBalancer(new GreedyBalancer(Configuration.EMPTY))
            .setAlgorithmConfig(
                AlgorithmConfig.builder()
                    .moveCost(HasMoveCost.of(List.of(new ReplicaLeaderCost())))
                    .movementConstraint(
                        movement ->
                            movement.changedReplicaLeaderCount().values().stream()
                                .allMatch(c -> c < 30))
                    .clusterCost(
                        HasClusterCost.of(
                            Map.ofEntries(
                                Map.entry(new NetworkIngressCost(), 3.0),
                                Map.entry(new NetworkEgressCost(), 3.0),
                                Map.entry(new ReplicaNumberCost(), 1.0))))
                    .build())
            .setClusterInfo(testcase.clusterInfo())
            .setClusterBean(testcase.clusterBean())
            .setExecutionTimeout(Duration.ofSeconds(30))
            .start()
            .join();
    var meanClusterCostTime =
        Duration.ofNanos((long) result.clusterCostProcessingTimeNs().getAverage());
    var meanMoveCostTime = Duration.ofNanos((long) result.moveCostProcessingTimeNs().getAverage());
    System.out.println("Total Run time: " + result.executionTime().toMillis() + " ms");
    System.out.println(
        "Total ClusterCost Evaluation: " + result.clusterCostProcessingTimeNs().getCount());
    System.out.println("Average ClusterCost Processing: " + meanClusterCostTime.toMillis() + " ms");
    System.out.println("Average MoveCost Processing: " + meanMoveCostTime.toMillis() + " ms");
    System.out.println("Initial Cost: " + result.initial());
    System.out.println("Final Cost: " + result.solution().orElseThrow().proposalClusterCost());
    var profilingFile = Utils.packException(() -> Files.createTempFile("profile-", ".csv"));
    System.out.println("Profiling File: " + profilingFile.toString());
    try (var stream = Files.newBufferedWriter(profilingFile)) {
      var start = result.costTimeSeries().keySet().stream().mapToLong(x -> x).min().orElseThrow();
      Utils.packException(() -> stream.write("time, cost\n"));
      result.costTimeSeries().entrySet().stream()
          .sorted(Map.Entry.comparingByKey())
          .forEach(
              (e) -> {
                var time = e.getKey();
                var cost = e.getValue();
                Utils.packException(
                    () -> stream.write(String.format("%d, %.7f%n", time - start, cost.value())));
              });
    } catch (IOException e) {
      e.printStackTrace();
    }
  }
}

interface BalancerTestcase {

  ClusterInfo clusterInfo();

  ClusterBean clusterBean();

  /**
   * Create a fake kafka cluster with some load, then scale up the number of node in this cluster.
   */
  static BalancerTestcase scaledCluster(int nodes, int nodesAfterScaled, int seed) {
    if (nodes <= 0 || nodesAfterScaled <= 0)
      throw new IllegalArgumentException("Illegal node number: " + nodes + ", " + nodesAfterScaled);
    if (!(nodesAfterScaled > nodes))
      throw new IllegalArgumentException(
          "node has to be more after scaled: " + nodes + " > " + nodesAfterScaled);
    final var nodeIds = IntStream.range(0, nodes).boxed().collect(Collectors.toUnmodifiableSet());
    final var newNodeIds =
        IntStream.range(nodes, nodesAfterScaled).boxed().collect(Collectors.toUnmodifiableSet());
    final var partitions = ThreadLocalRandom.current().nextInt(0, 1000) * nodeIds.size();
    final var maxDataRate = DataRate.MB.of(50).perSecond().byteRate();
    final var random = new Random(seed);
    final var cluster =
        ClusterInfoBuilder.builder()
            .addNode(nodeIds)
            .addFolders(
                nodeIds.stream()
                    .collect(
                        Collectors.toUnmodifiableMap(
                            id -> id, id -> Set.of("/folder0", "/folder1", "/folder2"))))
            .addTopic(
                "topic",
                partitions,
                (short) 1,
                (r) -> Replica.builder(r).size(random.nextInt((int) maxDataRate)).build())
            .addNode(newNodeIds)
            .addFolders(
                newNodeIds.stream()
                    .collect(
                        Collectors.toUnmodifiableMap(
                            id -> id, id -> Set.of("/folder0", "/folder1", "/folder2"))))
            .build();
    final var tpDataRates =
        cluster.replicas().stream()
            .collect(
                Collectors.toUnmodifiableMap(
                    Replica::topicPartition, r -> DataRate.Byte.of(r.size()).perSecond()));
    final var beans =
        MetricSeriesBuilder.builder()
            .cluster(cluster)
            .timeRange(LocalDateTime.now(), Duration.ZERO)
            .seriesByBrokerTopic(
                (time, broker, topic) ->
                    ServerMetrics.Topic.BYTES_IN_PER_SEC
                        .builder()
                        .topic(topic)
                        .time(time.toEpochSecond(ZoneOffset.UTC))
                        .fifteenMinuteRate(
                            cluster.replicaLeaders(BrokerTopic.of(broker, topic)).stream()
                                .filter(Replica::isLeader)
                                .filter(Replica::isOnline)
                                .map(r -> tpDataRates.get(r.topicPartition()))
                                .mapToDouble(DataRate::byteRate)
                                .sum())
                        .build())
            .seriesByBrokerTopic(
                (time, broker, topic) ->
                    ServerMetrics.Topic.BYTES_OUT_PER_SEC
                        .builder()
                        .topic(topic)
                        .time(time.toEpochSecond(ZoneOffset.UTC))
                        .fifteenMinuteRate(
                            cluster.replicaLeaders(BrokerTopic.of(broker, topic)).stream()
                                .filter(Replica::isLeader)
                                .filter(Replica::isOnline)
                                .map(r -> tpDataRates.get(r.topicPartition()))
                                .mapToDouble(DataRate::byteRate)
                                .sum())
                        .build())
            .seriesByBrokerReplica(
                (time, broker, replica) ->
                    LogMetrics.Log.SIZE
                        .builder()
                        .topic(replica.topic())
                        .partition(replica.partition())
                        .logSize((long) tpDataRates.get(replica.topicPartition()).byteRate())
                        .build())
            .seriesByBroker(
                (time, broker) ->
                    Stream.of((HasCount) () -> new BeanObject("?", Map.of(), Map.of())))
            .build();

    return new BalancerTestcase() {
      @Override
      public ClusterInfo clusterInfo() {
        return cluster;
      }

      @Override
      public ClusterBean clusterBean() {
        return beans;
      }
    };
  }
}

```
</details> 

跑個幾次之後有發現一些現象，每次跑出來的優化結果差異頗大，好的可以到把 cost 從 0.9 降到 0.3，差的只能降到 0.87 附近，而有的測試結果有劇烈的彈跳現象。估計是 Balancer 對 Constraint 沒有概念，導致找解上的方向感困難，才會出現這些情況。

![image](https://user-images.githubusercontent.com/39105714/219856608-3152a4bb-a2b7-4316-9a6c-002400640ab8.png)

![image](https://user-images.githubusercontent.com/39105714/219856613-fb752ab5-cd62-445f-bdbf-bdadc2092ccd.png)

![image](https://user-images.githubusercontent.com/39105714/219856620-1e437406-e647-4e70-8c28-0e984837df29.png)

![image](https://user-images.githubusercontent.com/39105714/219856635-af68930e-94df-463d-9fdb-83f2bcd7853b.png)


這個 PR 和 https://github.com/skiptests/astraea/issues/1108 有點關聯，但這個 PR 比較偏重在單一個 Balancer 的行為分析，沒有做到該 Issue 提到的兩個 Balancer 的比較層面。