### PR TITLE
Fix conflict of #1505

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/utils/ClusterInfoSensor.java
+++ b/common/src/main/java/org/astraea/common/cost/utils/ClusterInfoSensor.java
@@ -50,10 +50,12 @@ public class ClusterInfoSensor implements MetricSensor {
   public static ClusterInfo metricViewCluster(ClusterBean clusterBean) {
     var nodes =
         clusterBean.brokerIds().stream()
+            .filter(id -> id != -1)
             .map(id -> NodeInfo.of(id, "", -1))
             .collect(Collectors.toUnmodifiableMap(NodeInfo::id, x -> x));
     var replicas =
         clusterBean.brokerTopics().stream()
+            .filter(bt -> bt.broker() != -1)
             .flatMap(
                 (bt) -> {
                   var broker = bt.broker();
@@ -99,7 +101,9 @@ public class ClusterInfoSensor implements MetricSensor {
                 })
             .collect(Collectors.toUnmodifiableList());
     var clusterId =
-        clusterBean.all().values().stream()
+        clusterBean.all().entrySet().stream()
+            .filter(e -> e.getKey() != -1)
+            .map(Map.Entry::getValue)
             .flatMap(Collection::stream)
             .filter(x -> x instanceof ServerMetrics.KafkaServer.ClusterIdGauge)
             .map(x -> (ServerMetrics.KafkaServer.ClusterIdGauge) x)

--- a/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
@@ -405,12 +405,10 @@ class NetworkCostTest {
 
   @Test
   void testNoMetricCheck() {
-    try (var collector =
-        MetricCollector.local()
-            .addMetricSensor(ingressCost().metricSensor().get())
-            .interval(Duration.ofMillis(100))
-            .build()) {
-      var ingressCost = new NetworkIngressCost();
+    var ingressCost = new NetworkIngressCost();
+    var collectorBuilder = MetricCollector.local().interval(Duration.ofMillis(100));
+    ingressCost.metricSensor().ifPresent(collectorBuilder::addMetricSensor);
+    try (var collector = collectorBuilder.build()) {
 
       // sample metrics for a while.
       Utils.sleep(Duration.ofMillis(500));

--- a/common/src/test/java/org/astraea/common/cost/utils/ClusterInfoSensorTest.java
+++ b/common/src/test/java/org/astraea/common/cost/utils/ClusterInfoSensorTest.java
@@ -116,8 +116,7 @@ class ClusterInfoSensorTest {
                         TopicPartition.of(topic, 2))));
         // compare broker id
         Assertions.assertTrue(
-            info.replicaStream()
-                .allMatch(r -> r.nodeInfo().id() == aBroker.id()));
+            info.replicaStream().allMatch(r -> r.nodeInfo().id() == aBroker.id()));
         // compare replica size
         var realCluster = admin.clusterInfo(Set.of(topic)).toCompletableFuture().join();
         Assertions.assertTrue(

--- a/common/src/test/java/org/astraea/common/cost/utils/ClusterInfoSensorTest.java
+++ b/common/src/test/java/org/astraea/common/cost/utils/ClusterInfoSensorTest.java
@@ -117,7 +117,7 @@ class ClusterInfoSensorTest {
         // compare broker id
         Assertions.assertTrue(
             info.replicaStream()
-                .allMatch(r -> r.nodeInfo().id() == aBroker.id() || r.nodeInfo().id() == -1));
+                .allMatch(r -> r.nodeInfo().id() == aBroker.id()));
         // compare replica size
         var realCluster = admin.clusterInfo(Set.of(topic)).toCompletableFuture().join();
         Assertions.assertTrue(


### PR DESCRIPTION
修正 #1505 合併時產生的衝突。

使用者要自行過濾 Metric Collector 撈出來的 metric，把 local metric 過濾掉。

另外，修正在 `ClusterInfoTest` 使用 `registserLocalJmx()`，改成實際註冊 broker 的 jmx 。