### PR TITLE
[COST] Revise `NetworkCost` calculation formula

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/NetworkCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NetworkCost.java
@@ -148,10 +148,11 @@ public abstract class NetworkCost implements HasClusterCost {
     // add the brokers having no replicas into map
     clusterInfo.nodes().stream()
         .filter(node -> !brokerIngressRate.containsKey(node))
-        .forEach(node -> brokerIngressRate.put(node, 0.0));
-    clusterInfo.nodes().stream()
-        .filter(node -> !brokerEgressRate.containsKey(node))
-        .forEach(node -> brokerEgressRate.put(node, 0.0));
+        .forEach(
+            node -> {
+              brokerIngressRate.put(node, 0.0);
+              brokerEgressRate.put(node, 0.0);
+            });
 
     // the rate we are measuring
     var brokerRate =

--- a/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
@@ -256,11 +256,15 @@ class NetworkCostTest {
     double expectedIngress1 = 100 + 80;
     double expectedIngress2 = 100;
     double expectedIngress3 = 80;
+    double ingressSum = expectedIngress1 + expectedIngress2 + expectedIngress3;
     double expectedEgress1 = 300 + 100;
     double expectedEgress2 = 0;
-    double expectedEgress3 = 800 + 80 * 2;
-    double expectedIngressScore = (expectedIngress1 - expectedIngress3) / expectedIngress1;
-    double expectedEgressScore = (expectedEgress3 - expectedEgress2) / expectedEgress3;
+    double expectedEgress3 = 800 + 80;
+    double egressSum = expectedEgress1 + expectedEgress2 + expectedEgress3;
+    double expectedIngressScore =
+        (expectedIngress1 - expectedIngress3) / Math.max(ingressSum, egressSum);
+    double expectedEgressScore =
+        (expectedEgress3 - expectedEgress2) / Math.max(ingressSum, egressSum);
     double ingressScore = ingressCost().clusterCost(cluster, beans).value();
     double egressScore = egressCost().clusterCost(cluster, beans).value();
     Assertions.assertTrue(
@@ -269,6 +273,9 @@ class NetworkCostTest {
     Assertions.assertTrue(
         around.apply(expectedEgressScore).test(egressScore),
         "Egress score should be " + expectedEgressScore + " but it is " + egressScore);
+    Assertions.assertTrue(
+        egressScore > ingressScore,
+        "Egress is experience higher imbalance issues, its score should be higher");
   }
 
   @Test


### PR DESCRIPTION
Resolve #1285.

原本 `NetworkCost` 的分數計算方式，在同時優化網路輸入和網路輸出時會出現分數意義不平等的現象，可能導致優化結果不理想。這個 PR 修改 `NetworkCost` 的 ClusterCost 分數計算方式，他們會以 #1285 提到的方式，以相同的基準點下去做比較打分，比較能夠對比出二者不平衡的差異。