### PR TITLE
[METRICS] Append worker metrics

### DIFF
--- a/common/src/main/java/org/astraea/common/metrics/client/HasCoordinatorMetrics.java
+++ b/common/src/main/java/org/astraea/common/metrics/client/HasCoordinatorMetrics.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.metrics.client;
+
+import org.astraea.common.metrics.HasBeanObject;
+
+@FunctionalInterface
+public interface HasCoordinatorMetrics extends HasBeanObject {
+
+  default String clientId() {
+    return beanObject().properties().get("client-id");
+  }
+
+  default double failedRebalanceRatePerHour() {
+    return (double) beanObject().attributes().get("failed-rebalance-rate-per-hour");
+  }
+
+  default double failedRebalanceTotal() {
+    return (double) beanObject().attributes().get("failed-rebalance-total");
+  }
+
+  default double heartbeatRate() {
+    return (double) beanObject().attributes().get("heartbeat-rate");
+  }
+
+  default double heartbeatResponseTimeMax() {
+    return (double) beanObject().attributes().get("heartbeat-response-time-max");
+  }
+
+  default double heartbeatTotal() {
+    return (double) beanObject().attributes().get("heartbeat-total");
+  }
+
+  default double joinRate() {
+    return (double) beanObject().attributes().get("join-rate");
+  }
+
+  default double joinTimeAvg() {
+    return (double) beanObject().attributes().get("join-time-avg");
+  }
+
+  default double joinTimeMax() {
+    return (double) beanObject().attributes().get("join-time-max");
+  }
+
+  default double joinTotal() {
+    return (double) beanObject().attributes().get("join-total");
+  }
+
+  default double lastHeartbeatSecondsAgo() {
+    return (double) beanObject().attributes().get("last-heartbeat-seconds-ago");
+  }
+
+  default double lastRebalanceSecondsAgo() {
+    return (double) beanObject().attributes().get("last-rebalance-seconds-ago");
+  }
+
+  default double rebalanceLatencyAvg() {
+    return (double) beanObject().attributes().get("rebalance-latency-avg");
+  }
+
+  default double rebalanceLatencyMax() {
+    return (double) beanObject().attributes().get("rebalance-latency-max");
+  }
+
+  default double rebalanceLatencyTotal() {
+    return (double) beanObject().attributes().get("rebalance-latency-total");
+  }
+
+  default double rebalanceRatePerHour() {
+    return (double) beanObject().attributes().get("rebalance-rate-per-hour");
+  }
+
+  default double rebalanceTotal() {
+    return (double) beanObject().attributes().get("rebalance-total");
+  }
+
+  default double syncRate() {
+    return (double) beanObject().attributes().get("sync-rate");
+  }
+
+  default double syncTimeAvg() {
+    return (double) beanObject().attributes().get("sync-time-avg");
+  }
+
+  default double syncTimeMax() {
+    return (double) beanObject().attributes().get("sync-time-max");
+  }
+
+  default double syncTotal() {
+    return (double) beanObject().attributes().get("sync-total");
+  }
+}

--- a/common/src/main/java/org/astraea/common/metrics/client/HasNodeMetrics.java
+++ b/common/src/main/java/org/astraea/common/metrics/client/HasNodeMetrics.java
@@ -19,6 +19,7 @@ package org.astraea.common.metrics.client;
 import java.util.function.Function;
 import org.astraea.common.metrics.HasBeanObject;
 
+@FunctionalInterface
 public interface HasNodeMetrics extends HasBeanObject {
   Function<String, Integer> BROKER_ID_FETCHER =
       node -> Integer.parseInt(node.substring(node.indexOf("-") + 1));

--- a/common/src/main/java/org/astraea/common/metrics/client/HasSelectorMetrics.java
+++ b/common/src/main/java/org/astraea/common/metrics/client/HasSelectorMetrics.java
@@ -18,6 +18,7 @@ package org.astraea.common.metrics.client;
 
 import org.astraea.common.metrics.HasBeanObject;
 
+/** This FunctionalInterface corresponds to the selector in Kafka's underlying implementation */
 @FunctionalInterface
 public interface HasSelectorMetrics extends HasBeanObject {
 

--- a/common/src/main/java/org/astraea/common/metrics/client/HasSelectorMetrics.java
+++ b/common/src/main/java/org/astraea/common/metrics/client/HasSelectorMetrics.java
@@ -14,11 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.astraea.common.metrics.client.admin;
+package org.astraea.common.metrics.client;
 
 import org.astraea.common.metrics.HasBeanObject;
 
-public interface HasAdminMetrics extends HasBeanObject {
+@FunctionalInterface
+public interface HasSelectorMetrics extends HasBeanObject {
 
   default String clientId() {
     return beanObject().properties().get("client-id");
@@ -68,6 +69,10 @@ public interface HasAdminMetrics extends HasBeanObject {
     return (double) beanObject().attributes().get("incoming-byte-total");
   }
 
+  default double ioRatio() {
+    return (double) beanObject().attributes().get("io-ratio");
+  }
+
   default double ioTimeNsAvg() {
     return (double) beanObject().attributes().get("io-time-ns-avg");
   }
@@ -76,12 +81,24 @@ public interface HasAdminMetrics extends HasBeanObject {
     return (double) beanObject().attributes().get("io-time-ns-total");
   }
 
+  default double ioWaitRatio() {
+    return (double) beanObject().attributes().get("io-wait-ratio");
+  }
+
   default double ioWaitTimeNsAvg() {
     return (double) beanObject().attributes().get("io-wait-time-ns-avg");
   }
 
   default double ioWaitTimeNsTotal() {
     return (double) beanObject().attributes().get("io-wait-time-ns-total");
+  }
+
+  default double ioWaitTimeTotal() {
+    return (double) beanObject().attributes().get("io-waittime-total");
+  }
+
+  default double ioTimeTotal() {
+    return (double) beanObject().attributes().get("iotime-total");
   }
 
   default double networkIoRate() {

--- a/common/src/main/java/org/astraea/common/metrics/client/admin/AdminMetrics.java
+++ b/common/src/main/java/org/astraea/common/metrics/client/admin/AdminMetrics.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import org.astraea.common.metrics.BeanQuery;
 import org.astraea.common.metrics.MBeanClient;
 import org.astraea.common.metrics.client.HasNodeMetrics;
+import org.astraea.common.metrics.client.HasSelectorMetrics;
 
 public class AdminMetrics {
   /**
@@ -43,7 +44,7 @@ public class AdminMetrics {
         .collect(Collectors.toUnmodifiableList());
   }
 
-  public static Collection<HasAdminMetrics> of(MBeanClient mBeanClient) {
+  public static Collection<HasSelectorMetrics> of(MBeanClient mBeanClient) {
     return mBeanClient
         .beans(
             BeanQuery.builder()
@@ -52,7 +53,7 @@ public class AdminMetrics {
                 .property("client-id", "*")
                 .build())
         .stream()
-        .map(b -> (HasAdminMetrics) () -> b)
+        .map(b -> (HasSelectorMetrics) () -> b)
         .collect(Collectors.toUnmodifiableList());
   }
 }

--- a/common/src/main/java/org/astraea/common/metrics/client/consumer/HasConsumerCoordinatorMetrics.java
+++ b/common/src/main/java/org/astraea/common/metrics/client/consumer/HasConsumerCoordinatorMetrics.java
@@ -18,6 +18,7 @@ package org.astraea.common.metrics.client.consumer;
 
 import org.astraea.common.metrics.client.HasCoordinatorMetrics;
 
+@FunctionalInterface
 public interface HasConsumerCoordinatorMetrics extends HasCoordinatorMetrics {
 
   default double assignedPartitions() {

--- a/common/src/main/java/org/astraea/common/metrics/client/consumer/HasConsumerCoordinatorMetrics.java
+++ b/common/src/main/java/org/astraea/common/metrics/client/consumer/HasConsumerCoordinatorMetrics.java
@@ -16,13 +16,9 @@
  */
 package org.astraea.common.metrics.client.consumer;
 
-import org.astraea.common.metrics.HasBeanObject;
+import org.astraea.common.metrics.client.HasCoordinatorMetrics;
 
-public interface HasConsumerCoordinatorMetrics extends HasBeanObject {
-
-  default String clientId() {
-    return beanObject().properties().get("client-id");
-  }
+public interface HasConsumerCoordinatorMetrics extends HasCoordinatorMetrics {
 
   default double assignedPartitions() {
     return (double) beanObject().attributes().get("assigned-partitions");
@@ -42,42 +38,6 @@ public interface HasConsumerCoordinatorMetrics extends HasBeanObject {
 
   default double commitTotal() {
     return (double) beanObject().attributes().get("commit-total");
-  }
-
-  default double failedRebalanceRatePerHour() {
-    return (double) beanObject().attributes().get("failed-rebalance-rate-per-hour");
-  }
-
-  default double failedRebalanceTotal() {
-    return (double) beanObject().attributes().get("failed-rebalance-total");
-  }
-
-  default double heartbeatRate() {
-    return (double) beanObject().attributes().get("heartbeat-rate");
-  }
-
-  default double joinRate() {
-    return (double) beanObject().attributes().get("join-rate");
-  }
-
-  default double joinTimeAvg() {
-    return (double) beanObject().attributes().get("join-time-avg");
-  }
-
-  default double joinTimeMax() {
-    return (double) beanObject().attributes().get("join-time-max");
-  }
-
-  default double joinTotal() {
-    return (double) beanObject().attributes().get("join-total");
-  }
-
-  default double lastHeartbeatSecondsAgo() {
-    return (double) beanObject().attributes().get("last-heartbeat-seconds-ago");
-  }
-
-  default double lastRebalanceSecondsAgo() {
-    return (double) beanObject().attributes().get("last-rebalance-seconds-ago");
   }
 
   default double partitionAssignedLatencyAvg() {
@@ -102,41 +62,5 @@ public interface HasConsumerCoordinatorMetrics extends HasBeanObject {
 
   default double partitionRevokedLatencyMax() {
     return (double) beanObject().attributes().get("partition-revoked-latency-max");
-  }
-
-  default double rebalanceLatencyAvg() {
-    return (double) beanObject().attributes().get("rebalance-latency-avg");
-  }
-
-  default double rebalanceLatencyMax() {
-    return (double) beanObject().attributes().get("rebalance-latency-max");
-  }
-
-  default double rebalanceLatencyTotal() {
-    return (double) beanObject().attributes().get("rebalance-latency-total");
-  }
-
-  default double rebalanceRatePerHour() {
-    return (double) beanObject().attributes().get("rebalance-rate-per-hour");
-  }
-
-  default double rebalanceTotal() {
-    return (double) beanObject().attributes().get("rebalance-total");
-  }
-
-  default double syncRate() {
-    return (double) beanObject().attributes().get("sync-rate");
-  }
-
-  default double syncTimeAvg() {
-    return (double) beanObject().attributes().get("sync-time-avg");
-  }
-
-  default double syncTimeMax() {
-    return (double) beanObject().attributes().get("sync-time-max");
-  }
-
-  default double syncTotal() {
-    return (double) beanObject().attributes().get("sync-total");
   }
 }

--- a/common/src/main/java/org/astraea/common/metrics/client/consumer/HasConsumerFetchMetrics.java
+++ b/common/src/main/java/org/astraea/common/metrics/client/consumer/HasConsumerFetchMetrics.java
@@ -18,6 +18,7 @@ package org.astraea.common.metrics.client.consumer;
 
 import org.astraea.common.metrics.HasBeanObject;
 
+@FunctionalInterface
 public interface HasConsumerFetchMetrics extends HasBeanObject {
 
   default String clientId() {

--- a/common/src/main/java/org/astraea/common/metrics/client/consumer/HasConsumerMetrics.java
+++ b/common/src/main/java/org/astraea/common/metrics/client/consumer/HasConsumerMetrics.java
@@ -16,124 +16,28 @@
  */
 package org.astraea.common.metrics.client.consumer;
 
-import org.astraea.common.metrics.HasBeanObject;
+import org.astraea.common.metrics.client.HasSelectorMetrics;
 
-public interface HasConsumerMetrics extends HasBeanObject {
-
-  default String clientId() {
-    return beanObject().properties().get("client-id");
-  }
-
-  default double reauthenticationLatencyAvg() {
-    return (double) beanObject().attributes().get("reauthentication-latency-avg");
-  }
-
-  default double ioTimeNsTotal() {
-    return (double) beanObject().attributes().get("io-time-ns-total");
-  }
-
-  default double successfulAuthenticationTotal() {
-    return (double) beanObject().attributes().get("successful-authentication-total");
-  }
+public interface HasConsumerMetrics extends HasSelectorMetrics {
 
   default double committedTimeNsTotal() {
     return (double) beanObject().attributes().get("committed-time-ns-total");
-  }
-
-  default double reauthenticationLatencyMax() {
-    return (double) beanObject().attributes().get("reauthentication-latency-max");
-  }
-
-  default double successfulAuthenticationRate() {
-    return (double) beanObject().attributes().get("successful-authentication-rate");
   }
 
   default double commitSyncTimeNsTotal() {
     return (double) beanObject().attributes().get("commit-sync-time-ns-total");
   }
 
-  default double failedAuthenticationTotal() {
-    return (double) beanObject().attributes().get("failed-authentication-total");
-  }
-
   default double timeBetweenPollAvg() {
     return (double) beanObject().attributes().get("time-between-poll-avg");
-  }
-
-  default double connectionCount() {
-    return (double) beanObject().attributes().get("connection-count");
-  }
-
-  default double responseTotal() {
-    return (double) beanObject().attributes().get("response-total");
-  }
-
-  default double requestRate() {
-    return (double) beanObject().attributes().get("request-rate");
-  }
-
-  default double incomingByteRate() {
-    return (double) beanObject().attributes().get("incoming-byte-rate");
   }
 
   default double lastPollSecondsAgo() {
     return (double) beanObject().attributes().get("last-poll-seconds-ago");
   }
 
-  default double successfulAuthenticationNoReauthTotal() {
-    return (double) beanObject().attributes().get("successful-authentication-no-reauth-total");
-  }
-
   default double timeBetweenPollMax() {
     return (double) beanObject().attributes().get("time-between-poll-max");
-  }
-
-  default double failedReauthenticationTotal() {
-    return (double) beanObject().attributes().get("failed-reauthentication-total");
-  }
-
-  default double selectRate() {
-    return (double) beanObject().attributes().get("select-rate");
-  }
-
-  default double successfulReauthenticationTotal() {
-    return (double) beanObject().attributes().get("successful-reauthentication-total");
-  }
-
-  default double requestTotal() {
-    return (double) beanObject().attributes().get("request-total");
-  }
-
-  default double ioTimeNsAvg() {
-    return (double) beanObject().attributes().get("io-time-ns-avg");
-  }
-
-  default double ioWaitTimeNsTotal() {
-    return (double) beanObject().attributes().get("io-wait-time-ns-total");
-  }
-
-  default double networkIoRate() {
-    return (double) beanObject().attributes().get("network-io-rate");
-  }
-
-  default double connectionCreationRate() {
-    return (double) beanObject().attributes().get("connection-creation-rate");
-  }
-
-  default double requestSizeAvg() {
-    return (double) beanObject().attributes().get("request-size-avg");
-  }
-
-  default double responseRate() {
-    return (double) beanObject().attributes().get("response-rate");
-  }
-
-  default double successfulReauthenticationRate() {
-    return (double) beanObject().attributes().get("successful-reauthentication-rate");
-  }
-
-  default double selectTotal() {
-    return (double) beanObject().attributes().get("select-total");
   }
 
   default double outgoingByteTotal() {
@@ -144,43 +48,7 @@ public interface HasConsumerMetrics extends HasBeanObject {
     return (double) beanObject().attributes().get("poll-idle-ratio-avg");
   }
 
-  default double connectionCloseRate() {
-    return (double) beanObject().attributes().get("connection-close-rate");
-  }
-
   default double incomingByteTotal() {
     return (double) beanObject().attributes().get("incoming-byte-total");
-  }
-
-  default double requestSizeMax() {
-    return (double) beanObject().attributes().get("request-size-max");
-  }
-
-  default double failedAuthenticationRate() {
-    return (double) beanObject().attributes().get("failed-authentication-rate");
-  }
-
-  default double outgoingByteRate() {
-    return (double) beanObject().attributes().get("outgoing-byte-rate");
-  }
-
-  default double failedReauthenticationRate() {
-    return (double) beanObject().attributes().get("failed-reauthentication-rate");
-  }
-
-  default double ioWaitTimeNsAvg() {
-    return (double) beanObject().attributes().get("io-wait-time-ns-avg");
-  }
-
-  default double connectionCloseTotal() {
-    return (double) beanObject().attributes().get("connection-close-total");
-  }
-
-  default double connectionCreationTotal() {
-    return (double) beanObject().attributes().get("connection-creation-total");
-  }
-
-  default double networkIoTotal() {
-    return (double) beanObject().attributes().get("network-io-total");
   }
 }

--- a/common/src/main/java/org/astraea/common/metrics/client/consumer/HasConsumerMetrics.java
+++ b/common/src/main/java/org/astraea/common/metrics/client/consumer/HasConsumerMetrics.java
@@ -18,6 +18,7 @@ package org.astraea.common.metrics.client.consumer;
 
 import org.astraea.common.metrics.client.HasSelectorMetrics;
 
+@FunctionalInterface
 public interface HasConsumerMetrics extends HasSelectorMetrics {
 
   default double committedTimeNsTotal() {
@@ -40,15 +41,7 @@ public interface HasConsumerMetrics extends HasSelectorMetrics {
     return (double) beanObject().attributes().get("time-between-poll-max");
   }
 
-  default double outgoingByteTotal() {
-    return (double) beanObject().attributes().get("outgoing-byte-total");
-  }
-
   default double pollIdleRatioAvg() {
     return (double) beanObject().attributes().get("poll-idle-ratio-avg");
-  }
-
-  default double incomingByteTotal() {
-    return (double) beanObject().attributes().get("incoming-byte-total");
   }
 }

--- a/common/src/main/java/org/astraea/common/metrics/client/producer/HasProducerMetrics.java
+++ b/common/src/main/java/org/astraea/common/metrics/client/producer/HasProducerMetrics.java
@@ -18,6 +18,7 @@ package org.astraea.common.metrics.client.producer;
 
 import org.astraea.common.metrics.client.HasSelectorMetrics;
 
+@FunctionalInterface
 public interface HasProducerMetrics extends HasSelectorMetrics {
 
   default double batchSizeAvg() {

--- a/common/src/main/java/org/astraea/common/metrics/client/producer/HasProducerMetrics.java
+++ b/common/src/main/java/org/astraea/common/metrics/client/producer/HasProducerMetrics.java
@@ -16,13 +16,9 @@
  */
 package org.astraea.common.metrics.client.producer;
 
-import org.astraea.common.metrics.HasBeanObject;
+import org.astraea.common.metrics.client.HasSelectorMetrics;
 
-public interface HasProducerMetrics extends HasBeanObject {
-
-  default String clientId() {
-    return beanObject().properties().get("client-id");
-  }
+public interface HasProducerMetrics extends HasSelectorMetrics {
 
   default double batchSizeAvg() {
     return (double) beanObject().attributes().get("batch-size-avg");
@@ -68,88 +64,12 @@ public interface HasProducerMetrics extends HasBeanObject {
     return (double) beanObject().attributes().get("compression-rate-avg");
   }
 
-  default double connectionCloseRate() {
-    return (double) beanObject().attributes().get("connection-close-rate");
-  }
-
-  default double connectionCloseTotal() {
-    return (double) beanObject().attributes().get("connection-close-total");
-  }
-
-  default double connectionCount() {
-    return (double) beanObject().attributes().get("connection-count");
-  }
-
-  default double connectionCreationRate() {
-    return (double) beanObject().attributes().get("connection-creation-rate");
-  }
-
-  default double connectionCreationTotal() {
-    return (double) beanObject().attributes().get("connection-creation-total");
-  }
-
-  default double failedAuthenticationRate() {
-    return (double) beanObject().attributes().get("failed-authentication-rate");
-  }
-
-  default double failedAuthenticationTotal() {
-    return (double) beanObject().attributes().get("failed-authentication-total");
-  }
-
-  default double failedReauthenticationRate() {
-    return (double) beanObject().attributes().get("failed-reauthentication-rate");
-  }
-
-  default double failedReauthenticationTotal() {
-    return (double) beanObject().attributes().get("failed-reauthentication-total");
-  }
-
   default double flushTimeNsTotal() {
     return (double) beanObject().attributes().get("flush-time-ns-total");
   }
 
-  default double incomingByteRate() {
-    return (double) beanObject().attributes().get("incoming-byte-rate");
-  }
-
-  default double incomingByteTotal() {
-    return (double) beanObject().attributes().get("incoming-byte-total");
-  }
-
-  default double ioTimeNsAvg() {
-    return (double) beanObject().attributes().get("io-time-ns-avg");
-  }
-
-  default double ioTimeNsTotal() {
-    return (double) beanObject().attributes().get("io-time-ns-total");
-  }
-
-  default double ioWaitTimeNsAvg() {
-    return (double) beanObject().attributes().get("io-wait-time-ns-avg");
-  }
-
-  default double ioWaitTimeNsTotal() {
-    return (double) beanObject().attributes().get("io-wait-time-ns-total");
-  }
-
   default double metadataAge() {
     return (double) beanObject().attributes().get("metadata-age");
-  }
-
-  default double networkIoRate() {
-    return (double) beanObject().attributes().get("network-io-rate");
-  }
-
-  default double networkIoTotal() {
-    return (double) beanObject().attributes().get("network-io-total");
-  }
-
-  default double outgoingByteRate() {
-    return (double) beanObject().attributes().get("outgoing-byte-rate");
-  }
-
-  default double outgoingByteTotal() {
-    return (double) beanObject().attributes().get("outgoing-byte-total");
   }
 
   default double produceThrottleTimeAvg() {
@@ -158,14 +78,6 @@ public interface HasProducerMetrics extends HasBeanObject {
 
   default double produceThrottleTimeMax() {
     return (double) beanObject().attributes().get("produce-throttle-time-max");
-  }
-
-  default double reauthenticationLatencyAvg() {
-    return (double) beanObject().attributes().get("reauthentication-latency-avg");
-  }
-
-  default double reauthenticationLatencyMax() {
-    return (double) beanObject().attributes().get("reauthentication-latency-max");
   }
 
   default double recordErrorRate() {
@@ -220,60 +132,8 @@ public interface HasProducerMetrics extends HasBeanObject {
     return (double) beanObject().attributes().get("request-latency-max");
   }
 
-  default double requestRate() {
-    return (double) beanObject().attributes().get("request-rate");
-  }
-
-  default double requestSizeAvg() {
-    return (double) beanObject().attributes().get("request-size-avg");
-  }
-
-  default double requestSizeMax() {
-    return (double) beanObject().attributes().get("request-size-max");
-  }
-
-  default double requestTotal() {
-    return (double) beanObject().attributes().get("request-total");
-  }
-
   default double requestInFlight() {
     return (double) beanObject().attributes().get("requests-in-flight");
-  }
-
-  default double responseRate() {
-    return (double) beanObject().attributes().get("response-rate");
-  }
-
-  default double responseTotal() {
-    return (double) beanObject().attributes().get("response-total");
-  }
-
-  default double selectRate() {
-    return (double) beanObject().attributes().get("select-rate");
-  }
-
-  default double selectTotal() {
-    return (double) beanObject().attributes().get("select-total");
-  }
-
-  default double successfulAuthenticationNoReauthTotal() {
-    return (double) beanObject().attributes().get("successful-authentication-no-reauth-total");
-  }
-
-  default double successfulAuthenticationRate() {
-    return (double) beanObject().attributes().get("successful-authentication-rate");
-  }
-
-  default double successfulAuthenticationTotal() {
-    return (double) beanObject().attributes().get("successful-authentication-total");
-  }
-
-  default double successfulReauthenticationRate() {
-    return (double) beanObject().attributes().get("successful-reauthentication-rate");
-  }
-
-  default double successfulReauthenticationTotal() {
-    return (double) beanObject().attributes().get("successful-reauthentication-total");
   }
 
   default double txnAbortTimeNsTotal() {

--- a/common/src/main/java/org/astraea/common/metrics/client/producer/HasProducerTopicMetrics.java
+++ b/common/src/main/java/org/astraea/common/metrics/client/producer/HasProducerTopicMetrics.java
@@ -18,6 +18,7 @@ package org.astraea.common.metrics.client.producer;
 
 import org.astraea.common.metrics.HasBeanObject;
 
+@FunctionalInterface
 public interface HasProducerTopicMetrics extends HasBeanObject {
 
   default String topic() {

--- a/common/src/main/java/org/astraea/common/metrics/connector/ConnectCoordinatorInfo.java
+++ b/common/src/main/java/org/astraea/common/metrics/connector/ConnectCoordinatorInfo.java
@@ -16,28 +16,16 @@
  */
 package org.astraea.common.metrics.connector;
 
-import org.astraea.common.metrics.HasBeanObject;
+import org.astraea.common.metrics.client.HasCoordinatorMetrics;
 
 @FunctionalInterface
-public interface ConnectorInfo extends HasBeanObject {
+public interface ConnectCoordinatorInfo extends HasCoordinatorMetrics {
 
-  default String connectorName() {
-    return beanObject().properties().get("connector");
+  default double assignedConnectors() {
+    return (double) beanObject().attributes().get("assigned-connectors");
   }
 
-  default String connectorClass() {
-    return (String) beanObject().attributes().get("connector-class");
-  }
-
-  default String connectorType() {
-    return (String) beanObject().attributes().get("connector-type");
-  }
-
-  default String connectorVersion() {
-    return (String) beanObject().attributes().get("connector-version");
-  }
-
-  default String status() {
-    return (String) beanObject().attributes().get("status");
+  default double assignedTasks() {
+    return (double) beanObject().attributes().get("assigned-tasks");
   }
 }

--- a/common/src/main/java/org/astraea/common/metrics/connector/ConnectWorkerConnectorInfo.java
+++ b/common/src/main/java/org/astraea/common/metrics/connector/ConnectWorkerConnectorInfo.java
@@ -19,25 +19,36 @@ package org.astraea.common.metrics.connector;
 import org.astraea.common.metrics.HasBeanObject;
 
 @FunctionalInterface
-public interface ConnectorInfo extends HasBeanObject {
-
+public interface ConnectWorkerConnectorInfo extends HasBeanObject {
   default String connectorName() {
     return beanObject().properties().get("connector");
   }
 
-  default String connectorClass() {
-    return (String) beanObject().attributes().get("connector-class");
+  default long connectorDestroyedTaskCount() {
+    return (long) beanObject().attributes().get("connector-destroyed-task-count");
   }
 
-  default String connectorType() {
-    return (String) beanObject().attributes().get("connector-type");
+  default long connectorFailedTaskCount() {
+    return (long) beanObject().attributes().get("connector-failed-task-count");
   }
 
-  default String connectorVersion() {
-    return (String) beanObject().attributes().get("connector-version");
+  default long connectorPausedTaskCount() {
+    return (long) beanObject().attributes().get("connector-paused-task-count");
   }
 
-  default String status() {
-    return (String) beanObject().attributes().get("status");
+  default long connectorRestartingTaskCount() {
+    return (long) beanObject().attributes().get("connector-restarting-task-count");
+  }
+
+  default long connectorRunningTaskCount() {
+    return (long) beanObject().attributes().get("connector-running-task-count");
+  }
+
+  default long connectorTotalTaskCount() {
+    return (long) beanObject().attributes().get("connector-total-task-count");
+  }
+
+  default long connectorUnassignedTaskCount() {
+    return (long) beanObject().attributes().get("connector-unassigned-task-count");
   }
 }

--- a/common/src/main/java/org/astraea/common/metrics/connector/ConnectWorkerInfo.java
+++ b/common/src/main/java/org/astraea/common/metrics/connector/ConnectWorkerInfo.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.metrics.connector;
+
+import org.astraea.common.metrics.HasBeanObject;
+
+@FunctionalInterface
+public interface ConnectWorkerInfo extends HasBeanObject {
+
+  default double connectorCount() {
+    return (double) beanObject().attributes().get("connector-count");
+  }
+
+  default double connectorStartupAttemptsTotal() {
+    return (double) beanObject().attributes().get("connector-startup-attempts-total");
+  }
+
+  default double connectorStartupFailurePercentage() {
+    return (double) beanObject().attributes().get("connector-startup-failure-percentage");
+  }
+
+  default double connectorStartupFailureTotal() {
+    return (double) beanObject().attributes().get("connector-startup-failure-total");
+  }
+
+  default double connectorStartupSuccessPercentage() {
+    return (double) beanObject().attributes().get("connector-startup-success-percentage");
+  }
+
+  default double connectorStartupSuccessTotal() {
+    return (double) beanObject().attributes().get("connector-startup-success-total");
+  }
+
+  default double taskCount() {
+    return (double) beanObject().attributes().get("task-count");
+  }
+
+  default double taskStartupAttemptsTotal() {
+    return (double) beanObject().attributes().get("task-startup-attempts-total");
+  }
+
+  default double taskStartupFailurePercentage() {
+    return (double) beanObject().attributes().get("task-startup-failure-percentage");
+  }
+
+  default double taskStartupFailureTotal() {
+    return (double) beanObject().attributes().get("task-startup-failure-total");
+  }
+
+  default double taskStartupSuccessPercentage() {
+    return (double) beanObject().attributes().get("task-startup-success-percentage");
+  }
+
+  default double taskStartupSuccessTotal() {
+    return (double) beanObject().attributes().get("task-startup-success-total");
+  }
+}

--- a/common/src/main/java/org/astraea/common/metrics/connector/ConnectWorkerRebalanceInfo.java
+++ b/common/src/main/java/org/astraea/common/metrics/connector/ConnectWorkerRebalanceInfo.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.metrics.connector;
+
+import org.astraea.common.metrics.HasBeanObject;
+
+@FunctionalInterface
+public interface ConnectWorkerRebalanceInfo extends HasBeanObject {
+
+  default double completedRebalancesTotal() {
+    return (double) beanObject().attributes().get("completed-rebalances-total");
+  }
+
+  default String connectProtocol() {
+    return (String) beanObject().attributes().get("connect-protocol");
+  }
+
+  default double epoch() {
+    return (double) beanObject().attributes().get("epoch");
+  }
+
+  default String leaderName() {
+    return (String) beanObject().attributes().get("leader-name");
+  }
+
+  default double rebalanceAvgTimeMs() {
+    return (double) beanObject().attributes().get("rebalance-avg-time-ms");
+  }
+
+  default double rebalanceMaxTimeMs() {
+    return (double) beanObject().attributes().get("rebalance-max-time-ms");
+  }
+
+  default double rebalancing() {
+    return (double) beanObject().attributes().get("rebalancing");
+  }
+
+  default double timeSinceLastRebalanceMs() {
+    return (double) beanObject().attributes().get("time-since-last-rebalance-ms");
+  }
+}

--- a/common/src/main/java/org/astraea/common/metrics/connector/ConnectorMetrics.java
+++ b/common/src/main/java/org/astraea/common/metrics/connector/ConnectorMetrics.java
@@ -18,8 +18,11 @@ package org.astraea.common.metrics.connector;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import org.astraea.common.metrics.AppInfo;
 import org.astraea.common.metrics.BeanQuery;
 import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.client.HasNodeMetrics;
+import org.astraea.common.metrics.client.HasSelectorMetrics;
 
 public class ConnectorMetrics {
 
@@ -65,7 +68,7 @@ public class ConnectorMetrics {
         .collect(Collectors.toUnmodifiableList());
   }
 
-  public static List<ConnectorInfo> connectorInfo(MBeanClient client) {
+  public static List<ConnectorTaskInfo> connectorTaskInfo(MBeanClient client) {
     return client
         .beans(
             BeanQuery.builder()
@@ -75,7 +78,110 @@ public class ConnectorMetrics {
                 .property("task", "*")
                 .build())
         .stream()
+        .map(b -> (ConnectorTaskInfo) () -> b)
+        .collect(Collectors.toUnmodifiableList());
+  }
+
+  public static List<AppInfo> appInfo(MBeanClient client) {
+    return client
+        .beans(
+            BeanQuery.builder()
+                .domainName("kafka.connect")
+                .property("type", "app-info")
+                .property("client-id", "*")
+                .build())
+        .stream()
+        .map(b -> (AppInfo) () -> b)
+        .collect(Collectors.toList());
+  }
+
+  public static List<ConnectCoordinatorInfo> coordinatorInfo(MBeanClient client) {
+    return client
+        .beans(
+            BeanQuery.builder()
+                .domainName("kafka.connect")
+                .property("type", "connect-coordinator-metrics")
+                .property("client-id", "*")
+                .build())
+        .stream()
+        .map(b -> (ConnectCoordinatorInfo) () -> b)
+        .collect(Collectors.toUnmodifiableList());
+  }
+
+  public static List<ConnectorInfo> connectorInfo(MBeanClient client) {
+    return client
+        .beans(
+            BeanQuery.builder()
+                .domainName("kafka.connect")
+                .property("type", "connector-metrics")
+                .property("connector", "*")
+                .build())
+        .stream()
         .map(b -> (ConnectorInfo) () -> b)
+        .collect(Collectors.toUnmodifiableList());
+  }
+
+  public static List<ConnectWorkerRebalanceInfo> workerRebalanceInfo(MBeanClient client) {
+    return client
+        .beans(
+            BeanQuery.builder()
+                .domainName("kafka.connect")
+                .property("type", "connect-worker-rebalance-metrics")
+                .build())
+        .stream()
+        .map(b -> (ConnectWorkerRebalanceInfo) () -> b)
+        .collect(Collectors.toUnmodifiableList());
+  }
+
+  public static List<HasNodeMetrics> nodeInfo(MBeanClient client) {
+    return client
+        .beans(
+            BeanQuery.builder()
+                .domainName("kafka.connect")
+                .property("type", "connect-node-metrics")
+                .property("client-id", "*")
+                .property("node-id", "*")
+                .build())
+        .stream()
+        .map(b -> (HasNodeMetrics) () -> b)
+        .collect(Collectors.toUnmodifiableList());
+  }
+
+  public static List<ConnectWorkerInfo> workerInfo(MBeanClient client) {
+    return client
+        .beans(
+            BeanQuery.builder()
+                .domainName("kafka.connect")
+                .property("type", "connect-worker-metrics")
+                .build())
+        .stream()
+        .map(b -> (ConnectWorkerInfo) () -> b)
+        .collect(Collectors.toUnmodifiableList());
+  }
+
+  public static List<ConnectWorkerConnectorInfo> workerConnectorInfo(MBeanClient client) {
+    return client
+        .beans(
+            BeanQuery.builder()
+                .domainName("kafka.connect")
+                .property("type", "connect-worker-metrics")
+                .property("connector", "*")
+                .build())
+        .stream()
+        .map(b -> (ConnectWorkerConnectorInfo) () -> b)
+        .collect(Collectors.toUnmodifiableList());
+  }
+
+  public static List<HasSelectorMetrics> of(MBeanClient client) {
+    return client
+        .beans(
+            BeanQuery.builder()
+                .domainName("kafka.connect")
+                .property("type", "connect-metrics")
+                .property("client-id", "*")
+                .build())
+        .stream()
+        .map(b -> (HasSelectorMetrics) () -> b)
         .collect(Collectors.toUnmodifiableList());
   }
 }

--- a/common/src/main/java/org/astraea/common/metrics/connector/ConnectorTaskInfo.java
+++ b/common/src/main/java/org/astraea/common/metrics/connector/ConnectorTaskInfo.java
@@ -19,22 +19,46 @@ package org.astraea.common.metrics.connector;
 import org.astraea.common.metrics.HasBeanObject;
 
 @FunctionalInterface
-public interface ConnectorInfo extends HasBeanObject {
+public interface ConnectorTaskInfo extends HasBeanObject {
 
   default String connectorName() {
     return beanObject().properties().get("connector");
   }
 
-  default String connectorClass() {
-    return (String) beanObject().attributes().get("connector-class");
+  default int taskId() {
+    return Integer.parseInt(beanObject().properties().get("task"));
   }
 
   default String connectorType() {
-    return (String) beanObject().attributes().get("connector-type");
+    return beanObject().properties().get("type");
   }
 
-  default String connectorVersion() {
-    return (String) beanObject().attributes().get("connector-version");
+  default double batchSizeAvg() {
+    return (double) beanObject().attributes().get("batch-size-avg");
+  }
+
+  default double batchSizeMax() {
+    return (double) beanObject().attributes().get("batch-size-max");
+  }
+
+  default double offsetCommitAvgTimeMs() {
+    return (double) beanObject().attributes().get("offset-commit-avg-time-ms");
+  }
+
+  default double offsetCommitMaxTimeMs() {
+    return (double) beanObject().attributes().get("offset-commit-max-time-ms");
+  }
+
+  default double offsetCommitFailurePercentage() {
+    return (double) beanObject().attributes().get("offset-commit-failure-percentage");
+  }
+
+  default double offsetCommitSuccessPercentage() {
+    return (double) beanObject().attributes().get("offset-commit-success-percentage");
+  }
+
+  default double pauseRatio() {
+    return (double) beanObject().attributes().get("pause-ratio");
   }
 
   default String status() {

--- a/common/src/test/java/org/astraea/common/metrics/connector/ConnectorMetricsTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/connector/ConnectorMetricsTest.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.metrics.connector;
+
+import org.astraea.common.connector.ConnectorClient;
+import org.astraea.common.metrics.MBeanClient;
+import org.astraea.it.Service;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ConnectorMetricsTest {
+  private static final Service SERVICE =
+      Service.builder().numberOfWorkers(1).numberOfBrokers(1).build();
+
+  @AfterAll
+  static void closeService() {
+    SERVICE.close();
+  }
+
+  @Test
+  void testMetrics() {
+    ConnectorClient.builder().url(SERVICE.workerUrl()).build();
+
+    var m0 = ConnectorMetrics.appInfo(MBeanClient.local());
+    Assertions.assertNotEquals(0, m0.size());
+    m0.forEach(
+        m -> {
+          Assertions.assertDoesNotThrow(m::commitId);
+          Assertions.assertDoesNotThrow(m::startTimeMs);
+          Assertions.assertDoesNotThrow(m::version);
+        });
+
+    var m1 = ConnectorMetrics.coordinatorInfo(MBeanClient.local());
+    Assertions.assertNotEquals(0, m1.size());
+    m1.forEach(
+        m -> {
+          Assertions.assertDoesNotThrow(m::failedRebalanceRatePerHour);
+          Assertions.assertDoesNotThrow(m::failedRebalanceTotal);
+          Assertions.assertDoesNotThrow(m::heartbeatRate);
+          Assertions.assertDoesNotThrow(m::heartbeatResponseTimeMax);
+          Assertions.assertDoesNotThrow(m::heartbeatTotal);
+          Assertions.assertDoesNotThrow(m::joinRate);
+          Assertions.assertDoesNotThrow(m::joinTimeAvg);
+          Assertions.assertDoesNotThrow(m::joinTimeMax);
+          Assertions.assertDoesNotThrow(m::joinTotal);
+          Assertions.assertDoesNotThrow(m::lastHeartbeatSecondsAgo);
+          Assertions.assertDoesNotThrow(m::lastRebalanceSecondsAgo);
+          Assertions.assertDoesNotThrow(m::rebalanceLatencyAvg);
+          Assertions.assertDoesNotThrow(m::rebalanceLatencyMax);
+          Assertions.assertDoesNotThrow(m::rebalanceLatencyTotal);
+          Assertions.assertDoesNotThrow(m::rebalanceRatePerHour);
+          Assertions.assertDoesNotThrow(m::rebalanceTotal);
+          Assertions.assertDoesNotThrow(m::syncRate);
+          Assertions.assertDoesNotThrow(m::syncTimeAvg);
+          Assertions.assertDoesNotThrow(m::syncTimeMax);
+          Assertions.assertDoesNotThrow(m::syncTotal);
+          Assertions.assertDoesNotThrow(m::assignedConnectors);
+          Assertions.assertDoesNotThrow(m::assignedTasks);
+        });
+
+    var m2 = ConnectorMetrics.of(MBeanClient.local());
+    Assertions.assertNotEquals(0, m2.size());
+    m2.forEach(
+        m -> {
+          Assertions.assertDoesNotThrow(m::connectionCloseRate);
+          Assertions.assertDoesNotThrow(m::connectionCloseTotal);
+          Assertions.assertDoesNotThrow(m::connectionCount);
+          Assertions.assertDoesNotThrow(m::connectionCreationRate);
+          Assertions.assertDoesNotThrow(m::connectionCreationTotal);
+          Assertions.assertDoesNotThrow(m::failedAuthenticationRate);
+          Assertions.assertDoesNotThrow(m::failedAuthenticationTotal);
+          Assertions.assertDoesNotThrow(m::failedReauthenticationRate);
+          Assertions.assertDoesNotThrow(m::failedReauthenticationTotal);
+          Assertions.assertDoesNotThrow(m::incomingByteRate);
+          Assertions.assertDoesNotThrow(m::incomingByteTotal);
+          Assertions.assertDoesNotThrow(m::ioRatio);
+          Assertions.assertDoesNotThrow(m::ioTimeNsAvg);
+          Assertions.assertDoesNotThrow(m::ioTimeNsTotal);
+          Assertions.assertDoesNotThrow(m::ioWaitRatio);
+          Assertions.assertDoesNotThrow(m::ioWaitTimeNsAvg);
+          Assertions.assertDoesNotThrow(m::ioWaitTimeNsTotal);
+          Assertions.assertDoesNotThrow(m::ioWaitTimeTotal);
+          Assertions.assertDoesNotThrow(m::ioTimeTotal);
+          Assertions.assertDoesNotThrow(m::networkIoRate);
+          Assertions.assertDoesNotThrow(m::networkIoTotal);
+          Assertions.assertDoesNotThrow(m::outgoingByteRate);
+          Assertions.assertDoesNotThrow(m::outgoingByteTotal);
+          Assertions.assertDoesNotThrow(m::reauthenticationLatencyAvg);
+          Assertions.assertDoesNotThrow(m::reauthenticationLatencyMax);
+          Assertions.assertDoesNotThrow(m::requestRate);
+          Assertions.assertDoesNotThrow(m::requestSizeAvg);
+          Assertions.assertDoesNotThrow(m::requestSizeMax);
+          Assertions.assertDoesNotThrow(m::requestTotal);
+          Assertions.assertDoesNotThrow(m::selectRate);
+          Assertions.assertDoesNotThrow(m::selectTotal);
+          Assertions.assertDoesNotThrow(m::successfulAuthenticationNoReauthTotal);
+          Assertions.assertDoesNotThrow(m::successfulAuthenticationRate);
+          Assertions.assertDoesNotThrow(m::successfulAuthenticationTotal);
+          Assertions.assertDoesNotThrow(m::successfulReauthenticationRate);
+          Assertions.assertDoesNotThrow(m::successfulReauthenticationTotal);
+        });
+
+    var m3 = ConnectorMetrics.nodeInfo(MBeanClient.local());
+    Assertions.assertNotEquals(0, m3.size());
+    m3.forEach(
+        m -> {
+          Assertions.assertDoesNotThrow(m::incomingByteRate);
+          Assertions.assertDoesNotThrow(m::incomingByteTotal);
+          Assertions.assertDoesNotThrow(m::outgoingByteRate);
+          Assertions.assertDoesNotThrow(m::outgoingByteTotal);
+          Assertions.assertDoesNotThrow(m::requestLatencyAvg);
+          Assertions.assertDoesNotThrow(m::requestLatencyMax);
+          Assertions.assertDoesNotThrow(m::requestRate);
+          Assertions.assertDoesNotThrow(m::requestSizeAvg);
+          Assertions.assertDoesNotThrow(m::requestSizeMax);
+          Assertions.assertDoesNotThrow(m::requestTotal);
+          Assertions.assertDoesNotThrow(m::responseRate);
+          Assertions.assertDoesNotThrow(m::responseTotal);
+        });
+
+    var m4 = ConnectorMetrics.workerInfo(MBeanClient.local());
+    Assertions.assertNotEquals(0, m4.size());
+    m4.forEach(
+        m -> {
+          Assertions.assertDoesNotThrow(m::connectorCount);
+          Assertions.assertDoesNotThrow(m::connectorStartupAttemptsTotal);
+          Assertions.assertDoesNotThrow(m::connectorStartupFailurePercentage);
+          Assertions.assertDoesNotThrow(m::connectorStartupFailureTotal);
+          Assertions.assertDoesNotThrow(m::connectorStartupSuccessPercentage);
+          Assertions.assertDoesNotThrow(m::connectorStartupSuccessTotal);
+          Assertions.assertDoesNotThrow(m::taskCount);
+          Assertions.assertDoesNotThrow(m::taskStartupAttemptsTotal);
+          Assertions.assertDoesNotThrow(m::taskStartupFailurePercentage);
+          Assertions.assertDoesNotThrow(m::taskStartupFailureTotal);
+          Assertions.assertDoesNotThrow(m::taskStartupSuccessPercentage);
+          Assertions.assertDoesNotThrow(m::taskStartupSuccessTotal);
+        });
+
+    var m5 = ConnectorMetrics.workerRebalanceInfo(MBeanClient.local());
+    Assertions.assertNotEquals(0, m5.size());
+    m5.forEach(
+        m -> {
+          Assertions.assertDoesNotThrow(m::completedRebalancesTotal);
+          Assertions.assertDoesNotThrow(m::connectProtocol);
+          Assertions.assertDoesNotThrow(m::epoch);
+          Assertions.assertDoesNotThrow(m::leaderName);
+          Assertions.assertDoesNotThrow(m::rebalanceAvgTimeMs);
+          Assertions.assertDoesNotThrow(m::rebalanceMaxTimeMs);
+          Assertions.assertDoesNotThrow(m::rebalancing);
+          Assertions.assertDoesNotThrow(m::timeSinceLastRebalanceMs);
+        });
+  }
+}

--- a/connector/src/test/java/org/astraea/connector/perf/PerfSinkTest.java
+++ b/connector/src/test/java/org/astraea/connector/perf/PerfSinkTest.java
@@ -175,7 +175,7 @@ public class PerfSinkTest {
         });
 
     var m2 =
-        ConnectorMetrics.connectorInfo(MBeanClient.local()).stream()
+        ConnectorMetrics.connectorTaskInfo(MBeanClient.local()).stream()
             .filter(m -> m.connectorName().equals(name))
             .collect(Collectors.toList());
     Assertions.assertEquals(1, m2.size());
@@ -191,6 +191,35 @@ public class PerfSinkTest {
           Assertions.assertDoesNotThrow(m::offsetCommitAvgTimeMs);
           Assertions.assertDoesNotThrow(m::offsetCommitMaxTimeMs);
           Assertions.assertDoesNotThrow(m::pauseRatio);
+          Assertions.assertDoesNotThrow(m::status);
+        });
+
+    var m3 =
+        ConnectorMetrics.workerConnectorInfo(MBeanClient.local()).stream()
+            .filter(m -> m.connectorName().equals(name))
+            .collect(Collectors.toList());
+    Assertions.assertEquals(1, m3.size());
+    m3.forEach(
+        m -> {
+          Assertions.assertDoesNotThrow(m::connectorDestroyedTaskCount);
+          Assertions.assertDoesNotThrow(m::connectorFailedTaskCount);
+          Assertions.assertDoesNotThrow(m::connectorPausedTaskCount);
+          Assertions.assertDoesNotThrow(m::connectorRestartingTaskCount);
+          Assertions.assertDoesNotThrow(m::connectorRunningTaskCount);
+          Assertions.assertDoesNotThrow(m::connectorTotalTaskCount);
+          Assertions.assertDoesNotThrow(m::connectorUnassignedTaskCount);
+        });
+
+    var m4 =
+        ConnectorMetrics.connectorInfo(MBeanClient.local()).stream()
+            .filter(m -> m.connectorName().equals(name))
+            .collect(Collectors.toList());
+    Assertions.assertEquals(1, m4.size());
+    m4.forEach(
+        m -> {
+          Assertions.assertEquals(PerfSink.class.getName(), m.connectorClass());
+          Assertions.assertEquals("sink", m.connectorType());
+          Assertions.assertDoesNotThrow(m::connectorVersion);
           Assertions.assertDoesNotThrow(m::status);
         });
   }

--- a/connector/src/test/java/org/astraea/connector/perf/PerfSourceTest.java
+++ b/connector/src/test/java/org/astraea/connector/perf/PerfSourceTest.java
@@ -331,7 +331,7 @@ public class PerfSourceTest {
         });
 
     var m2 =
-        ConnectorMetrics.connectorInfo(MBeanClient.local()).stream()
+        ConnectorMetrics.connectorTaskInfo(MBeanClient.local()).stream()
             .filter(m -> m.connectorName().equals(name))
             .collect(Collectors.toList());
     Assertions.assertEquals(1, m2.size());
@@ -347,6 +347,35 @@ public class PerfSourceTest {
           Assertions.assertDoesNotThrow(m::offsetCommitAvgTimeMs);
           Assertions.assertDoesNotThrow(m::offsetCommitMaxTimeMs);
           Assertions.assertDoesNotThrow(m::pauseRatio);
+          Assertions.assertDoesNotThrow(m::status);
+        });
+
+    var m3 =
+        ConnectorMetrics.workerConnectorInfo(MBeanClient.local()).stream()
+            .filter(m -> m.connectorName().equals(name))
+            .collect(Collectors.toList());
+    Assertions.assertEquals(1, m3.size());
+    m3.forEach(
+        m -> {
+          Assertions.assertDoesNotThrow(m::connectorDestroyedTaskCount);
+          Assertions.assertDoesNotThrow(m::connectorFailedTaskCount);
+          Assertions.assertDoesNotThrow(m::connectorPausedTaskCount);
+          Assertions.assertDoesNotThrow(m::connectorRestartingTaskCount);
+          Assertions.assertDoesNotThrow(m::connectorRunningTaskCount);
+          Assertions.assertDoesNotThrow(m::connectorTotalTaskCount);
+          Assertions.assertDoesNotThrow(m::connectorUnassignedTaskCount);
+        });
+
+    var m4 =
+        ConnectorMetrics.connectorInfo(MBeanClient.local()).stream()
+            .filter(m -> m.connectorName().equals(name))
+            .collect(Collectors.toList());
+    Assertions.assertEquals(1, m4.size());
+    m4.forEach(
+        m -> {
+          Assertions.assertEquals(PerfSource.class.getName(), m.connectorClass());
+          Assertions.assertEquals("source", m.connectorType());
+          Assertions.assertDoesNotThrow(m::connectorVersion);
           Assertions.assertDoesNotThrow(m::status);
         });
   }


### PR DESCRIPTION
fix #1496

- 新增 "kafka.connect" metrics `app-info` `connect-coordinator-metrics` `connect-metrics` `connect-node-metrics` `connect-worker-metrics` `connect-worker-rebalance-metrics` `connector-metrics`

- rename file `ConnectorInfo` to `ConnectorTaskInfo`  (connector-task-metrics) 因為將新增的 connector-metrics 命名為前者

- 新增 `HasCoordinatorMetrics` -> 將 consumer 及 connector 的 coordinator 合併共同 metrics 

- 新增 `HasSelectorMetrics` -> admin, consumer, producer, connector -metrics 合併共同 metrics

- 新增測試 `ConnectorMetricsTest`