### PR TITLE
[COMMON] hanging when creating multi consumers in single thread with …

### DIFF
--- a/common/src/main/java/org/astraea/common/consumer/TopicsBuilder.java
+++ b/common/src/main/java/org/astraea/common/consumer/TopicsBuilder.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -103,6 +104,10 @@ public class TopicsBuilder<Key, Value> extends Builder<Key, Value> {
             Deserializer.of((Deserializer<Key>) keyDeserializer),
             Deserializer.of((Deserializer<Value>) valueDeserializer));
 
+    // consumer rebalance requires all consumers keeps polling to complete whole process.
+    // we invoke another thread to poll consumer to complete rebalance
+    // otherwise, users can't create multi consumers at once in same thread.
+    CompletableFuture<Void> waitRebalance = CompletableFuture.completedFuture(null);
     if (seekStrategy != SeekStrategy.NONE) {
       // make sure this consumer is assigned before seeking
       var latch = new CountDownLatch(1);
@@ -115,12 +120,17 @@ public class TopicsBuilder<Key, Value> extends Builder<Key, Value> {
             patternTopics,
             ConsumerRebalanceListener.of(List.of(listener, ignored -> latch.countDown())));
 
-      while (latch.getCount() != 0) {
-        // the offset will be reset, so it is fine to poll data
-        // TODO: should we disable auto-commit here?
-        kafkaConsumer.poll(Duration.ofMillis(500));
-        Utils.sleep(Duration.ofSeconds(1));
-      }
+      waitRebalance =
+          CompletableFuture.runAsync(
+              () -> {
+                while (latch.getCount() != 0) {
+                  // the offset will be reset, so it is fine to poll data
+                  // TODO: should we disable auto-commit here?
+                  kafkaConsumer.poll(Duration.ofMillis(500));
+                  Utils.sleep(Duration.ofSeconds(1));
+                }
+                seekStrategy.apply(kafkaConsumer, seekValue);
+              });
     } else {
       // nothing to seek so we just subscribe topics
       if (patternTopics == null)
@@ -128,49 +138,74 @@ public class TopicsBuilder<Key, Value> extends Builder<Key, Value> {
       else kafkaConsumer.subscribe(patternTopics, ConsumerRebalanceListener.of(List.of(listener)));
     }
 
-    seekStrategy.apply(kafkaConsumer, seekValue);
-
-    return new SubscribedConsumerImpl<>(kafkaConsumer, setTopics, patternTopics, listener);
+    return new SubscribedConsumerImpl<>(
+        waitRebalance, kafkaConsumer, setTopics, patternTopics, listener);
   }
 
   private static class SubscribedConsumerImpl<Key, Value> extends Builder.BaseConsumer<Key, Value>
       implements SubscribedConsumer<Key, Value> {
+    private final CompletableFuture<Void> waitRebalance;
     private final Set<String> setTopics;
     private final Pattern patternTopics;
     private final ConsumerRebalanceListener listener;
 
     public SubscribedConsumerImpl(
+        CompletableFuture<Void> waitRebalance,
         org.apache.kafka.clients.consumer.Consumer<Key, Value> kafkaConsumer,
         Set<String> setTopics,
         Pattern patternTopics,
         ConsumerRebalanceListener listener) {
       super(kafkaConsumer);
+      this.waitRebalance = waitRebalance;
       this.setTopics = setTopics;
       this.patternTopics = patternTopics;
       this.listener = listener;
     }
 
     @Override
+    public void unsubscribe() {
+      waitRebalance.join();
+      super.unsubscribe();
+    }
+
+    @Override
+    public List<Record<Key, Value>> poll(int recordCount, Duration timeout) {
+      waitRebalance.join();
+      return super.poll(recordCount, timeout);
+    }
+
+    @Override
+    public void close() {
+      waitRebalance.join();
+      super.close();
+    }
+
+    @Override
     public void commitOffsets(Duration timeout) {
+      waitRebalance.join();
       kafkaConsumer.commitSync(timeout);
     }
 
     @Override
     public String groupId() {
+      waitRebalance.join();
       return kafkaConsumer.groupMetadata().groupId();
     }
 
     @Override
     public String memberId() {
+      waitRebalance.join();
       return kafkaConsumer.groupMetadata().memberId();
     }
 
     public Optional<String> groupInstanceId() {
+      waitRebalance.join();
       return kafkaConsumer.groupMetadata().groupInstanceId();
     }
 
     @Override
     protected void doResubscribe() {
+      waitRebalance.join();
       if (patternTopics == null)
         kafkaConsumer.subscribe(setTopics, ConsumerRebalanceListener.of(List.of(listener)));
       else kafkaConsumer.subscribe(patternTopics, ConsumerRebalanceListener.of(List.of(listener)));
@@ -178,6 +213,7 @@ public class TopicsBuilder<Key, Value> extends Builder<Key, Value> {
 
     @Override
     public Set<TopicPartition> assignments() {
+      waitRebalance.join();
       return kafkaConsumer.assignment().stream()
           .map(TopicPartition::from)
           .collect(Collectors.toUnmodifiableSet());

--- a/common/src/test/java/org/astraea/common/consumer/ConsumerTest.java
+++ b/common/src/test/java/org/astraea/common/consumer/ConsumerTest.java
@@ -689,4 +689,22 @@ public class ConsumerTest {
     closed.set(true);
     futures.join();
   }
+
+  @Test
+  void testCreateMultiConsumersWithSameGroup() {
+    var topic = Utils.randomString();
+    var groupId = Utils.randomString();
+    var consumers =
+        IntStream.range(0, 2)
+            .mapToObj(
+                i ->
+                    Consumer.forTopics(Set.of(topic))
+                        .bootstrapServers(SERVICE.bootstrapServers())
+                        .config(ConsumerConfigs.GROUP_ID_CONFIG, groupId)
+                        .seek(SeekStrategy.DISTANCE_FROM_BEGINNING, 0)
+                        .build())
+            .collect(Collectors.toUnmodifiableList());
+    consumers.forEach(consumer -> consumer.poll(Duration.ofSeconds(1)));
+    consumers.forEach(Consumer::close);
+  }
 }


### PR DESCRIPTION
啟用 `seek`的時候，我們會內部等待 rebalance 的發生，在單一執行緒同時啟動多個consumers時，會導致後面一個consumer在等待前面一個consumer回應 (也就是poll)，但因為只有一個執行序，這導致後一個consumer只能等待前一個consumer 被
 timeout ...

這隻PR改用獨立的執行緒來完成上述操作