### PR TITLE
[COST] Improve `NetworkCost` Performance

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/NetworkCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NetworkCost.java
@@ -277,12 +277,11 @@ public abstract class NetworkCost implements HasClusterCost {
   }
 
   private class CachedCalculation {
-    private final ClusterInfo metricViewCluster;
     private final Map<TopicPartition, Long> partitionIngressRate;
     private final Map<TopicPartition, Long> partitionEgressRate;
 
     private CachedCalculation(ClusterBean sourceMetric) {
-      this.metricViewCluster = ClusterInfoSensor.metricViewCluster(sourceMetric);
+      final var metricViewCluster = ClusterInfoSensor.metricViewCluster(sourceMetric);
       this.partitionIngressRate =
           estimateRate(metricViewCluster, sourceMetric, ServerMetrics.Topic.BYTES_IN_PER_SEC);
       this.partitionEgressRate =

--- a/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
@@ -396,11 +396,11 @@ class NetworkCostTest {
     var costI =
         (NetworkCost.NetworkClusterCost) new NetworkIngressCost().clusterCost(scaledCluster, beans);
     Assertions.assertEquals(2, costI.brokerRate.size());
-    Assertions.assertEquals(0.0, costI.brokerRate.get(node));
+    Assertions.assertEquals(0L, costI.brokerRate.get(node.id()));
     var costE =
         (NetworkCost.NetworkClusterCost) new NetworkEgressCost().clusterCost(scaledCluster, beans);
     Assertions.assertEquals(2, costE.brokerRate.size());
-    Assertions.assertEquals(0.0, costE.brokerRate.get(node));
+    Assertions.assertEquals(0L, costE.brokerRate.get(node.id()));
   }
 
   @Test


### PR DESCRIPTION
Context: https://github.com/skiptests/astraea/pull/1476#issuecomment-1454429787

目前 `NetworkCost` 在大量 Partition （約 10000）的情境下會出現效能上的問題，這個 PR 對 `NetworkCost` 實作做一些優化。

* 快取 `ClusterBean` 計算出的 Partition 流量結果，以後這些昂貴的計算在整個 Balance 的流程中只會做一次。
* 修改衡量 `ClusterInfo` 的節點流量的方法，原本是從 raw replica stream 中做 `Collector.groupingBy` 聚合。現在透過 `ClusterInfo#replicas(int broker)` 已經聚合過的結果做流量加總，可以節省一些重複的聚合邏輯。

## 優化前

```
Total Run time: 35263 ms
Total ClusterCost Evaluation: 12
Average ClusterCost Processing: 2890ms
Average MoveCost Processing: 0 ms
Initial Cost: 0.20270230731415478
Final Cost: 0.20125311107585134
```

## 優化後

```
Total Run time: 30045 ms
Total ClusterCost Evaluation: 963
Average ClusterCost Processing: 9ms
Average MoveCost Processing: 0 ms
Initial Cost: 0.20265291955203096
Final Cost: 0.15089094792725546
```

## 優化後的火焰圖

![image](https://user-images.githubusercontent.com/39105714/222905499-03dc5c75-f3a7-4b2d-9cb9-96389cbfad16.png)

目前時間貢獻最多的是 `ShuffleTweaker` 的部分，從統計結果來看，30秒裡面只有8.6秒是在做 ClusterCost 的計算。剩下 22 秒都是 `ShuffleTweaker` 的貢獻，後面可能可以考慮看看這邊有沒有優化的機會。