### PR TITLE
[TEST] fix Admin#testSubtractTopicConfigs and Admin#testAppendConfigs…

### DIFF
--- a/common/src/test/java/org/astraea/common/admin/AdminTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AdminTest.java
@@ -1426,7 +1426,7 @@ public class AdminTest {
           .setProducerQuotas(Map.of(Utils.hostname(), DataRate.Byte.of(100).perSecond()))
           .toCompletableFuture()
           .join();
-
+      Utils.sleep(Duration.ofSeconds(2));
       var quotas =
           admin.quotas(Set.of(QuotaConfigs.CLIENT_ID)).toCompletableFuture().join().stream()
               .filter(q -> q.targetValue().equals(Utils.hostname()))

--- a/common/src/test/java/org/astraea/common/admin/AdminTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AdminTest.java
@@ -1925,6 +1925,7 @@ public class AdminTest {
                   topic, Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "*")))
           .toCompletableFuture()
           .join();
+      Utils.sleep(Duration.ofSeconds(3));
       Assertions.assertEquals(
           "*",
           admin
@@ -1987,6 +1988,7 @@ public class AdminTest {
                   Map.of(TopicConfigs.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG, "1:1001")))
           .toCompletableFuture()
           .join();
+      Utils.sleep(Duration.ofSeconds(3));
       Assertions.assertEquals(
           "2:1003",
           admin


### PR DESCRIPTION
fix #1548 #1549

Kraft 的架構上所有節點都必須等 Kraft quorum 的資料更新，而不是之前選一個 controller 然後身上總是有最新的 cache，這導致有些操作反而需要等待 metadata 的更新