### PR TITLE
[WEB] Enable Data Directory Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@
 13. [Build](docs/build_project.md): 說明如何建構與測試本專案各模組
 14. [etl](./docs/etl/README.md): 構建 spark-kafka 的資料傳輸通道
 
+# Kafka Q&A
+
+* [Astraea 故障排除](./docs/troubleshooting.md)： 統整 Astraea 工具使用上可能會遇到的問題和解決方法
+
 # 技術發表
 
 `Astraea` 鼓勵貢獻者參與研討會做技術發表，各年度的發表請見下列連結：

--- a/app/src/main/java/org/astraea/app/web/BalancerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BalancerHandler.java
@@ -16,7 +16,6 @@
  */
 package org.astraea.app.web;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Collection;
@@ -72,7 +71,6 @@ class BalancerHandler implements Handler {
 
   private final Admin admin;
   private final BalancerConsole balancerConsole;
-  private final RebalancePlanExecutor executor;
   private final Map<String, PostRequestWrapper> taskMetadata = new ConcurrentHashMap<>();
   private final Map<String, CompletionStage<Balancer.Plan>> planGenerations =
       new ConcurrentHashMap<>();
@@ -80,23 +78,11 @@ class BalancerHandler implements Handler {
   private final Function<Integer, Optional<Integer>> jmxPortMapper;
 
   BalancerHandler(Admin admin) {
-    this(admin, (ignore) -> Optional.empty(), new StraightPlanExecutor(true));
+    this(admin, (ignore) -> Optional.empty());
   }
 
   BalancerHandler(Admin admin, Function<Integer, Optional<Integer>> jmxPortMapper) {
-    this(admin, jmxPortMapper, new StraightPlanExecutor(true));
-  }
-
-  BalancerHandler(Admin admin, RebalancePlanExecutor executor) {
-    this(admin, (ignore) -> Optional.empty(), executor);
-  }
-
-  BalancerHandler(
-      Admin admin,
-      Function<Integer, Optional<Integer>> jmxPortMapper,
-      RebalancePlanExecutor executor) {
     this.admin = admin;
-    this.executor = executor;
     this.jmxPortMapper = jmxPortMapper;
     this.balancerConsole = BalancerConsole.create(admin);
   }
@@ -165,6 +151,9 @@ class BalancerHandler implements Handler {
     final var request = channel.request(TypeRef.of(BalancerPutRequest.class));
     final var taskId = request.id;
     final var taskPhase = balancerConsole.taskPhase(taskId);
+    final var executorConfig = Configuration.of(request.executorConfig);
+    final var executor =
+        Utils.construct(request.executor, RebalancePlanExecutor.class, executorConfig);
 
     if (taskPhase.isEmpty())
       throw new IllegalArgumentException("No such rebalance plan id: " + taskId);
@@ -412,7 +401,9 @@ class BalancerHandler implements Handler {
   }
 
   static class BalancerPutRequest implements Request {
-    private String id;
+    String id;
+    String executor = StraightPlanExecutor.class.getName();
+    Map<String, String> executorConfig = Map.of();
   }
 
   static class PostRequestWrapper {
@@ -437,9 +428,7 @@ class BalancerHandler implements Handler {
 
     final int brokerId;
 
-    // temporarily disable data-directory migration, there are some Kafka bug related to it.
-    // see https://github.com/skiptests/astraea/issues/1325#issue-1506582838
-    @JsonIgnore final String directory;
+    final String directory;
 
     final Optional<Long> size;
 

--- a/common/src/main/java/org/astraea/common/balancer/executor/RebalancePlanExecutor.java
+++ b/common/src/main/java/org/astraea/common/balancer/executor/RebalancePlanExecutor.java
@@ -25,6 +25,7 @@ import org.astraea.common.admin.ClusterInfo;
 /** This class associate with the logic of fulfill given rebalance plan. */
 public interface RebalancePlanExecutor {
 
+  // TODO: Replace this usage with optimization constraint at Balancer in the future.
   String CONFIG_ENABLE_DATA_DIRECTORY_MIGRATION = "enableDataDirectoryMigration";
 
   static RebalancePlanExecutor of() {

--- a/common/src/main/java/org/astraea/common/balancer/executor/RebalancePlanExecutor.java
+++ b/common/src/main/java/org/astraea/common/balancer/executor/RebalancePlanExecutor.java
@@ -18,6 +18,7 @@ package org.astraea.common.balancer.executor;
 
 import java.time.Duration;
 import java.util.concurrent.CompletionStage;
+import org.astraea.common.Configuration;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.admin.ClusterInfo;
 
@@ -27,7 +28,7 @@ public interface RebalancePlanExecutor {
   String CONFIG_ENABLE_DATA_DIRECTORY_MIGRATION = "enableDataDirectoryMigration";
 
   static RebalancePlanExecutor of() {
-    return new StraightPlanExecutor();
+    return new StraightPlanExecutor(Configuration.EMPTY);
   }
 
   /**

--- a/common/src/main/java/org/astraea/common/balancer/executor/RebalancePlanExecutor.java
+++ b/common/src/main/java/org/astraea/common/balancer/executor/RebalancePlanExecutor.java
@@ -24,6 +24,8 @@ import org.astraea.common.admin.ClusterInfo;
 /** This class associate with the logic of fulfill given rebalance plan. */
 public interface RebalancePlanExecutor {
 
+  String CONFIG_ENABLE_DATA_DIRECTORY_MIGRATION = "enableDataDirectoryMigration";
+
   static RebalancePlanExecutor of() {
     return new StraightPlanExecutor();
   }

--- a/common/src/main/java/org/astraea/common/balancer/executor/StraightPlanExecutor.java
+++ b/common/src/main/java/org/astraea/common/balancer/executor/StraightPlanExecutor.java
@@ -33,20 +33,12 @@ public class StraightPlanExecutor implements RebalancePlanExecutor {
 
   private final boolean enableDataDirectoryMigration;
 
-  public StraightPlanExecutor() {
-    this(false);
-  }
-
   public StraightPlanExecutor(Configuration configuration) {
     this.enableDataDirectoryMigration =
         configuration
             .string(StraightPlanExecutor.CONFIG_ENABLE_DATA_DIRECTORY_MIGRATION)
             .map(Boolean::parseBoolean)
             .orElse(false);
-  }
-
-  public StraightPlanExecutor(boolean enableDataDirectoryMigration) {
-    this.enableDataDirectoryMigration = enableDataDirectoryMigration;
   }
 
   @Override

--- a/common/src/test/java/org/astraea/common/balancer/BalancerConsoleTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerConsoleTest.java
@@ -224,7 +224,7 @@ class BalancerConsoleTest {
           () ->
               console
                   .launchRebalancePlanExecution()
-                  .setExecutor(new StraightPlanExecutor())
+                  .setExecutor(new StraightPlanExecutor(Configuration.EMPTY))
                   .checkPlanConsistency(true)
                   .execute("THE_TASK_0")
                   .toCompletableFuture()

--- a/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
@@ -126,7 +126,7 @@ class BalancerTest {
                       .build())
               .solution()
               .orElseThrow();
-      new StraightPlanExecutor(true)
+      new StraightPlanExecutor(false)
           .run(admin, plan.proposal(), Duration.ofSeconds(10))
           .toCompletableFuture()
           .join();

--- a/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerTest.java
@@ -126,7 +126,7 @@ class BalancerTest {
                       .build())
               .solution()
               .orElseThrow();
-      new StraightPlanExecutor(false)
+      new StraightPlanExecutor(Configuration.EMPTY)
           .run(admin, plan.proposal(), Duration.ofSeconds(10))
           .toCompletableFuture()
           .join();

--- a/common/src/test/java/org/astraea/common/balancer/executor/StraightPlanExecutorTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/executor/StraightPlanExecutorTest.java
@@ -114,7 +114,10 @@ class StraightPlanExecutorTest {
       final var expectedTopicPartition = expectedAllocation.topicPartitions();
 
       var execute =
-          new StraightPlanExecutor(true).run(admin, expectedAllocation, Duration.ofSeconds(10));
+          new StraightPlanExecutor(
+                  Configuration.of(
+                      Map.of(StraightPlanExecutor.CONFIG_ENABLE_DATA_DIRECTORY_MIGRATION, "true")))
+              .run(admin, expectedAllocation, Duration.ofSeconds(10));
 
       execute.toCompletableFuture().join();
 

--- a/common/src/test/java/org/astraea/common/balancer/executor/StraightPlanExecutorTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/executor/StraightPlanExecutorTest.java
@@ -19,13 +19,16 @@ package org.astraea.common.balancer.executor;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.astraea.common.Configuration;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.admin.ClusterInfoBuilder;
 import org.astraea.common.admin.ClusterInfoTest;
 import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.Replica;
@@ -34,6 +37,7 @@ import org.astraea.it.Service;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class StraightPlanExecutorTest {
 
@@ -110,7 +114,7 @@ class StraightPlanExecutorTest {
       final var expectedTopicPartition = expectedAllocation.topicPartitions();
 
       var execute =
-          new StraightPlanExecutor().run(admin, expectedAllocation, Duration.ofSeconds(10));
+          new StraightPlanExecutor(true).run(admin, expectedAllocation, Duration.ofSeconds(10));
 
       execute.toCompletableFuture().join();
 
@@ -133,6 +137,46 @@ class StraightPlanExecutorTest {
                   ClusterInfo.placementMatch(
                       expectedAllocation.replicas(topicPartition),
                       CurrentAllocation.replicas(topicPartition))));
+    }
+  }
+
+  @Test
+  void testDisableDataDirMigration() {
+    try (var admin = Admin.of(SERVICE.bootstrapServers())) {
+      var topic = Utils.randomString();
+      admin
+          .creator()
+          .topic(topic)
+          .numberOfPartitions(30)
+          .numberOfReplicas((short) 1)
+          .run()
+          .toCompletableFuture()
+          .join();
+      Utils.sleep(Duration.ofMillis(300));
+
+      var source = admin.clusterInfo(Set.of(topic)).toCompletableFuture().join();
+      var target =
+          ClusterInfoBuilder.builder(source)
+              .mapLog(
+                  replica ->
+                      Replica.builder(replica)
+                          .path(
+                              source.brokerFolders().get(replica.nodeInfo().id()).stream()
+                                  .filter(p -> !replica.path().equals(p))
+                                  .findAny()
+                                  .orElseThrow())
+                          .build())
+              .build();
+
+      var spiedAdmin = Mockito.spy(admin);
+      var executor =
+          new StraightPlanExecutor(
+              Configuration.of(
+                  Map.of(StraightPlanExecutor.CONFIG_ENABLE_DATA_DIRECTORY_MIGRATION, "false")));
+
+      executor.run(spiedAdmin, target, Duration.ofSeconds(30)).toCompletableFuture().join();
+
+      Mockito.verify(spiedAdmin, Mockito.never()).moveToFolders(Mockito.anyMap());
     }
   }
 }

--- a/docs/performance_benchmark.md
+++ b/docs/performance_benchmark.md
@@ -21,32 +21,49 @@
 
 #### Performance Benchmark Configurations
 
-|      參數名稱       | 說明                                                         |          預設值          |
-| :-----------------: | :----------------------------------------------------------- | :----------------------: |
-|  bootstrap.servers  | (必填) 欲連接的Kafka server address                          |            無            |
-|       topics        | (必填) 指定要用來測試讀寫的 topics <br />例如 : --topics test,test1,test2 |            無            |
-|       pattern       | (選填) 利用正則表達式來指定 consumers 訂閱的 pattern topics，使用此參數後 consumers 只會用 pattern 訂閱<br />例如：--pattern p.*<br />若要訂閱多個 pattern 可用 &vert;&vert; 來分隔 ，例如：--pattern a.&vert;&vert;test. |            無            |
-|      consumers      | (選填) 欲開啟的consumer thread(s)數量                        |            1             |
-|      producers      | (選填) 欲開啟的producer thread(s)數量                        |            1             |
-|      run.until      | (選填) 可選擇兩種結束執行的模式，一種是發送records數量達到設定值，另一種則是執行時間達到設定值，格式為`數值`+`單位`<br />1. 選擇producers要送多少records，範例：發送89000 records 後結束，"--run.until 89000records"<br />2. 選擇producer在給定時間內發送資料，時間單位可以選擇`days`, `day`, `h`, `m`, `s`, `ms`, `us`, `ns`，範例：執行一分鐘後結束， "--run.until 1m"。 |       1000records        |
-|      key.size       | (選填) 每筆record key的大小上限                              |          4Byte           |
-|  key.distribution   | (選填) key的分佈，可用的分佈為：`uniform`, `zipfian`, `latest`, `fixed` |         uniform          |
-|     value.size      | (選填) 每筆record value的大小上限                            |           1KiB           |
-| value.distribution  | (選填) value的分佈， 可用的分佈為: `uniform`, `zipfian`, `latest`, `fixed` |         uniform          |
-|      prop.file      | (選填) 配置property file的路徑                               |           none           |
-|     partitioner     | (選填) 配置producer使用的partitioner                         |           none           |
-|       configs       | (選填) 給partitioner的設置檔。 設置格式為 "\<key1\>=\<value1\>[,\<key2\>=\<value2\>]*"。 <br />例如: "--configs broker.1001.jmx.port=14338,org.astraea.cost.ThroughputCost=1" |           none           |
-|     throughput      | (選填) 用來限制輸出資料的速度, 範例： "--throughput 2MiB/m", "--throughput 2GB" 預設值是秒 <br/>大小單位: MB, MiB, Kb etc. <br />時間單位: second(s), minute(m), hour(h), day(d) or PT expression(PT30S) |      500 GiB/second      |
-|   specify.brokers   | (選填) 指定broker的ID，送資料到指定的broker，若 broker 上有 "目標 topic 的 partition" |           none           |
-| specify.partitions  | (選填) 指定要傳送資料的 topic/partitions，多個項目之間可以用逗號隔開，注意這個選項不能和 `specify.brokers` 、`throttle` 或 `partitioner` 一起使用 |           none           |
-|     report.path     | (選填) report file的檔案路徑                                 |           none           |
-|    report.format    | (選填) 選擇輸出檔案格式, 可用的格式：`csv`, `json`           |           csv            |
-|  transaction.size   | (選填) 每個transaction的records數量。若設置1以上，會使用transaction，否則都是一般write |            1             |
-|      group.id       | (選填) 設置 consumer group id                                | groupId-{Time in millis} |
-|      read.idle      | (選填) 讀取端將被終止如果超過這個時間沒有讀取到新的資料      |           2秒            |
-| interdependent.size | (選填) 每幾筆 record 要發到同一個 partition。(注意：只有 Astraea Dispatcher 可以使用) |            1             |
-|       monkeys       | (選填) 設定 chaos monkey 的觸發頻率，支援 : `kill`, `add`, `unsubscribe`。<br />觸發頻率單位為 ：day, h, m, s, ms, us, ns<br />範例：`--monkeys kill:3s,add:5s` |           none           |
-|      throttle       | (選填) 用來指定 topic-partitions 的限流值<br />例如：--throttle a1-0:5MB/s,a2-0:10MB/s,a10-4:30MB/s<br />注意此參數不可與`specify.partitions`、`specify.brokers` 或`partitioner` 一起使用 |           none           |
+|             參數名稱             | 說明                                                                                                                                                                                                                                                                    |           預設值            |
+|:----------------------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------:|
+|      bootstrap.servers       | (必填) 欲連接的Kafka server address                                                                                                                                                                                                                                         |            無             |
+|            topics            | (必填) 指定要用來測試讀寫的 topics <br />例如 : --topics test,test1,test2                                                                                                                                                                                                           |            無             |
+|           pattern            | (選填) 利用正則表達式來指定 consumers 訂閱的 pattern topics，使用此參數後 consumers 只會用 pattern 訂閱<br />例如：--pattern p.*<br />若要訂閱多個 pattern 可用 &vert;&vert; 來分隔 ，例如：--pattern a.&vert;&vert;test.                                                                                          |            無             |
+|          consumers           | (選填) 欲開啟的consumer thread(s)數量                                                                                                                                                                                                                                         |            1             |
+|          producers           | (選填) 欲開啟的producer thread(s)數量                                                                                                                                                                                                                                         |            1             |
+|          run.until           | (選填) 可選擇兩種結束執行的模式，一種是發送records數量達到設定值，另一種則是執行時間達到設定值，格式為`數值`+`單位`<br />1. 選擇producers要送多少records，範例：發送89000 records 後結束，"--run.until 89000records"<br />2. 選擇producer在給定時間內發送資料，時間單位可以選擇`days`, `day`, `h`, `m`, `s`, `ms`, `us`, `ns`，範例：執行一分鐘後結束， "--run.until 1m"。 |       1000records        |
+|     seed.key-value.table     | (選填) 產生 Record Key/Value 表格內容的亂數產生器種子，當嘗試於多臺設備啟動 Performance Tool 時，可以嘗試給各 Performance Tools 設定一樣的亂數種子，如此一來所有 instance 的 Key/Value Table 會是一樣的長相。當套用不平衡的機率分佈時，這可以使多個 Performance Tool 對當前的 hot key 有共識                                                                |           隨機值            |
+|           key.size           | (選填) 每筆record key的大小上限                                                                                                                                                                                                                                                |          4Byte           |
+|    key.size.distribution     | (選填) key 欄位的大小的分佈，可用的分佈為：`uniform`, `zipfian`, `latest`, `fixed`                                                                                                                                                                                                      |          fixed           |
+| key.size.distribution.config | (選填) key 欄位的大小的機率分佈參數，為一連串以逗號相隔的 `key=value` pair，每個機率分佈支援的參數可能不同，可以參考 [機率分佈參數](#機率分佈參數)                                                                                                                                                                              |          fixed           |
+|       key.distribution       | (選填) key 的選用分佈，選用不平均的分佈可以做到 Hotspot 或 Skew Load 的效果，可用的分佈為：`uniform`, `zipfian`, `latest`, `fixed`                                                                                                                                                                    |         uniform          |
+|   key.distribution.config    | (選填) key 欄位的選擇的機率分佈參數，為一連串以逗號相隔的 `key=value` pair，每個機率分佈支援的參數可能不同，可以參考 [機率分佈參數](#機率分佈參數)                                                                                                                                                                              |          fixed           |
+|          value.size          | (選填) 每筆record value的大小上限                                                                                                                                                                                                                                              |           1KiB           |
+|      value.distribution      | (選填) value 的分佈， 可用的分佈為: `uniform`, `zipfian`, `latest`, `fixed`                                                                                                                                                                                                       |         uniform          |
+|  value.distribution.config   | (選填) value 欄位的選擇的機率分佈參數，為一連串以逗號相隔的 `key=value` pair，每個機率分佈支援的參數可能不同，可以參考 [機率分佈參數](#機率分佈參數)                                                                                                                                                                            |          fixed           |
+|          prop.file           | (選填) 配置property file的路徑                                                                                                                                                                                                                                               |           none           |
+|         partitioner          | (選填) 配置producer使用的partitioner                                                                                                                                                                                                                                         |           none           |
+|           configs            | (選填) 給partitioner的設置檔。 設置格式為 "\<key1\>=\<value1\>[,\<key2\>=\<value2\>]*"。 <br />例如: "--configs broker.1001.jmx.port=14338,org.astraea.cost.ThroughputCost=1"                                                                                                         |           none           |
+|          throughput          | (選填) 用來限制輸出資料的速度, 範例： "--throughput 2MiB/m", "--throughput 2GB" 預設值是秒 <br/>大小單位: MB, MiB, Kb etc. <br />時間單位: second(s), minute(m), hour(h), day(d) or PT expression(PT30S)                                                                                           |      500 GiB/second      |
+|       specify.brokers        | (選填) 指定broker的ID，送資料到指定的broker，若 broker 上有 "目標 topic 的 partition"                                                                                                                                                                                                     |           none           |
+|      specify.partitions      | (選填) 指定要傳送資料的 topic/partitions，多個項目之間可以用逗號隔開，注意這個選項不能和 `specify.brokers` 、`throttle` 或 `partitioner` 一起使用                                                                                                                                                             |           none           |
+|         report.path          | (選填) report file的檔案路徑                                                                                                                                                                                                                                                 |           none           |
+|        report.format         | (選填) 選擇輸出檔案格式, 可用的格式：`csv`, `json`                                                                                                                                                                                                                                    |           csv            |
+|       transaction.size       | (選填) 每個transaction的records數量。若設置1以上，會使用transaction，否則都是一般write                                                                                                                                                                                                        |            1             |
+|           group.id           | (選填) 設置 consumer group id                                                                                                                                                                                                                                             | groupId-{Time in millis} |
+|          read.idle           | (選填) 讀取端將被終止如果超過這個時間沒有讀取到新的資料                                                                                                                                                                                                                                         |            2秒            |
+|     interdependent.size      | (選填) 每幾筆 record 要發到同一個 partition。(注意：只有 Astraea Dispatcher 可以使用)                                                                                                                                                                                                      |            1             |
+|           monkeys            | (選填) 設定 chaos monkey 的觸發頻率，支援 : `kill`, `add`, `unsubscribe`。<br />觸發頻率單位為 ：day, h, m, s, ms, us, ns<br />範例：`--monkeys kill:3s,add:5s`                                                                                                                               |           none           |
+|           throttle           | (選填) 用來指定 topic-partitions 的限流值<br />例如：--throttle a1-0:5MB/s,a2-0:10MB/s,a10-4:30MB/s<br />注意此參數不可與`specify.partitions`、`specify.brokers` 或`partitioner` 一起使用                                                                                                        |           none           |
+
+##### 機率分佈參數
+
+* uniform 分佈參數
+  * 無
+* zipfain 分佈參數
+    * `seed`: 機率分佈背後的亂數產生器採用的種子，預設是一個執行時決定的隨機值。
+    * `exponent`: Zipfian 機率分佈的指數參數，數值越高、傾斜趨勢越強烈，預設值是 1。
+* latest 分佈參數
+    * 無
+* fixed 分佈參數
+    * 無
 
 #### 使用範例
 

--- a/docs/performance_benchmark.md
+++ b/docs/performance_benchmark.md
@@ -21,49 +21,32 @@
 
 #### Performance Benchmark Configurations
 
-|             參數名稱             | 說明                                                                                                                                                                                                                                                                    |           預設值            |
-|:----------------------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------:|
-|      bootstrap.servers       | (必填) 欲連接的Kafka server address                                                                                                                                                                                                                                         |            無             |
-|            topics            | (必填) 指定要用來測試讀寫的 topics <br />例如 : --topics test,test1,test2                                                                                                                                                                                                           |            無             |
-|           pattern            | (選填) 利用正則表達式來指定 consumers 訂閱的 pattern topics，使用此參數後 consumers 只會用 pattern 訂閱<br />例如：--pattern p.*<br />若要訂閱多個 pattern 可用 &vert;&vert; 來分隔 ，例如：--pattern a.&vert;&vert;test.                                                                                          |            無             |
-|          consumers           | (選填) 欲開啟的consumer thread(s)數量                                                                                                                                                                                                                                         |            1             |
-|          producers           | (選填) 欲開啟的producer thread(s)數量                                                                                                                                                                                                                                         |            1             |
-|          run.until           | (選填) 可選擇兩種結束執行的模式，一種是發送records數量達到設定值，另一種則是執行時間達到設定值，格式為`數值`+`單位`<br />1. 選擇producers要送多少records，範例：發送89000 records 後結束，"--run.until 89000records"<br />2. 選擇producer在給定時間內發送資料，時間單位可以選擇`days`, `day`, `h`, `m`, `s`, `ms`, `us`, `ns`，範例：執行一分鐘後結束， "--run.until 1m"。 |       1000records        |
-|     seed.key-value.table     | (選填) 產生 Record Key/Value 表格內容的亂數產生器種子，當嘗試於多臺設備啟動 Performance Tool 時，可以嘗試給各 Performance Tools 設定一樣的亂數種子，如此一來所有 instance 的 Key/Value Table 會是一樣的長相。當套用不平衡的機率分佈時，這可以使多個 Performance Tool 對當前的 hot key 有共識                                                                |           隨機值            |
-|           key.size           | (選填) 每筆record key的大小上限                                                                                                                                                                                                                                                |          4Byte           |
-|    key.size.distribution     | (選填) key 欄位的大小的分佈，可用的分佈為：`uniform`, `zipfian`, `latest`, `fixed`                                                                                                                                                                                                      |          fixed           |
-| key.size.distribution.config | (選填) key 欄位的大小的機率分佈參數，為一連串以逗號相隔的 `key=value` pair，每個機率分佈支援的參數可能不同，可以參考 [機率分佈參數](#機率分佈參數)                                                                                                                                                                              |          fixed           |
-|       key.distribution       | (選填) key 的選用分佈，選用不平均的分佈可以做到 Hotspot 或 Skew Load 的效果，可用的分佈為：`uniform`, `zipfian`, `latest`, `fixed`                                                                                                                                                                    |         uniform          |
-|   key.distribution.config    | (選填) key 欄位的選擇的機率分佈參數，為一連串以逗號相隔的 `key=value` pair，每個機率分佈支援的參數可能不同，可以參考 [機率分佈參數](#機率分佈參數)                                                                                                                                                                              |          fixed           |
-|          value.size          | (選填) 每筆record value的大小上限                                                                                                                                                                                                                                              |           1KiB           |
-|      value.distribution      | (選填) value 的分佈， 可用的分佈為: `uniform`, `zipfian`, `latest`, `fixed`                                                                                                                                                                                                       |         uniform          |
-|  value.distribution.config   | (選填) value 欄位的選擇的機率分佈參數，為一連串以逗號相隔的 `key=value` pair，每個機率分佈支援的參數可能不同，可以參考 [機率分佈參數](#機率分佈參數)                                                                                                                                                                            |          fixed           |
-|          prop.file           | (選填) 配置property file的路徑                                                                                                                                                                                                                                               |           none           |
-|         partitioner          | (選填) 配置producer使用的partitioner                                                                                                                                                                                                                                         |           none           |
-|           configs            | (選填) 給partitioner的設置檔。 設置格式為 "\<key1\>=\<value1\>[,\<key2\>=\<value2\>]*"。 <br />例如: "--configs broker.1001.jmx.port=14338,org.astraea.cost.ThroughputCost=1"                                                                                                         |           none           |
-|          throughput          | (選填) 用來限制輸出資料的速度, 範例： "--throughput 2MiB/m", "--throughput 2GB" 預設值是秒 <br/>大小單位: MB, MiB, Kb etc. <br />時間單位: second(s), minute(m), hour(h), day(d) or PT expression(PT30S)                                                                                           |      500 GiB/second      |
-|       specify.brokers        | (選填) 指定broker的ID，送資料到指定的broker，若 broker 上有 "目標 topic 的 partition"                                                                                                                                                                                                     |           none           |
-|      specify.partitions      | (選填) 指定要傳送資料的 topic/partitions，多個項目之間可以用逗號隔開，注意這個選項不能和 `specify.brokers` 、`throttle` 或 `partitioner` 一起使用                                                                                                                                                             |           none           |
-|         report.path          | (選填) report file的檔案路徑                                                                                                                                                                                                                                                 |           none           |
-|        report.format         | (選填) 選擇輸出檔案格式, 可用的格式：`csv`, `json`                                                                                                                                                                                                                                    |           csv            |
-|       transaction.size       | (選填) 每個transaction的records數量。若設置1以上，會使用transaction，否則都是一般write                                                                                                                                                                                                        |            1             |
-|           group.id           | (選填) 設置 consumer group id                                                                                                                                                                                                                                             | groupId-{Time in millis} |
-|          read.idle           | (選填) 讀取端將被終止如果超過這個時間沒有讀取到新的資料                                                                                                                                                                                                                                         |            2秒            |
-|     interdependent.size      | (選填) 每幾筆 record 要發到同一個 partition。(注意：只有 Astraea Dispatcher 可以使用)                                                                                                                                                                                                      |            1             |
-|           monkeys            | (選填) 設定 chaos monkey 的觸發頻率，支援 : `kill`, `add`, `unsubscribe`。<br />觸發頻率單位為 ：day, h, m, s, ms, us, ns<br />範例：`--monkeys kill:3s,add:5s`                                                                                                                               |           none           |
-|           throttle           | (選填) 用來指定 topic-partitions 的限流值<br />例如：--throttle a1-0:5MB/s,a2-0:10MB/s,a10-4:30MB/s<br />注意此參數不可與`specify.partitions`、`specify.brokers` 或`partitioner` 一起使用                                                                                                        |           none           |
-
-##### 機率分佈參數
-
-* uniform 分佈參數
-  * 無
-* zipfain 分佈參數
-    * `seed`: 機率分佈背後的亂數產生器採用的種子，預設是一個執行時決定的隨機值。
-    * `exponent`: Zipfian 機率分佈的指數參數，數值越高、傾斜趨勢越強烈，預設值是 1。
-* latest 分佈參數
-    * 無
-* fixed 分佈參數
-    * 無
+|      參數名稱       | 說明                                                         |          預設值          |
+| :-----------------: | :----------------------------------------------------------- | :----------------------: |
+|  bootstrap.servers  | (必填) 欲連接的Kafka server address                          |            無            |
+|       topics        | (必填) 指定要用來測試讀寫的 topics <br />例如 : --topics test,test1,test2 |            無            |
+|       pattern       | (選填) 利用正則表達式來指定 consumers 訂閱的 pattern topics，使用此參數後 consumers 只會用 pattern 訂閱<br />例如：--pattern p.*<br />若要訂閱多個 pattern 可用 &vert;&vert; 來分隔 ，例如：--pattern a.&vert;&vert;test. |            無            |
+|      consumers      | (選填) 欲開啟的consumer thread(s)數量                        |            1             |
+|      producers      | (選填) 欲開啟的producer thread(s)數量                        |            1             |
+|      run.until      | (選填) 可選擇兩種結束執行的模式，一種是發送records數量達到設定值，另一種則是執行時間達到設定值，格式為`數值`+`單位`<br />1. 選擇producers要送多少records，範例：發送89000 records 後結束，"--run.until 89000records"<br />2. 選擇producer在給定時間內發送資料，時間單位可以選擇`days`, `day`, `h`, `m`, `s`, `ms`, `us`, `ns`，範例：執行一分鐘後結束， "--run.until 1m"。 |       1000records        |
+|      key.size       | (選填) 每筆record key的大小上限                              |          4Byte           |
+|  key.distribution   | (選填) key的分佈，可用的分佈為：`uniform`, `zipfian`, `latest`, `fixed` |         uniform          |
+|     value.size      | (選填) 每筆record value的大小上限                            |           1KiB           |
+| value.distribution  | (選填) value的分佈， 可用的分佈為: `uniform`, `zipfian`, `latest`, `fixed` |         uniform          |
+|      prop.file      | (選填) 配置property file的路徑                               |           none           |
+|     partitioner     | (選填) 配置producer使用的partitioner                         |           none           |
+|       configs       | (選填) 給partitioner的設置檔。 設置格式為 "\<key1\>=\<value1\>[,\<key2\>=\<value2\>]*"。 <br />例如: "--configs broker.1001.jmx.port=14338,org.astraea.cost.ThroughputCost=1" |           none           |
+|     throughput      | (選填) 用來限制輸出資料的速度, 範例： "--throughput 2MiB/m", "--throughput 2GB" 預設值是秒 <br/>大小單位: MB, MiB, Kb etc. <br />時間單位: second(s), minute(m), hour(h), day(d) or PT expression(PT30S) |      500 GiB/second      |
+|   specify.brokers   | (選填) 指定broker的ID，送資料到指定的broker，若 broker 上有 "目標 topic 的 partition" |           none           |
+| specify.partitions  | (選填) 指定要傳送資料的 topic/partitions，多個項目之間可以用逗號隔開，注意這個選項不能和 `specify.brokers` 、`throttle` 或 `partitioner` 一起使用 |           none           |
+|     report.path     | (選填) report file的檔案路徑                                 |           none           |
+|    report.format    | (選填) 選擇輸出檔案格式, 可用的格式：`csv`, `json`           |           csv            |
+|  transaction.size   | (選填) 每個transaction的records數量。若設置1以上，會使用transaction，否則都是一般write |            1             |
+|      group.id       | (選填) 設置 consumer group id                                | groupId-{Time in millis} |
+|      read.idle      | (選填) 讀取端將被終止如果超過這個時間沒有讀取到新的資料      |           2秒            |
+| interdependent.size | (選填) 每幾筆 record 要發到同一個 partition。(注意：只有 Astraea Dispatcher 可以使用) |            1             |
+|       monkeys       | (選填) 設定 chaos monkey 的觸發頻率，支援 : `kill`, `add`, `unsubscribe`。<br />觸發頻率單位為 ：day, h, m, s, ms, us, ns<br />範例：`--monkeys kill:3s,add:5s` |           none           |
+|      throttle       | (選填) 用來指定 topic-partitions 的限流值<br />例如：--throttle a1-0:5MB/s,a2-0:10MB/s,a10-4:30MB/s<br />注意此參數不可與`specify.partitions`、`specify.brokers` 或`partitioner` 一起使用 |           none           |
 
 #### 使用範例
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,200 @@
+# Astraea 使用故障排除
+
+這個條目記錄一些 Astraea 工具使用上可能會遭遇到的問題。
+
+## Balancer 的 Data Directory 負載轉移造成 Replica 損毀
+
+Astraea Balancer 支援同節點 Data Director 的負載轉移。但由於 Apache Kafka 2.2.0 到 3.5.0 版本之間的一個 bug，
+這個負載轉移的過程有機會觸發一個節點狀態操作上的 race condition ，這最終會導致 Replica 損毀不可用。由於這個 bug，
+目前 WebService Balancer 預設是**不進行**同節點下的 Data Directory 負載轉移。但使用者可以透過重寫特定設定來強制啟動 
+Data Directory 的負載轉移操作，詳情參考[文件](./web_server/web_api_balancer_chinese.md#進行-Data-Directory-負載轉移的風險)。
+
+### 症狀
+
+如果 Data Directory 的負載轉移真的觸發了這個錯誤，叢集會有下面這些症狀：
+
+* 部分的 Replica 一直處於 `future` 狀態。
+  * 對 Astraea WebService 發送 `GET /topics`，如果回傳結果指出有部分 Replica 的 `isFuture` 一直處於 `true`，且他的 `size` 
+    總是維持在 `0`。
+* 負責該 Replica 的 Apache Kafka Broker，其 log 有類似下者的錯誤：
+    ```
+    java.lang.IllegalStateException: Offset mismatch for the future replica topicB-121: fetched offset = 142138, log end offset = 0.
+        at kafka.server.ReplicaAlterLogDirsThread.processPartitionData(ReplicaAlterLogDirsThread.scala:67)
+        at kafka.server.AbstractFetcherThread.$anonfun$processFetchRequest$7(AbstractFetcherThread.scala:336)
+        at scala.Option.foreach(Option.scala:437)
+        at kafka.server.AbstractFetcherThread.$anonfun$processFetchRequest$6(AbstractFetcherThread.scala:325)
+        at kafka.server.AbstractFetcherThread.$anonfun$processFetchRequest$6$adapted(AbstractFetcherThread.scala:324)
+        at kafka.utils.Implicits$MapExtensionMethods$.$anonfun$forKeyValue$1(Implicits.scala:62)
+        at scala.collection.MapOps.foreachEntry(Map.scala:244)
+        at scala.collection.MapOps.foreachEntry$(Map.scala:240)
+        at scala.collection.AbstractMap.foreachEntry(Map.scala:405)
+        at kafka.server.AbstractFetcherThread.processFetchRequest(AbstractFetcherThread.scala:324)
+        at kafka.server.AbstractFetcherThread.$anonfun$maybeFetch$3(AbstractFetcherThread.scala:124)
+        at kafka.server.AbstractFetcherThread.$anonfun$maybeFetch$3$adapted(AbstractFetcherThread.scala:123)
+        at scala.Option.foreach(Option.scala:437)
+        at kafka.server.AbstractFetcherThread.maybeFetch(AbstractFetcherThread.scala:123)
+        at kafka.server.AbstractFetcherThread.doWork(AbstractFetcherThread.scala:106)
+        at kafka.utils.ShutdownableThread.run(ShutdownableThread.scala:96)
+    ```
+
+### 解決方法
+
+首先需要知道遇到問題的 Replica 有哪些，而後對他們做修正，下面透過 WebService 來示範如何修正問題。
+
+首先啟動 Astraea WebService，假設他的位置在 `localhost:8001`，接著執行：
+
+```shell
+curl -X GET --location "http://localhost:8001/topics" \
+  | jq '[ .topics[] | {name, partitions: [.partitions[] | select(.replicas[].isFuture == true) | {id, replicas: [.replicas[]]}]} ]'
+```
+
+這個指令首先對 WebService 撈取特定 topics 的資訊，而後透過 `jq` 從所有 topics 中找出 `isFuture` 是 `true` 的那些 partition 有誰。
+執行之後可能會看到類似下列的輸出
+
+```json5
+[
+  {
+    "name": "__consumer_offsets",
+    "partitions": []
+  },
+  {
+    "name": "topicA",
+    "partitions": []
+  },
+  {
+    "name": "topicB",
+    "partitions": [
+      {
+        "id": 121,    // Partition 編號
+        "replicas": [
+          {
+            "broker": 1,
+            "inSync": true,
+            "isFuture": true,   // <-----  isFuture == true
+            "lag": 188858,
+            "leader": false,
+            "path": "/tmp/log-folder-2", // 負載優化要移動到的 data directory
+            "size": 0           // <----- size 0
+          },
+          {
+            "broker": 1,
+            "inSync": true,
+            "isFuture": false,
+            "lag": 0,
+            "leader": false,
+            "path": "/tmp/log-folder-1", // 最初的 data directory
+            "size": 325283565
+          },
+          {
+            "broker": 2,
+            "inSync": true,
+            "isFuture": false,
+            "lag": 0,
+            "leader": true,
+            "path": "/tmp/log-folder-0",
+            "size": 325283565
+          }
+        ]
+      },
+      {
+        "id": 221,    // Partition 編號
+        "replicas": [
+          {
+            "broker": 1,
+            "inSync": true,
+            "isFuture": false,
+            "lag": 0,
+            "leader": true,
+            "path": "/tmp/log-folder-2",
+            "size": 386236916
+          },
+          {
+            "broker": 4,
+            "inSync": true,
+            "isFuture": false,
+            "lag": 0,
+            "leader": false,
+            "path": "/tmp/log-folder-0", // 最初的 data directory
+            "size": 386236916
+          },
+          {
+            "broker": 4,
+            "inSync": true,
+            "isFuture": true,   // <-----  isFuture == true
+            "lag": 202107,
+            "leader": false,
+            "path": "/tmp/log-folder-1", // 負載優化要移動到的 data directory
+            "size": 0           // <----- size 0
+          }
+        ]
+      }
+    ]
+  }
+]
+```
+
+上述輸出中，`topicB` 的部分有兩個 Partition 有遇到這個問題。 出問題的 Partition 分別是 `topicB-121` 和 `topicB-221`，
+他們各自有個 Replica，其 `isFuture` 是 `true` 且 `size` 維持在 `0` 不動。
+您可以順便去查看節點編號 1 和 4 的 Kafka Broker，應該可以在他們的 log 中看到相關的錯誤訊息。
+
+同一個 Replica 其 `isFuture` 為 `false` 那一份是套用負載優化前的原先位置。我們現在要嘗試手動抵消這個搬移操作，
+對 Web Service 發起類似下者 reassignment request，指示那份 replica 應該要放回他們原先的位置。
+
+```shell
+curl -X POST --location "http://localhost:8001/reassignments" \
+    -H "Content-Type: application/json" \
+    -d '{
+          "toFolders": [
+            { "topic":  "topicB", "partition":  121, "broker":  1, "to":  "/tmp/log-folder-1"},
+            { "topic":  "topicB", "partition":  221, "broker":  4, "to":  "/tmp/log-folder-0"}
+          ]
+        }'
+```
+
+上述的 HTTP Request 把有 isFuture 問題的 replica 移動回他們負載優化前的資料夾。
+
+重複執行剛剛的指令
+
+```shell
+curl -X GET --location "http://localhost:8001/topics" \
+  | jq '[ .topics[] | {name, partitions: [.partitions[] | select(.replicas[].isFuture == true) | {id, replicas: [.replicas[]]}]} ]'
+```
+
+原先 future 卡住的 replica 應該會消失不見。
+
+```json
+[
+  {
+    "name": "__consumer_offsets",
+    "partitions": []
+  },
+  {
+    "name": "topicA",
+    "partitions": []
+  },
+  {
+    "name": "topicB",
+    "partitions": []
+  }
+]
+```
+
+再來，原先的負載優化計劃希望把
+
+* `topicB-121` 在 broker 4 的 replica 搬移到 `/tmp/log-folder-2`
+* `topicB-221` 在 broker 1 的 replica 搬移到 `/tmp/log-folder-1`
+
+我們發起另外一個 reassignment request，將他們移回預期的位置。
+
+```shell
+curl -X POST --location "http://localhost:8001/reassignments" \
+    -H "Content-Type: application/json" \
+    -d '{
+          "toFolders": [
+            { "topic":  "topicB", "partition":  121, "broker":  1, "to":  "/tmp/log-folder-2"},
+            { "topic":  "topicB", "partition":  221, "broker":  4, "to":  "/tmp/log-folder-1"}
+          ]
+        }'
+```
+
+如此一來即可解決這個 data directory 間的搬移的 bug。

--- a/docs/web_server/web_api_balancer_chinese.md
+++ b/docs/web_server/web_api_balancer_chinese.md
@@ -67,7 +67,7 @@ JSON Response 範例
 }
 ```
 
-> ##### 搜尋負載優化計劃需要時間
+> ##### 搜尋負載優化計劃需要時間c
 > 透過 `POST /balancer` 發起搜尋後，由於演算法邏輯和叢集效能資訊收集因素，這個計劃可能會花上一段時間才會找到。
 > `POST /balancer` 回傳的計劃 id 能夠透過 [GET /balancer/{id}](#查詢負載優化計劃的狀態) 查詢其搜尋狀態，
 > 如果其 response 欄位 `generated` 為 `true`，則代表此計劃已經完成搜尋，能夠被 `PUT /balancer` 執行。
@@ -84,14 +84,22 @@ cURL 範例
 ```shell
 curl -X PUT http://localhost:8001/balancer \
     -H "Content-Type: application/json" \
-    -d '{ "id": "46ecf6e7-aa28-4f72-b1b6-a788056c122a" }'
+    -d '{ 
+      "id": "46ecf6e7-aa28-4f72-b1b6-a788056c122a",
+      "executor": "org.astraea.common.balancer.executor.StraightPlanExecutor",
+      "executorConfig": {
+        "enableDataDirectoryMigration": false
+      }
+    }'
 ```
 
 JSON Request 格式
 
-| 名稱  | 說明                 | 預設值 |
-|-----|--------------------|-----|
-| id  | (必填) 欲執行的負載優化計劃之編號 | 無   |
+| 名稱             | 說明                                                           | 預設值                                                       |
+|----------------|--------------------------------------------------------------|-----------------------------------------------------------|
+| id             | (必填) 欲執行的負載優化計劃之編號                                           | 無                                                         |
+| executor       | (選填) 欲使用的計劃執行演算法                                             | org.astraea.common.balancer.executor.StraightPlanExecutor |
+| executorConfig | (選填) 計劃執行演算法的實作細節參數，此為一個 JSON Object 內含一系列的 key/value String | 無                                                         |
 
 JSON Response 範例
 
@@ -102,6 +110,14 @@ JSON Response 範例
 ```
 
 後續能用特定 [API](#查詢負載優化計劃的狀態) 來查詢負載優化計劃的執行進度。
+
+> ##### 進行 Data Directory 負載轉移的風險
+> Kafka 本身支援在同一個節點進行 Data Directory 之間的負載轉移，但在 Apache Kafka Version 2.2.0 
+> 到 3.5.0 之間存在一個 [Bug](https://issues.apache.org/jira/browse/KAFKA-9087)，這個 Bug 
+> 會使這類的負載轉移操作有機率卡住無法結束。 由於這個風險的存在，預設上 `StraightPlanExecutor`
+> 的實作會忽略這種同節點的負載搬移行為。這樣做雖然可以避免觸發 Bug，但由於部分計劃內容被忽略沒有套用，
+> 最後負載優化的結果可能會和預期的結果失真。這個行為可以透過設定覆蓋，使用者可以透過設定 `executorConfig` 
+> 的 `enableDataDirectoryMigration` 設定為 `true` 來啟動 Data Directory 之間的負載轉移。
 
 > ##### 一個叢集同時間只能執行一個負載優化計劃
 > 嘗試對一個叢集同時套用多個負載優化計劃會導致意外的結果，因此 `PUT /balancer` 被設計為：

--- a/docs/web_server/web_api_balancer_chinese.md
+++ b/docs/web_server/web_api_balancer_chinese.md
@@ -67,7 +67,7 @@ JSON Response 範例
 }
 ```
 
-> ##### 搜尋負載優化計劃需要時間c
+> ##### 搜尋負載優化計劃需要時間
 > 透過 `POST /balancer` 發起搜尋後，由於演算法邏輯和叢集效能資訊收集因素，這個計劃可能會花上一段時間才會找到。
 > `POST /balancer` 回傳的計劃 id 能夠透過 [GET /balancer/{id}](#查詢負載優化計劃的狀態) 查詢其搜尋狀態，
 > 如果其 response 欄位 `generated` 為 `true`，則代表此計劃已經完成搜尋，能夠被 `PUT /balancer` 執行。
@@ -118,6 +118,9 @@ JSON Response 範例
 > 的實作會忽略這種同節點的負載搬移行為。這樣做雖然可以避免觸發 Bug，但由於部分計劃內容被忽略沒有套用，
 > 最後負載優化的結果可能會和預期的結果失真。這個行為可以透過設定覆蓋，使用者可以透過設定 `executorConfig` 
 > 的 `enableDataDirectoryMigration` 設定為 `true` 來啟動 Data Directory 之間的負載轉移。
+> 
+> 由於這個錯誤是有機率性的觸發，如果你賭一把進行 Data Directory 的轉移，但事後真的不幸觸發錯誤，
+> 可以參考 [故障排除文件](../troubleshooting.md)， 那邊有觸發這個 bug 時的一些症狀和解決方案。
 
 > ##### 一個叢集同時間只能執行一個負載優化計劃
 > 嘗試對一個叢集同時套用多個負載優化計劃會導致意外的結果，因此 `PUT /balancer` 被設計為：
@@ -207,7 +210,7 @@ JSON Response 範例
 }
 ```
 
-```json
+```json5
 {
   "id": "46ecf6e7-aa28-4f72-b1b6-a788056c122a",
   "phase": "Searched",

--- a/docs/web_server/web_api_balancer_chinese.md
+++ b/docs/web_server/web_api_balancer_chinese.md
@@ -120,7 +120,8 @@ JSON Response 範例
 > 的 `enableDataDirectoryMigration` 設定為 `true` 來啟動 Data Directory 之間的負載轉移。
 > 
 > 由於這個錯誤是有機率性的觸發，如果你賭一把進行 Data Directory 的轉移，但事後真的不幸觸發錯誤，
-> 可以參考 [故障排除文件](../troubleshooting.md)， 那邊有觸發這個 bug 時的一些症狀和解決方案。
+> 可以參考[故障排除文件](../troubleshooting.md#Balancer-的-Data-Directory-負載轉移失敗)，
+> 那邊有觸發這個 bug 時的一些症狀和解決方案。
 
 > ##### 一個叢集同時間只能執行一個負載優化計劃
 > 嘗試對一個叢集同時套用多個負載優化計劃會導致意外的結果，因此 `PUT /balancer` 被設計為：


### PR DESCRIPTION
Context: https://github.com/skiptests/astraea/issues/1393#issuecomment-1382656937
Related Issue: https://github.com/skiptests/astraea/issues/1325

這個 PR 是 #1325 Data Directory 搬移時的應對機制

* 在進行 `PUT /balancer` 的時候可以指定 executor 的實作，還有 executor 的參數。其中 `enableDataDirectoryMigration` 參數指出要進行 data directory 之間的負載優化。預設是不進行。
* 現在 `GET /balancer` 會顯示 data dir 的資訊。
* 新增 troubleshooting 文件描述如何判斷遇到這個問題，還有修正這個問題。