### PR TITLE
[COMMON] Parallelize the sampling of `MBeanClient#beans`

### DIFF
--- a/common/src/main/java/org/astraea/common/metrics/MBeanClient.java
+++ b/common/src/main/java/org/astraea/common/metrics/MBeanClient.java
@@ -192,6 +192,8 @@ public interface MBeanClient extends AutoCloseable {
       return Utils.packException(
           () ->
               connection.queryMBeans(beanQuery.objectName(), null).stream()
+                  // Parallelize the sampling of bean objects. The underlying RMI is thread-safe.
+                  // https://github.com/skiptests/astraea/issues/1553#issuecomment-1461143723
                   .parallel()
                   .map(ObjectInstance::getObjectName)
                   .map(BeanQuery::fromObjectName)

--- a/common/src/main/java/org/astraea/common/metrics/MBeanClient.java
+++ b/common/src/main/java/org/astraea/common/metrics/MBeanClient.java
@@ -192,6 +192,7 @@ public interface MBeanClient extends AutoCloseable {
       return Utils.packException(
           () ->
               connection.queryMBeans(beanQuery.objectName(), null).stream()
+                  .parallel()
                   .map(ObjectInstance::getObjectName)
                   .map(BeanQuery::fromObjectName)
                   .map(this::bean)


### PR DESCRIPTION
Context: #1553

`MBeanClient` 實作所基於的 `MBeanServerConnection` 為 Thread-Safe，這個 PR 允許 `MBeanClient#beans()` 底層的效能指標撈取同步化執行。