### PR TITLE
[CONNECTOR] Add dependencies for hdfs connector

### DIFF
--- a/connector/src/main/java/org/astraea/connector/backup/Exporter.java
+++ b/connector/src/main/java/org/astraea/connector/backup/Exporter.java
@@ -16,7 +16,6 @@
  */
 package org.astraea.connector.backup;
 
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -24,6 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.astraea.common.Configuration;
@@ -143,23 +143,22 @@ public class Exporter extends SinkConnector {
         FileSystem fs,
         String path,
         String topicName,
-        Duration interval,
+        Long interval,
         DataSize size,
-        AtomicBoolean closed,
-        BlockingQueue<Record<byte[], byte[]>> recordsQueue) {
+        Supplier<Boolean> closed,
+        Supplier<Record<byte[], byte[]>> recordsQueue) {
       return () -> {
         var writers = new HashMap<TopicPartition, RecordWriter>();
-        var intervalTimeInMillis = interval.toMillis();
-        var sleepTime = Math.min(intervalTimeInMillis, 1000);
         var lastWriteTime = System.currentTimeMillis();
+
         try {
           while (!closed.get()) {
-            var record = recordsQueue.poll(sleepTime, TimeUnit.MILLISECONDS);
+            var record = recordsQueue.get();
             var currentTime = System.currentTimeMillis();
 
             if (record == null) {
               // close all writers if they have been idle over roll.duration.
-              if (currentTime - lastWriteTime > intervalTimeInMillis) {
+              if (currentTime - lastWriteTime > interval) {
                 writers.values().forEach(RecordWriter::close);
                 writers.clear();
               }
@@ -187,8 +186,6 @@ public class Exporter extends SinkConnector {
               fs.close();
             }
           }
-        } catch (InterruptedException ignored) {
-          // swallow
         } finally {
           writers.forEach((tp, writer) -> writer.close());
         }
@@ -204,13 +201,24 @@ public class Exporter extends SinkConnector {
               configuration.string(SIZE_KEY.name()).orElse(SIZE_KEY.defaultValue().toString()));
       var interval =
           Utils.toDuration(
-              configuration.string(TIME_KEY.name()).orElse(TIME_KEY.defaultValue().toString()));
+                  configuration.string(TIME_KEY.name()).orElse(TIME_KEY.defaultValue().toString()))
+              .toMillis();
 
       var fs = FileSystem.of(configuration.requireString(SCHEMA_KEY.name()), configuration);
-
       this.writerFuture =
           CompletableFuture.runAsync(
-              createWriter(fs, path, topicName, interval, size, this.closed, this.recordsQueue));
+              createWriter(
+                  fs,
+                  path,
+                  topicName,
+                  interval,
+                  size,
+                  this.closed::get,
+                  () ->
+                      Utils.packException(
+                          () ->
+                              this.recordsQueue.poll(
+                                  Math.min(interval, 1000), TimeUnit.MILLISECONDS))));
     }
 
     @Override

--- a/connector/src/main/java/org/astraea/connector/backup/Exporter.java
+++ b/connector/src/main/java/org/astraea/connector/backup/Exporter.java
@@ -143,7 +143,7 @@ public class Exporter extends SinkConnector {
         FileSystem fs,
         String path,
         String topicName,
-        Long interval,
+        long interval,
         DataSize size,
         Supplier<Boolean> closed,
         Supplier<Record<byte[], byte[]>> recordsQueue) {

--- a/connector/src/main/java/org/astraea/connector/backup/Exporter.java
+++ b/connector/src/main/java/org/astraea/connector/backup/Exporter.java
@@ -144,6 +144,53 @@ public class Exporter extends SinkConnector {
 
     private final BlockingQueue<Record<byte[], byte[]>> recordsQueue = new LinkedBlockingQueue<>();
 
+    void writer(FileSystem fileSystem) {
+      var writers = new HashMap<TopicPartition, RecordWriter>();
+      var intervalTimeInMillis = interval.toMillis();
+      var sleepTime = Math.min(intervalTimeInMillis, 1000);
+      var lastWriteTime = System.currentTimeMillis();
+      try {
+        while (!closed.get()) {
+          var record = recordsQueue.poll(sleepTime, TimeUnit.MILLISECONDS);
+          var currentTime = System.currentTimeMillis();
+
+          if (record == null) {
+            // close all writers if they have been idle over roll.duration.
+            if (currentTime - lastWriteTime > intervalTimeInMillis) {
+              writers.values().forEach(RecordWriter::close);
+              writers.clear();
+            }
+            continue;
+          }
+          var writer =
+              writers.computeIfAbsent(
+                  record.topicPartition(),
+                  ignored -> {
+                    var fileName = String.valueOf(record.offset());
+                    return RecordWriter.builder(
+                            fileSystem.write(
+                                String.join(
+                                    "/",
+                                    path,
+                                    topicName,
+                                    String.valueOf(record.partition()),
+                                    fileName)))
+                        .build();
+                  });
+          writer.append(record);
+          lastWriteTime = System.currentTimeMillis();
+          if (writer.size().greaterThan(size)) {
+            writers.remove(record.topicPartition()).close();
+            fileSystem.close();
+          }
+        }
+      } catch (InterruptedException ignored) {
+        // swallow
+      } finally {
+        writers.forEach((tp, writer) -> writer.close());
+      }
+    }
+
     @Override
     protected void init(Configuration configuration) {
       this.topicName = configuration.requireString(TOPICS_KEY);
@@ -155,56 +202,8 @@ public class Exporter extends SinkConnector {
           Utils.toDuration(
               configuration.string(TIME_KEY.name()).orElse(TIME_KEY.defaultValue().toString()));
 
-      this.writerFuture =
-          CompletableFuture.runAsync(
-              () -> {
-                var fs =
-                    FileSystem.of(configuration.requireString(SCHEMA_KEY.name()), configuration);
-                var writers = new HashMap<TopicPartition, RecordWriter>();
-                var intervalTimeInMillis = interval.toMillis();
-                var sleepTime = Math.min(intervalTimeInMillis, 1000);
-                var lastWriteTime = System.currentTimeMillis();
-                try {
-                  while (!closed.get()) {
-                    var record = recordsQueue.poll(sleepTime, TimeUnit.MILLISECONDS);
-                    var currentTime = System.currentTimeMillis();
-
-                    if (record == null) {
-                      // close all writers if they have been idle over roll.duration.
-                      if (currentTime - lastWriteTime > intervalTimeInMillis) {
-                        writers.values().forEach(RecordWriter::close);
-                        writers.clear();
-                      }
-                      continue;
-                    }
-                    var writer =
-                        writers.computeIfAbsent(
-                            record.topicPartition(),
-                            ignored -> {
-                              var fileName = String.valueOf(record.offset());
-                              return RecordWriter.builder(
-                                      fs.write(
-                                          String.join(
-                                              "/",
-                                              path,
-                                              topicName,
-                                              String.valueOf(record.partition()),
-                                              fileName)))
-                                  .build();
-                            });
-                    writer.append(record);
-                    lastWriteTime = System.currentTimeMillis();
-                    if (writer.size().greaterThan(size)) {
-                      writers.remove(record.topicPartition()).close();
-                    }
-                  }
-                } catch (InterruptedException ignored) {
-                  // swallow
-                } finally {
-                  writers.forEach((tp, writer) -> writer.close());
-                  fs.close();
-                }
-              });
+      var fs = FileSystem.of(configuration.requireString(SCHEMA_KEY.name()), configuration);
+      this.writerFuture = CompletableFuture.runAsync(() -> this.writer(fs));
     }
 
     @Override

--- a/fs/build.gradle
+++ b/fs/build.gradle
@@ -40,6 +40,11 @@ dependencies {
         // Hence, the later must be excluded from hadoop dependencies to make embedded Kafka worker work
         exclude group: "com.sun.jersey"
     }
+
+    //following dependencies are used for hdfs connector
+    implementation libs["commons-logging"]
+    implementation libs["hadoop-client-api"]
+    implementation libs["hadoop-client-runtime"]
 }
 
 java {

--- a/fs/src/main/java/org/astraea/fs/hdfs/HdfsFileSystem.java
+++ b/fs/src/main/java/org/astraea/fs/hdfs/HdfsFileSystem.java
@@ -37,10 +37,10 @@ public class HdfsFileSystem implements FileSystem {
   public static final String USER_KEY = "fs.hdfs.user";
   public static final String OVERRIDE_KEY = "fs.hdfs.override";
 
-  private org.apache.hadoop.fs.FileSystem fs;
+  private final org.apache.hadoop.fs.FileSystem fs;
 
-  public HdfsFileSystem(Configuration config) {
-    Utils.swallowException(
+  static org.apache.hadoop.fs.FileSystem create(Configuration config) {
+    return Utils.packException(
         () -> {
           var uri =
               new URI(
@@ -56,8 +56,12 @@ public class HdfsFileSystem implements FileSystem {
               .entrySet()
               .forEach(configItem -> conf.set(configItem.getKey(), configItem.getValue()));
 
-          fs = org.apache.hadoop.fs.FileSystem.get(uri, conf, config.requireString(USER_KEY));
+          return org.apache.hadoop.fs.FileSystem.get(uri, conf, config.requireString(USER_KEY));
         });
+  }
+
+  public HdfsFileSystem(Configuration config) {
+    fs = create(config);
   }
 
   @Override
@@ -140,6 +144,6 @@ public class HdfsFileSystem implements FileSystem {
 
   @Override
   public void close() {
-    Utils.packException(() -> fs.close());
+    Utils.packException(fs::close);
   }
 }

--- a/fs/src/main/java/org/astraea/fs/hdfs/HdfsFileSystem.java
+++ b/fs/src/main/java/org/astraea/fs/hdfs/HdfsFileSystem.java
@@ -40,7 +40,7 @@ public class HdfsFileSystem implements FileSystem {
   private org.apache.hadoop.fs.FileSystem fs;
 
   public HdfsFileSystem(Configuration config) {
-    Utils.packException(
+    Utils.swallowException(
         () -> {
           var uri =
               new URI(

--- a/fs/src/test/java/org/astraea/fs/hdfs/HdfsFileSystemTest.java
+++ b/fs/src/test/java/org/astraea/fs/hdfs/HdfsFileSystemTest.java
@@ -22,10 +22,29 @@ import org.astraea.fs.AbstractFileSystemTest;
 import org.astraea.fs.FileSystem;
 import org.astraea.it.HdfsServer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class HdfsFileSystemTest extends AbstractFileSystemTest {
 
   private final HdfsServer server = HdfsServer.local();
+
+  @Test
+  void testCreate() {
+    var fs =
+        HdfsFileSystem.create(
+            Configuration.of(
+                Map.of(
+                    HdfsFileSystem.HOSTNAME_KEY,
+                    server.hostname(),
+                    HdfsFileSystem.PORT_KEY,
+                    String.valueOf(server.port()),
+                    HdfsFileSystem.USER_KEY,
+                    server.user())));
+
+    Assertions.assertEquals(
+        fs.getUri().toString(), "hdfs://" + server.hostname() + ":" + server.port());
+  }
 
   @Override
   protected FileSystem fileSystem() {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,6 +23,7 @@ def versions = [
         "commons-io"          : project.properties['commons-io.version'] ?: "2.11.0",
         "commons-math3"       : project.properties['commons-math3.version'] ?: "3.6.1",
         "commons-net"         : project.properties['commons-net.version'] ?: "3.9.0",
+        "commons-logging"     : project.properties['commons-logging.version'] ?: "1.2",
         "ftp-server"          : project.properties['ftp-server.version'] ?: "1.2.0",
         jackson               : project.properties['jackson.version'] ?: "2.14.1",
         jcommander            : project.properties['jcommander.version'] ?: "1.82",
@@ -36,14 +37,14 @@ def versions = [
         spark                 : project.properties['spark.version'] ?: "3.3.1",
         "wix-embedded-mysql"  : project.properties['wix-embedded-mysql.version'] ?: "4.6.2",
         zookeeper             : project.properties['zookeeper.version'] ?: "3.8.1",
-        "hadoop-common"       : project.properties['hadoop-common.version'] ?: "3.3.4",
-        "hadoop-minicluster"  : project.properties['hadoop-minicluster.version'] ?: "3.3.4",
+        "hadoop"              : project.properties["hadoop.version"] ?: "3.3.4",
 ]
 
 libs += [
         "commons-io"           : "commons-io:commons-io:${versions["commons-io"]}",
         "commons-math3"        : "org.apache.commons:commons-math3:${versions["commons-math3"]}",
         "commons-net"          : "commons-net:commons-net:${versions["commons-net"]}",
+        "commons-logging"      : "commons-logging:commons-logging:${versions["commons-logging"]}",
         "ftp-server"           : "org.apache.ftpserver:ftpserver-core:${versions["ftp-server"]}",
         "jackson-databind"     : "com.fasterxml.jackson.core:jackson-databind:${versions["jackson"]}",
         "jackson-datatype-jdk8": "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${versions["jackson"]}",
@@ -64,7 +65,9 @@ libs += [
         "spark-sql"            : "org.apache.spark:spark-sql_2.13:${versions["spark"]}",
         "wix-embedded-mysql"   : "com.wix:wix-embedded-mysql:${versions["wix-embedded-mysql"]}",
         zookeeper              : "org.apache.zookeeper:zookeeper:${versions["zookeeper"]}",
-        "hadoop-common"        : "org.apache.hadoop:hadoop-common:${versions["hadoop-common"]}",
-        "hadoop-minicluster"   : "org.apache.hadoop:hadoop-minicluster:${versions["hadoop-minicluster"]}",
-
+        "hadoop-common"        : "org.apache.hadoop:hadoop-common:${versions["hadoop"]}",
+        "hadoop-client"        : "org.apache.hadoop:hadoop-client:${versions["hadoop"]}",
+        "hadoop-minicluster"   : "org.apache.hadoop:hadoop-minicluster:${versions["hadoop"]}",
+        "hadoop-client-api"    : "org.apache.hadoop:hadoop-client-api:${versions["hadoop"]}",
+        "hadoop-client-runtime": "org.apache.hadoop:hadoop-client-runtime:${versions["hadoop"]}",
 ]


### PR DESCRIPTION
增加 hadoop 相關的 dependencies 使 hdfs 版的 backup 工具可以正常執行
在透過`start_worker.sh`建立 worker 時，會透過 shadowJar 建立 jar 檔案至 worker 中的 /opt/kafka/libs 當中

在使用 hdfs 的 connector 時，若直接建立會導致 `No FileSystem for scheme "hdfs"` 的錯誤出現，為此需要在建立 task 時加上以下參數才可以順利執行
`fs.hdfs.override.fs.hdfs.impl":"org.apache.hadoop.hdfs.DistributedFileSystem` 

為了避免發生此錯誤時 worker 中完全沒有任何訊息，因此將 `HdfsFileSystem` 中的 `packExeception` 替換為 `swallowException`