### PR TITLE
[TEST] remove "auto.leader.rebalance.enable" from testing

### DIFF
--- a/it/src/main/java/org/astraea/it/BrokerCluster.java
+++ b/it/src/main/java/org/astraea/it/BrokerCluster.java
@@ -139,7 +139,7 @@ public interface BrokerCluster extends AutoCloseable {
 
                   // disable auto leader balance to ensure AdminTest#preferredLeaderElection works
                   // correctly.
-                  configs.put("auto.leader.rebalance.enable", String.valueOf(false));
+//                  configs.put("auto.leader.rebalance.enable", String.valueOf(false));
 
                   // add custom configs
                   configs.putAll(override);

--- a/it/src/main/java/org/astraea/it/BrokerCluster.java
+++ b/it/src/main/java/org/astraea/it/BrokerCluster.java
@@ -137,10 +137,6 @@ public interface BrokerCluster extends AutoCloseable {
                   configs.put("offsets.topic.replication.factor", String.valueOf(1));
                   configs.put("log.dirs", String.join(",", tempFolders.get(entry.getKey())));
 
-                  // disable auto leader balance to ensure AdminTest#preferredLeaderElection works
-                  // correctly.
-//                  configs.put("auto.leader.rebalance.enable", String.valueOf(false));
-
                   // add custom configs
                   configs.putAll(override);
 


### PR DESCRIPTION
該參數來自於 https://github.com/skiptests/astraea/pull/388#discussion_r889496058

原本的用法應該是要避免自動平衡影響我們測試的期待，不過原本最會被影響的測試已經移除了，所以清掉該測試來看看還有沒有被影響的可能