### PR TITLE
Implementation of `ClusterInfoSensor`

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/NetworkCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NetworkCost.java
@@ -88,10 +88,13 @@ public abstract class NetworkCost implements HasClusterCost {
     noMetricCheck(clusterBean);
     final var metricViewCluster = ClusterInfoSensor.metricViewCluster(clusterBean);
 
+    // Use the real cluster(metricViewCluster) and real metrics to derive the data rate of each
+    // partition
     var ingressRate =
         estimateRate(metricViewCluster, clusterBean, ServerMetrics.Topic.BYTES_IN_PER_SEC);
     var egressRate =
         estimateRate(metricViewCluster, clusterBean, ServerMetrics.Topic.BYTES_OUT_PER_SEC);
+    // Evaluate the score of the balancer-tweaked cluster(clusterInfo)
     var brokerIngressRate =
         clusterInfo
             .replicaStream()

--- a/common/src/main/java/org/astraea/common/cost/NetworkCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NetworkCost.java
@@ -22,7 +22,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -34,6 +33,7 @@ import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.Replica;
 import org.astraea.common.admin.TopicPartition;
+import org.astraea.common.cost.utils.ClusterInfoSensor;
 import org.astraea.common.metrics.HasBeanObject;
 import org.astraea.common.metrics.broker.HasRate;
 import org.astraea.common.metrics.broker.LogMetrics;
@@ -63,8 +63,8 @@ import org.astraea.common.metrics.platform.HostMetrics;
  */
 public abstract class NetworkCost implements HasClusterCost {
 
-  private final AtomicReference<ClusterInfo> currentCluster = new AtomicReference<>();
   private final BandwidthType bandwidthType;
+  private final ClusterInfoSensor clusterInfoSensor = new ClusterInfoSensor();
 
   NetworkCost(BandwidthType bandwidthType) {
     this.bandwidthType = bandwidthType;
@@ -83,31 +83,15 @@ public abstract class NetworkCost implements HasClusterCost {
           "The following brokers have no metric available: " + noMetricBrokers);
   }
 
-  void updateCurrentCluster(
-      ClusterInfo clusterInfo, ClusterBean clusterBean, AtomicReference<ClusterInfo> ref) {
-    // TODO: We need a reliable way to access the actual current cluster info. The following method
-    //  try to compare the equality of cluster info and cluster bean in terms of replica set. But it
-    //  didn't consider the data folder info. See the full discussion:
-    //  https://github.com/skiptests/astraea/pull/1240#discussion_r1044487473
-    var metricReplicas = clusterBean.replicas();
-    var mismatchSet =
-        clusterInfo.topicPartitionReplicas().stream()
-            .filter(tpr -> !metricReplicas.contains(tpr))
-            .collect(Collectors.toUnmodifiableSet());
-    if (mismatchSet.isEmpty()) ref.set(clusterInfo);
-    if (ref.get() == null)
-      fail("Initial clusterInfo required, the following replicas are mismatch: " + mismatchSet);
-  }
-
   @Override
   public ClusterCost clusterCost(ClusterInfo clusterInfo, ClusterBean clusterBean) {
     noMetricCheck(clusterBean);
-    updateCurrentCluster(clusterInfo, clusterBean, currentCluster);
+    final var metricViewCluster = ClusterInfoSensor.metricViewCluster(clusterBean);
 
     var ingressRate =
-        estimateRate(currentCluster.get(), clusterBean, ServerMetrics.Topic.BYTES_IN_PER_SEC);
+        estimateRate(metricViewCluster, clusterBean, ServerMetrics.Topic.BYTES_IN_PER_SEC);
     var egressRate =
-        estimateRate(currentCluster.get(), clusterBean, ServerMetrics.Topic.BYTES_OUT_PER_SEC);
+        estimateRate(metricViewCluster, clusterBean, ServerMetrics.Topic.BYTES_OUT_PER_SEC);
     var brokerIngressRate =
         clusterInfo
             .replicaStream()
@@ -192,7 +176,8 @@ public abstract class NetworkCost implements HasClusterCost {
                     List.of(HostMetrics.jvmMemory(client)),
                     ServerMetrics.Topic.BYTES_IN_PER_SEC.fetch(client),
                     ServerMetrics.Topic.BYTES_OUT_PER_SEC.fetch(client),
-                    LogMetrics.Log.SIZE.fetch(client))
+                    LogMetrics.Log.SIZE.fetch(client),
+                    clusterInfoSensor.fetch(client, clusterBean))
                 .flatMap(Collection::stream)
                 .collect(Collectors.toUnmodifiableList()));
   }

--- a/common/src/main/java/org/astraea/common/cost/utils/ClusterInfoSensor.java
+++ b/common/src/main/java/org/astraea/common/cost/utils/ClusterInfoSensor.java
@@ -101,14 +101,8 @@ public class ClusterInfoSensor implements MetricSensor {
     var clusterId =
         clusterBean.all().values().stream()
             .flatMap(Collection::stream)
-            .filter(x -> x instanceof HasGauge)
-            .filter(
-                x ->
-                    x.beanObject()
-                        .properties()
-                        .get("name")
-                        .equals(ServerMetrics.KafkaServer.CLUSTER_ID))
-            .map(x -> (HasGauge<String>) x)
+            .filter(x -> x instanceof ServerMetrics.KafkaServer.ClusterIdGauge)
+            .map(x -> (ServerMetrics.KafkaServer.ClusterIdGauge) x)
             .findAny()
             .map(HasGauge::value)
             .orElse("");

--- a/common/src/main/java/org/astraea/common/cost/utils/ClusterInfoSensor.java
+++ b/common/src/main/java/org/astraea/common/cost/utils/ClusterInfoSensor.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.cost.utils;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.astraea.common.admin.ClusterBean;
+import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.admin.NodeInfo;
+import org.astraea.common.admin.Replica;
+import org.astraea.common.admin.TopicPartition;
+import org.astraea.common.metrics.BeanObject;
+import org.astraea.common.metrics.BeanQuery;
+import org.astraea.common.metrics.HasBeanObject;
+import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.broker.HasGauge;
+import org.astraea.common.metrics.broker.LogMetrics;
+import org.astraea.common.metrics.collector.MetricSensor;
+
+/** This MetricSensor attempts to reconstruct a ClusterInfo of the kafka cluster via JMX metrics. */
+public class ClusterInfoSensor implements MetricSensor {
+
+  @Override
+  public List<? extends HasBeanObject> fetch(MBeanClient client, ClusterBean bean) {
+    return Stream.of(
+            LogMetrics.Log.SIZE.fetch(client), ClusterInfoSensor.ReplicasCountMetric.fetch(client))
+        .flatMap(Collection::stream)
+        .collect(Collectors.toUnmodifiableList());
+  }
+
+  public static ClusterInfo metricViewCluster(ClusterBean clusterBean) {
+    var nodes =
+        clusterBean.brokerIds().stream()
+            .map(id -> NodeInfo.of(id, "", -1))
+            .collect(Collectors.toUnmodifiableMap(NodeInfo::id, x -> x));
+    var replicas =
+        clusterBean.brokerTopics().stream()
+            .flatMap(
+                (bt) -> {
+                  var broker = bt.broker();
+                  var partitions =
+                      clusterBean
+                          .brokerTopicMetrics(bt, ReplicasCountMetric.class)
+                          .sorted(
+                              Comparator.comparingLong(HasBeanObject::createdTimestamp).reversed())
+                          .collect(
+                              Collectors.toUnmodifiableMap(
+                                  ReplicasCountMetric::topicPartition,
+                                  m -> {
+                                    var tp = m.topicPartition();
+                                    var size =
+                                        clusterBean
+                                            .brokerMetrics(broker, LogMetrics.Log.Gauge.class)
+                                            .filter(x -> x.partition() == tp.partition())
+                                            .filter(x -> x.topic().equals(tp.topic()))
+                                            .filter(
+                                                x ->
+                                                    LogMetrics.Log.SIZE
+                                                        .metricName()
+                                                        .equals(x.metricsName()))
+                                            .max(
+                                                Comparator.comparingLong(
+                                                    HasBeanObject::createdTimestamp))
+                                            .orElseThrow()
+                                            .value();
+                                    var build =
+                                        Replica.builder()
+                                            .topic(tp.topic())
+                                            .partition(tp.partition())
+                                            .nodeInfo(nodes.get(broker))
+                                            .path("")
+                                            .size(size);
+                                    return m.isLeader()
+                                        ? build.buildLeader()
+                                        : build.buildInSyncFollower();
+                                  },
+                                  (latest, earlier) -> latest));
+                  return partitions.values().stream();
+                })
+            .collect(Collectors.toUnmodifiableList());
+
+    return ClusterInfo.of("", List.copyOf(nodes.values()), Map.of(), replicas);
+  }
+
+  public static class ReplicasCountMetric implements HasGauge<Integer> {
+
+    private final BeanObject beanObject;
+
+    ReplicasCountMetric(BeanObject beanObject) {
+      this.beanObject = beanObject;
+    }
+
+    public static ReplicasCountMetric of(String topic, int partition, int count) {
+      return new ReplicasCountMetric(
+          new BeanObject(
+              "kafka.cluster",
+              Map.ofEntries(
+                  Map.entry("type", "Partition"),
+                  Map.entry("topic", topic),
+                  Map.entry("partition", Integer.toString(partition)),
+                  Map.entry("name", "ReplicasCount")),
+              Map.of("Value", count)));
+    }
+
+    static List<ReplicasCountMetric> fetch(MBeanClient client) {
+      return client
+          .beans(
+              BeanQuery.builder()
+                  .domainName("kafka.cluster")
+                  .property("type", "Partition")
+                  .property("topic", "*")
+                  .property("partition", "*")
+                  .property("name", "ReplicasCount")
+                  .build())
+          .stream()
+          .map(ReplicasCountMetric::new)
+          .collect(Collectors.toUnmodifiableList());
+    }
+
+    @Override
+    public BeanObject beanObject() {
+      return beanObject;
+    }
+
+    public TopicPartition topicPartition() {
+      return TopicPartition.of(
+          beanObject.properties().get("topic"),
+          Integer.parseInt(beanObject.properties().get("partition")));
+    }
+
+    public boolean isLeader() {
+      return this.value() != 0;
+    }
+  }
+
+  static class Builder {
+    private String topic;
+    private int partition;
+    private long size;
+  }
+}

--- a/common/src/main/java/org/astraea/common/cost/utils/ClusterInfoSensor.java
+++ b/common/src/main/java/org/astraea/common/cost/utils/ClusterInfoSensor.java
@@ -150,10 +150,4 @@ public class ClusterInfoSensor implements MetricSensor {
       return this.value() != 0;
     }
   }
-
-  static class Builder {
-    private String topic;
-    private int partition;
-    private long size;
-  }
 }

--- a/common/src/main/java/org/astraea/common/metrics/broker/ClusterMetrics.java
+++ b/common/src/main/java/org/astraea/common/metrics/broker/ClusterMetrics.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.metrics.broker;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.astraea.common.EnumInfo;
+import org.astraea.common.admin.TopicPartition;
+import org.astraea.common.metrics.BeanObject;
+import org.astraea.common.metrics.BeanQuery;
+import org.astraea.common.metrics.MBeanClient;
+
+public final class ClusterMetrics {
+
+  public static final String DOMAIN_NAME = "kafka.cluster";
+
+  public enum Partition implements EnumInfo {
+    REPLICAS_COUNT("ReplicasCount");
+
+    private final String metricName;
+
+    Partition(String metricName) {
+      this.metricName = metricName;
+    }
+
+    public PartitionMetric of(String topic, int partition, int value) {
+      return new PartitionMetric(
+          new BeanObject(
+              DOMAIN_NAME,
+              Map.ofEntries(
+                  Map.entry("type", "Partition"),
+                  Map.entry("topic", topic),
+                  Map.entry("partition", Integer.toString(partition)),
+                  Map.entry("name", metricName())),
+              Map.of("Value", value)));
+    }
+
+    @Override
+    public String alias() {
+      return metricName();
+    }
+
+    @Override
+    public String toString() {
+      return alias();
+    }
+
+    public String metricName() {
+      return this.metricName;
+    }
+
+    public static ClusterMetrics.Partition ofAlias(String alias) {
+      return EnumInfo.ignoreCaseEnum(ClusterMetrics.Partition.class, alias);
+    }
+
+    public List<PartitionMetric> fetch(MBeanClient client) {
+      return client
+          .beans(
+              BeanQuery.builder()
+                  .domainName(DOMAIN_NAME)
+                  .property("type", "Partition")
+                  .property("topic", "*")
+                  .property("partition", "*")
+                  .property("name", metricName())
+                  .build())
+          .stream()
+          .map(PartitionMetric::new)
+          .collect(Collectors.toUnmodifiableList());
+    }
+  }
+
+  public static class PartitionMetric implements HasGauge<Integer> {
+    private final BeanObject beanObject;
+
+    PartitionMetric(BeanObject beanObject) {
+      this.beanObject = beanObject;
+    }
+
+    @Override
+    public BeanObject beanObject() {
+      return beanObject;
+    }
+
+    public TopicPartition topicPartition() {
+      return TopicPartition.of(
+          beanObject.properties().get("topic"),
+          Integer.parseInt(beanObject.properties().get("partition")));
+    }
+  }
+
+  private ClusterMetrics() {}
+}

--- a/common/src/main/java/org/astraea/common/metrics/broker/ClusterMetrics.java
+++ b/common/src/main/java/org/astraea/common/metrics/broker/ClusterMetrics.java
@@ -17,7 +17,6 @@
 package org.astraea.common.metrics.broker;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import org.astraea.common.EnumInfo;
 import org.astraea.common.admin.TopicPartition;
@@ -36,18 +35,6 @@ public final class ClusterMetrics {
 
     Partition(String metricName) {
       this.metricName = metricName;
-    }
-
-    public PartitionMetric of(String topic, int partition, int value) {
-      return new PartitionMetric(
-          new BeanObject(
-              DOMAIN_NAME,
-              Map.ofEntries(
-                  Map.entry("type", "Partition"),
-                  Map.entry("topic", topic),
-                  Map.entry("partition", Integer.toString(partition)),
-                  Map.entry("name", metricName())),
-              Map.of("Value", value)));
     }
 
     @Override
@@ -87,7 +74,7 @@ public final class ClusterMetrics {
   public static class PartitionMetric implements HasGauge<Integer> {
     private final BeanObject beanObject;
 
-    PartitionMetric(BeanObject beanObject) {
+    public PartitionMetric(BeanObject beanObject) {
       this.beanObject = beanObject;
     }
 

--- a/common/src/main/java/org/astraea/common/metrics/broker/ClusterMetrics.java
+++ b/common/src/main/java/org/astraea/common/metrics/broker/ClusterMetrics.java
@@ -97,9 +97,7 @@ public final class ClusterMetrics {
     }
 
     public TopicPartition topicPartition() {
-      return TopicPartition.of(
-          beanObject.properties().get("topic"),
-          Integer.parseInt(beanObject.properties().get("partition")));
+      return partitionIndex().orElseThrow();
     }
   }
 

--- a/common/src/main/java/org/astraea/common/metrics/broker/HasGauge.java
+++ b/common/src/main/java/org/astraea/common/metrics/broker/HasGauge.java
@@ -28,7 +28,7 @@ import org.astraea.common.metrics.HasBeanObject;
 public interface HasGauge<T> extends HasBeanObject {
   String VALUE_KEY = "Value";
 
-  static HasGauge<Long> ofLong(BeanObject beanObject) {
+  static <T> HasGauge<T> of(BeanObject beanObject, Class<T> aClass) {
     return () -> beanObject;
   }
 

--- a/common/src/main/java/org/astraea/common/metrics/broker/HasGauge.java
+++ b/common/src/main/java/org/astraea/common/metrics/broker/HasGauge.java
@@ -28,7 +28,7 @@ import org.astraea.common.metrics.HasBeanObject;
 public interface HasGauge<T> extends HasBeanObject {
   String VALUE_KEY = "Value";
 
-  static <T> HasGauge<T> of(BeanObject beanObject, Class<T> aClass) {
+  static HasGauge<?> of(BeanObject beanObject) {
     return () -> beanObject;
   }
 

--- a/common/src/main/java/org/astraea/common/metrics/broker/ServerMetrics.java
+++ b/common/src/main/java/org/astraea/common/metrics/broker/ServerMetrics.java
@@ -192,14 +192,14 @@ public final class ServerMetrics {
 
     private final String metricName;
 
-    public static HasGauge<String> clusterId(MBeanClient mBeanClient) {
-      return () ->
+    public static ClusterIdGauge clusterId(MBeanClient mBeanClient) {
+      return new ClusterIdGauge(
           mBeanClient.bean(
               BeanQuery.builder()
                   .domainName(DOMAIN_NAME)
                   .property("type", "KafkaServer")
                   .property("name", CLUSTER_ID)
-                  .build());
+                  .build()));
     }
 
     KafkaServer(String name) {
@@ -247,6 +247,19 @@ public final class ServerMetrics {
 
       public KafkaServer type() {
         return ofAlias(metricsName());
+      }
+
+      @Override
+      public BeanObject beanObject() {
+        return beanObject;
+      }
+    }
+
+    public static class ClusterIdGauge implements HasGauge<String> {
+      private final BeanObject beanObject;
+
+      public ClusterIdGauge(BeanObject beanObject) {
+        this.beanObject = beanObject;
       }
 
       @Override

--- a/common/src/test/java/org/astraea/common/admin/ClusterBeanTest.java
+++ b/common/src/test/java/org/astraea/common/admin/ClusterBeanTest.java
@@ -94,12 +94,12 @@ class ClusterBeanTest {
         ClusterBean.of(
             Map.of(
                 1,
-                List.of(HasGauge.of(testBeanObjectWithPartition1, Long.class)),
+                List.of(HasGauge.of(testBeanObjectWithPartition1)),
                 2,
                 List.of(
-                    HasGauge.of(testBeanObjectWithoutPartition, Long.class),
-                    HasGauge.of(testBeanObjectWithPartition2, Long.class),
-                    HasGauge.of(testBeanObjectWithPartition3, Long.class))));
+                    HasGauge.of(testBeanObjectWithoutPartition),
+                    HasGauge.of(testBeanObjectWithPartition2),
+                    HasGauge.of(testBeanObjectWithPartition3))));
     // test all
     Assertions.assertEquals(2, clusterBean.all().size());
     Assertions.assertEquals(1, clusterBean.all().get(1).size());

--- a/common/src/test/java/org/astraea/common/admin/ClusterBeanTest.java
+++ b/common/src/test/java/org/astraea/common/admin/ClusterBeanTest.java
@@ -94,12 +94,12 @@ class ClusterBeanTest {
         ClusterBean.of(
             Map.of(
                 1,
-                List.of(HasGauge.ofLong(testBeanObjectWithPartition1)),
+                List.of(HasGauge.of(testBeanObjectWithPartition1, Long.class)),
                 2,
                 List.of(
-                    HasGauge.ofLong(testBeanObjectWithoutPartition),
-                    HasGauge.ofLong(testBeanObjectWithPartition2),
-                    HasGauge.ofLong(testBeanObjectWithPartition3))));
+                    HasGauge.of(testBeanObjectWithoutPartition, Long.class),
+                    HasGauge.of(testBeanObjectWithPartition2, Long.class),
+                    HasGauge.of(testBeanObjectWithPartition3, Long.class))));
     // test all
     Assertions.assertEquals(2, clusterBean.all().size());
     Assertions.assertEquals(1, clusterBean.all().get(1).size());

--- a/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
@@ -41,9 +41,9 @@ import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.balancer.AlgorithmConfig;
 import org.astraea.common.balancer.Balancer;
 import org.astraea.common.balancer.tweakers.ShuffleTweaker;
-import org.astraea.common.cost.utils.ClusterInfoSensor;
 import org.astraea.common.metrics.BeanObject;
 import org.astraea.common.metrics.MetricSeriesBuilder;
+import org.astraea.common.metrics.broker.ClusterMetrics;
 import org.astraea.common.metrics.broker.LogMetrics;
 import org.astraea.common.metrics.broker.ServerMetrics;
 import org.astraea.common.metrics.collector.MetricCollector;
@@ -199,20 +199,20 @@ class NetworkCostTest {
             Map.of(
                 1,
                     List.of(
-                        ClusterInfoSensor.ReplicasCountMetric.of("Rain", 0, 2),
-                        ClusterInfoSensor.ReplicasCountMetric.of("Drop", 0, 0),
+                        ClusterMetrics.Partition.REPLICAS_COUNT.of("Rain", 0, 2),
+                        ClusterMetrics.Partition.REPLICAS_COUNT.of("Drop", 0, 0),
                         LogMetrics.Log.SIZE.builder().topic("Rain").partition(0).logSize(1).build(),
                         LogMetrics.Log.SIZE.builder().topic("Drop").partition(0).logSize(1).build(),
                         bandwidth(ServerMetrics.Topic.BYTES_IN_PER_SEC, "Rain", 100),
                         bandwidth(ServerMetrics.Topic.BYTES_OUT_PER_SEC, "Rain", 300)),
                 2,
                     List.of(
-                        ClusterInfoSensor.ReplicasCountMetric.of("Rain", 0, 0),
+                        ClusterMetrics.Partition.REPLICAS_COUNT.of("Rain", 0, 0),
                         LogMetrics.Log.SIZE.builder().topic("Rain").partition(0).logSize(1).build(),
                         noise(5566)),
                 3,
                     List.of(
-                        ClusterInfoSensor.ReplicasCountMetric.of("Drop", 0, 2),
+                        ClusterMetrics.Partition.REPLICAS_COUNT.of("Drop", 0, 2),
                         LogMetrics.Log.SIZE.builder().topic("Drop").partition(0).logSize(1).build(),
                         bandwidth(ServerMetrics.Topic.BYTES_IN_PER_SEC, "Drop", 80),
                         bandwidth(ServerMetrics.Topic.BYTES_OUT_PER_SEC, "Drop", 800))));
@@ -264,7 +264,7 @@ class NetworkCostTest {
             Map.of(
                 1,
                     List.of(
-                        ClusterInfoSensor.ReplicasCountMetric.of("Pipeline", 0, 2),
+                        ClusterMetrics.Partition.REPLICAS_COUNT.of("Pipeline", 0, 2),
                         LogMetrics.Log.SIZE
                             .builder()
                             .topic("Pipeline")
@@ -274,7 +274,7 @@ class NetworkCostTest {
                         noise(5566)),
                 2,
                     List.of(
-                        ClusterInfoSensor.ReplicasCountMetric.of("Pipeline", 0, 0),
+                        ClusterMetrics.Partition.REPLICAS_COUNT.of("Pipeline", 0, 0),
                         LogMetrics.Log.SIZE
                             .builder()
                             .topic("Pipeline")
@@ -284,7 +284,7 @@ class NetworkCostTest {
                         noise(5566)),
                 3,
                     List.of(
-                        ClusterInfoSensor.ReplicasCountMetric.of("Pipeline", 0, 0),
+                        ClusterMetrics.Partition.REPLICAS_COUNT.of("Pipeline", 0, 0),
                         LogMetrics.Log.SIZE
                             .builder()
                             .topic("Pipeline")
@@ -599,7 +599,7 @@ class NetworkCostTest {
                           .build())
               .seriesByBrokerReplica(
                   (time, broker, replica) ->
-                      ClusterInfoSensor.ReplicasCountMetric.of(
+                      ClusterMetrics.Partition.REPLICAS_COUNT.of(
                           replica.topic(), replica.partition(), replica.isLeader() ? 1 : 0))
               .build();
     }

--- a/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
@@ -42,8 +42,8 @@ import org.astraea.common.balancer.AlgorithmConfig;
 import org.astraea.common.balancer.Balancer;
 import org.astraea.common.balancer.tweakers.ShuffleTweaker;
 import org.astraea.common.metrics.BeanObject;
+import org.astraea.common.metrics.MetricFactory;
 import org.astraea.common.metrics.MetricSeriesBuilder;
-import org.astraea.common.metrics.broker.ClusterMetrics;
 import org.astraea.common.metrics.broker.LogMetrics;
 import org.astraea.common.metrics.broker.ServerMetrics;
 import org.astraea.common.metrics.collector.MetricCollector;
@@ -199,20 +199,20 @@ class NetworkCostTest {
             Map.of(
                 1,
                     List.of(
-                        ClusterMetrics.Partition.REPLICAS_COUNT.of("Rain", 0, 2),
-                        ClusterMetrics.Partition.REPLICAS_COUNT.of("Drop", 0, 0),
+                        MetricFactory.ofPartitionMetric("Rain", 0, 2),
+                        MetricFactory.ofPartitionMetric("Drop", 0, 0),
                         LogMetrics.Log.SIZE.builder().topic("Rain").partition(0).logSize(1).build(),
                         LogMetrics.Log.SIZE.builder().topic("Drop").partition(0).logSize(1).build(),
                         bandwidth(ServerMetrics.Topic.BYTES_IN_PER_SEC, "Rain", 100),
                         bandwidth(ServerMetrics.Topic.BYTES_OUT_PER_SEC, "Rain", 300)),
                 2,
                     List.of(
-                        ClusterMetrics.Partition.REPLICAS_COUNT.of("Rain", 0, 0),
+                        MetricFactory.ofPartitionMetric("Rain", 0, 0),
                         LogMetrics.Log.SIZE.builder().topic("Rain").partition(0).logSize(1).build(),
                         noise(5566)),
                 3,
                     List.of(
-                        ClusterMetrics.Partition.REPLICAS_COUNT.of("Drop", 0, 2),
+                        MetricFactory.ofPartitionMetric("Drop", 0, 2),
                         LogMetrics.Log.SIZE.builder().topic("Drop").partition(0).logSize(1).build(),
                         bandwidth(ServerMetrics.Topic.BYTES_IN_PER_SEC, "Drop", 80),
                         bandwidth(ServerMetrics.Topic.BYTES_OUT_PER_SEC, "Drop", 800))));
@@ -264,7 +264,7 @@ class NetworkCostTest {
             Map.of(
                 1,
                     List.of(
-                        ClusterMetrics.Partition.REPLICAS_COUNT.of("Pipeline", 0, 2),
+                        MetricFactory.ofPartitionMetric("Pipeline", 0, 2),
                         LogMetrics.Log.SIZE
                             .builder()
                             .topic("Pipeline")
@@ -274,7 +274,7 @@ class NetworkCostTest {
                         noise(5566)),
                 2,
                     List.of(
-                        ClusterMetrics.Partition.REPLICAS_COUNT.of("Pipeline", 0, 0),
+                        MetricFactory.ofPartitionMetric("Pipeline", 0, 0),
                         LogMetrics.Log.SIZE
                             .builder()
                             .topic("Pipeline")
@@ -284,7 +284,7 @@ class NetworkCostTest {
                         noise(5566)),
                 3,
                     List.of(
-                        ClusterMetrics.Partition.REPLICAS_COUNT.of("Pipeline", 0, 0),
+                        MetricFactory.ofPartitionMetric("Pipeline", 0, 0),
                         LogMetrics.Log.SIZE
                             .builder()
                             .topic("Pipeline")
@@ -599,7 +599,7 @@ class NetworkCostTest {
                           .build())
               .seriesByBrokerReplica(
                   (time, broker, replica) ->
-                      ClusterMetrics.Partition.REPLICAS_COUNT.of(
+                      MetricFactory.ofPartitionMetric(
                           replica.topic(), replica.partition(), replica.isLeader() ? 1 : 0))
               .build();
     }

--- a/common/src/test/java/org/astraea/common/cost/utils/ClusterInfoSensorTest.java
+++ b/common/src/test/java/org/astraea/common/cost/utils/ClusterInfoSensorTest.java
@@ -17,23 +17,36 @@
 package org.astraea.common.cost.utils;
 
 import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
+import org.astraea.common.admin.ClusterBean;
+import org.astraea.common.admin.Replica;
 import org.astraea.common.admin.TopicPartition;
+import org.astraea.common.metrics.HasBeanObject;
+import org.astraea.common.metrics.broker.ClusterMetrics;
 import org.astraea.common.metrics.broker.LogMetrics;
 import org.astraea.common.metrics.collector.MetricCollector;
 import org.astraea.common.producer.Producer;
 import org.astraea.common.producer.Record;
 import org.astraea.it.Service;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class ClusterInfoSensorTest {
 
   private static final Service SERVICE = Service.builder().numberOfBrokers(1).build();
+
+  @AfterAll
+  public static void close() {
+    SERVICE.close();
+  }
 
   @Test
   void testClusterInfoSensor() {
@@ -78,7 +91,7 @@ class ClusterInfoSensorTest {
                 (broker, metrics) ->
                     Assertions.assertTrue(
                         metrics.stream()
-                            .anyMatch(x -> x instanceof ClusterInfoSensor.ReplicasCountMetric)));
+                            .anyMatch(x -> x instanceof ClusterMetrics.PartitionMetric)));
 
         var info = ClusterInfoSensor.metricViewCluster(cb);
         // compare topic
@@ -113,5 +126,106 @@ class ClusterInfoSensorTest {
                     }));
       }
     }
+  }
+
+  @Test
+  void testFollower() {
+    var cb =
+        ClusterBean.of(
+            Map.ofEntries(
+                Map.entry(
+                    1,
+                    List.of(
+                        ClusterMetrics.Partition.REPLICAS_COUNT.of("TwoReplica", 0, 2),
+                        LogMetrics.Log.SIZE
+                            .builder()
+                            .topic("TwoReplica")
+                            .partition(0)
+                            .logSize(200)
+                            .build(),
+                        ClusterMetrics.Partition.REPLICAS_COUNT.of("OneReplica", 0, 1),
+                        LogMetrics.Log.SIZE
+                            .builder()
+                            .topic("OneReplica")
+                            .partition(0)
+                            .logSize(100)
+                            .build())),
+                Map.entry(
+                    2,
+                    List.of(
+                        ClusterMetrics.Partition.REPLICAS_COUNT.of("TwoReplica", 0, 0),
+                        LogMetrics.Log.SIZE
+                            .builder()
+                            .topic("TwoReplica")
+                            .partition(0)
+                            .logSize(150)
+                            .build()))));
+    var info = ClusterInfoSensor.metricViewCluster(cb);
+
+    Assertions.assertEquals(Set.of("TwoReplica", "OneReplica"), info.topicNames());
+    Assertions.assertEquals(
+        Set.of(TopicPartition.of("TwoReplica", 0), TopicPartition.of("OneReplica", 0)),
+        info.topicPartitions());
+    Assertions.assertEquals(1, info.replicas("OneReplica").size());
+    Assertions.assertEquals(100, info.replicas("OneReplica").get(0).size());
+    Assertions.assertEquals(2, info.replicas("TwoReplica").size());
+    Assertions.assertEquals(1, info.replicaLeaders("TwoReplica").size());
+    Assertions.assertEquals(200, info.replicaLeaders("TwoReplica").get(0).size());
+    Assertions.assertEquals(
+        150, info.replicaStream().filter(Replica::isFollower).findFirst().orElseThrow().size());
+  }
+
+  @Test
+  void testVariousReplicaFactor() {
+    var topic =
+        new Object() {
+          Stream<HasBeanObject> partition(int partition, int replica) {
+            return Stream.of(
+                ClusterMetrics.Partition.REPLICAS_COUNT.of("topic", partition, replica),
+                LogMetrics.Log.SIZE
+                    .builder()
+                    .topic("topic")
+                    .partition(partition)
+                    .logSize(0)
+                    .build());
+          }
+        };
+
+    var cb =
+        ClusterBean.of(
+            Map.ofEntries(
+                Map.entry(
+                    1,
+                    Stream.of(topic.partition(0, 1), topic.partition(1, 2), topic.partition(2, 3))
+                        .flatMap(x -> x)
+                        .collect(Collectors.toUnmodifiableList())),
+                Map.entry(
+                    2,
+                    Stream.of(topic.partition(1, 0), topic.partition(2, 0))
+                        .flatMap(x -> x)
+                        .collect(Collectors.toUnmodifiableList())),
+                Map.entry(
+                    3,
+                    Stream.of(topic.partition(2, 0))
+                        .flatMap(x -> x)
+                        .collect(Collectors.toUnmodifiableList()))));
+    var info = ClusterInfoSensor.metricViewCluster(cb);
+
+    Assertions.assertEquals(Set.of("topic"), info.topicNames());
+    Assertions.assertEquals(
+        Set.of(
+            TopicPartition.of("topic", 0),
+            TopicPartition.of("topic", 1),
+            TopicPartition.of("topic", 2)),
+        info.topicPartitions());
+    Assertions.assertEquals(3, info.replicaStream(1).count());
+    Assertions.assertEquals(2, info.replicaStream(2).count());
+    Assertions.assertEquals(1, info.replicaStream(3).count());
+    Assertions.assertEquals(1, info.replicas(TopicPartition.of("topic", 0)).size());
+    Assertions.assertEquals(2, info.replicas(TopicPartition.of("topic", 1)).size());
+    Assertions.assertEquals(3, info.replicas(TopicPartition.of("topic", 2)).size());
+    Assertions.assertTrue(info.replicaStream(1).allMatch(Replica::isLeader));
+    Assertions.assertTrue(info.replicaStream(2).allMatch(Replica::isFollower));
+    Assertions.assertTrue(info.replicaStream(3).allMatch(Replica::isFollower));
   }
 }

--- a/common/src/test/java/org/astraea/common/cost/utils/ClusterInfoSensorTest.java
+++ b/common/src/test/java/org/astraea/common/cost/utils/ClusterInfoSensorTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.cost.utils;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.astraea.common.Utils;
+import org.astraea.common.admin.Admin;
+import org.astraea.common.admin.TopicPartition;
+import org.astraea.common.metrics.broker.LogMetrics;
+import org.astraea.common.metrics.collector.MetricCollector;
+import org.astraea.common.producer.Producer;
+import org.astraea.common.producer.Record;
+import org.astraea.it.Service;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ClusterInfoSensorTest {
+
+  private static final Service SERVICE = Service.builder().numberOfBrokers(1).build();
+
+  @Test
+  void testClusterInfoSensor() {
+    try (var admin = Admin.of(SERVICE.bootstrapServers())) {
+      var aBroker = admin.brokers().toCompletableFuture().join().get(0);
+      var sensor = new ClusterInfoSensor();
+      var topic = Utils.randomString();
+      admin
+          .creator()
+          .topic(topic)
+          .numberOfPartitions(3)
+          .numberOfReplicas((short) 1)
+          .run()
+          .toCompletableFuture()
+          .join();
+      try (var producer = Producer.of(SERVICE.bootstrapServers())) {
+        producer
+            .send(
+                IntStream.range(0, 100)
+                    .mapToObj(x -> Record.builder().topic(topic).value(new byte[x]).build())
+                    .collect(Collectors.toUnmodifiableList()))
+            .forEach(i -> i.toCompletableFuture().join());
+      }
+
+      try (var mc = MetricCollector.builder().interval(Duration.ofSeconds(1)).build()) {
+        mc.addMetricSensor(sensor);
+        mc.registerLocalJmx(0);
+
+        Utils.sleep(Duration.ofSeconds(2));
+
+        var cb = mc.clusterBean();
+        // assert contains that metrics
+        mc.clusterBean()
+            .all()
+            .forEach(
+                (broker, metrics) ->
+                    Assertions.assertTrue(
+                        metrics.stream().anyMatch(x -> x instanceof LogMetrics.Log.Gauge)));
+        mc.clusterBean()
+            .all()
+            .forEach(
+                (broker, metrics) ->
+                    Assertions.assertTrue(
+                        metrics.stream()
+                            .anyMatch(x -> x instanceof ClusterInfoSensor.ReplicasCountMetric)));
+
+        var info = ClusterInfoSensor.metricViewCluster(cb);
+        // compare topic
+        Assertions.assertTrue(info.topicNames().contains(topic));
+        // compare topic partition
+        Assertions.assertTrue(
+            info.topicPartitions()
+                .containsAll(
+                    Set.of(
+                        TopicPartition.of(topic, 0),
+                        TopicPartition.of(topic, 1),
+                        TopicPartition.of(topic, 2))));
+        // compare broker id
+        Assertions.assertTrue(
+            info.replicaStream().allMatch(r -> r.nodeInfo().id() == aBroker.id()));
+        // compare replica size
+        var realCluster = admin.clusterInfo(Set.of(topic)).toCompletableFuture().join();
+        Assertions.assertTrue(
+            info.replicaStream()
+                .allMatch(
+                    metricReplica -> {
+                      var realReplica =
+                          realCluster
+                              .replicaStream()
+                              .filter(
+                                  x ->
+                                      x.topicPartitionReplica()
+                                          .equals(metricReplica.topicPartitionReplica()))
+                              .findFirst()
+                              .orElseThrow();
+                      return realReplica.size() == metricReplica.size();
+                    }));
+      }
+    }
+  }
+}

--- a/common/src/test/java/org/astraea/common/cost/utils/ClusterInfoSensorTest.java
+++ b/common/src/test/java/org/astraea/common/cost/utils/ClusterInfoSensorTest.java
@@ -31,7 +31,6 @@ import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.metrics.BeanObject;
 import org.astraea.common.metrics.HasBeanObject;
 import org.astraea.common.metrics.broker.ClusterMetrics;
-import org.astraea.common.metrics.broker.HasGauge;
 import org.astraea.common.metrics.broker.LogMetrics;
 import org.astraea.common.metrics.broker.ServerMetrics;
 import org.astraea.common.metrics.collector.MetricCollector;
@@ -242,7 +241,7 @@ class ClusterInfoSensorTest {
             Map.of(
                 0,
                 List.of(
-                    HasGauge.of(
+                    new ServerMetrics.KafkaServer.ClusterIdGauge(
                         new BeanObject(
                             ServerMetrics.DOMAIN_NAME,
                             Map.of(
@@ -250,8 +249,7 @@ class ClusterInfoSensorTest {
                                 "KafkaServer",
                                 "name",
                                 ServerMetrics.KafkaServer.CLUSTER_ID),
-                            Map.of("Value", id)),
-                        String.class))));
+                            Map.of("Value", id))))));
 
     var info = ClusterInfoSensor.metricViewCluster(cb);
 

--- a/common/src/test/java/org/astraea/common/cost/utils/ClusterInfoSensorTest.java
+++ b/common/src/test/java/org/astraea/common/cost/utils/ClusterInfoSensorTest.java
@@ -30,6 +30,7 @@ import org.astraea.common.admin.Replica;
 import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.metrics.BeanObject;
 import org.astraea.common.metrics.HasBeanObject;
+import org.astraea.common.metrics.MetricFactory;
 import org.astraea.common.metrics.broker.ClusterMetrics;
 import org.astraea.common.metrics.broker.LogMetrics;
 import org.astraea.common.metrics.broker.ServerMetrics;
@@ -140,14 +141,14 @@ class ClusterInfoSensorTest {
                 Map.entry(
                     1,
                     List.of(
-                        ClusterMetrics.Partition.REPLICAS_COUNT.of("TwoReplica", 0, 2),
+                        MetricFactory.ofPartitionMetric("TwoReplica", 0, 2),
                         LogMetrics.Log.SIZE
                             .builder()
                             .topic("TwoReplica")
                             .partition(0)
                             .logSize(200)
                             .build(),
-                        ClusterMetrics.Partition.REPLICAS_COUNT.of("OneReplica", 0, 1),
+                        MetricFactory.ofPartitionMetric("OneReplica", 0, 1),
                         LogMetrics.Log.SIZE
                             .builder()
                             .topic("OneReplica")
@@ -157,7 +158,7 @@ class ClusterInfoSensorTest {
                 Map.entry(
                     2,
                     List.of(
-                        ClusterMetrics.Partition.REPLICAS_COUNT.of("TwoReplica", 0, 0),
+                        MetricFactory.ofPartitionMetric("TwoReplica", 0, 0),
                         LogMetrics.Log.SIZE
                             .builder()
                             .topic("TwoReplica")
@@ -185,7 +186,7 @@ class ClusterInfoSensorTest {
         new Object() {
           Stream<HasBeanObject> partition(int partition, int replica) {
             return Stream.of(
-                ClusterMetrics.Partition.REPLICAS_COUNT.of("topic", partition, replica),
+                MetricFactory.ofPartitionMetric("topic", partition, replica),
                 LogMetrics.Log.SIZE
                     .builder()
                     .topic("topic")

--- a/common/src/test/java/org/astraea/common/metrics/MetricFactory.java
+++ b/common/src/test/java/org/astraea/common/metrics/MetricFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.metrics;
+
+import java.util.Map;
+import org.astraea.common.metrics.broker.ClusterMetrics;
+
+public class MetricFactory {
+
+  public static ClusterMetrics.PartitionMetric ofPartitionMetric(
+      String topic, int partition, int value) {
+    return new ClusterMetrics.PartitionMetric(
+        new BeanObject(
+            ClusterMetrics.DOMAIN_NAME,
+            Map.ofEntries(
+                Map.entry("type", "Partition"),
+                Map.entry("topic", topic),
+                Map.entry("partition", Integer.toString(partition)),
+                Map.entry("name", ClusterMetrics.Partition.REPLICAS_COUNT.metricName())),
+            Map.of("Value", value)));
+  }
+}


### PR DESCRIPTION
Resolve #1508

這個 PR 提供一個 `ClusterInfoSensor`，這個 `MetricSensor` 提供從包含特定 Kafka JMX metrics 的 ClusterBean 重建一個 ClusterInfo 的能力。這個重建出來的 `ClusterInfo` 沒有包含完全的叢集狀態，目前 `ClusterInfoSensor` 可以從 ClusterBean 萃取下列的叢集負載狀態資訊：

* 每個 Broker 負責的 TopicPartition
* TopicPartition 的 leader/follower 身份
* TopicPartition 的 size
* Cluster 的簡略節點資訊 (node info, 只有 id)

`NetworkCost` 透過這個 `ClusterInfoSensor` 來取得 ClusterBean 背後對應的 Cluster 長相，這個 PR 替代其原先的複雜檢查機制。
