### PR TITLE
update Kafka QA docs

### DIFF
--- a/docs/kafka_Q&A.md
+++ b/docs/kafka_Q&A.md
@@ -3,7 +3,7 @@
 此文件整理 Kafka 使用上可能會遇到的問題，以及解決方法
 
 1. [單一partition的fetch速度太慢](#單一partition的fetch速度太慢)
-3. [資料流入較慢的 partitions 會拖慢同節點內其他 partitions 被消費的速度](#資料流入較慢的-partitions-會拖慢同節點內其他-partitions-被消費的速度)
+2. [資料流入較慢的 partitions 會拖慢同節點內其他 partitions 被消費的速度](#資料流入較慢的-partitions-會拖慢同節點內其他-partitions-被消費的速度)
 
 ## 單一partition的fetch速度太慢
 

--- a/docs/kafka_Q&A.md
+++ b/docs/kafka_Q&A.md
@@ -19,7 +19,7 @@ Consumer: 調整Consumer config的"receive.buffer.bytes"，建議設定為-1，�
 
 ### 副作用
 
-理論上把"replica.socket.receive.buffer.bytes"，調大可以增加throughput沒錯，但是要注意的是，當調大到一定的大小之後，kafka fetch的這端可能會處理的速度比buffer進來的速度還慢，當這個現象發生時，再調大buffer size只會佔用更多的記憶體，而沒辦法再提昇fetch的效能
+理論上把調大buffer size可以增加throughput沒錯，但是要注意的是，當調大到一定的大小之後，kafka fetch的這端可能會處理的速度比buffer進來的速度還慢，當這個現象發生時，再調大buffer size只會佔用更多的記憶體，而沒辦法再提昇fetch的效能
 
 ### 詳細討論
 

--- a/docs/kafka_Q&A.md
+++ b/docs/kafka_Q&A.md
@@ -2,19 +2,20 @@
 
 此文件整理 Kafka 使用上可能會遇到的問題，以及解決方法
 
-1. [單一partition的副本同步速度太慢](#單一partition的副本同步速度太慢)
-2. [單一partition的Consumer拉取的速度太慢](#單一partition的Consumer拉取的速度太慢)
+1. [單一partition的fetch速度太慢](#單一partition的fetch速度太慢)
 3. [資料流入較慢的 partitions 會拖慢同節點內其他 partitions 被消費的速度](#資料流入較慢的-partitions-會拖慢同節點內其他-partitions-被消費的速度)
 
-## 單一partition的副本同步速度太慢
+## 單一partition的fetch速度太慢
 
 ### 原因
 
-Kafka端處理fetch request時，會有一個迴圈，這個迴圈會在跟os的receive buffer要資料之後還會對這些資料做一些處理，因此每次跟receive buffer poll資料會有一定的時間間隔，而receive buffer預設值是64KB, 若是調大這個buffer size可以讓buffer更慢一點塞滿，也就是說可以讓buffer能放的資料量變更多，塞滿buffer size的時間更長，更加接近每次poll資料的間隔，從而讓fetch的throughput提升
+Kafka端或Consumer端處理fetch request時，會有一個迴圈，這個迴圈會在跟os的receive buffer要資料之後還會對這些資料做一些處理，因此每次跟receive buffer poll資料會有一定的時間間隔，而receive buffer預設值是64KB, 若是調大這個buffer size可以讓buffer更慢一點塞滿，也就是說可以讓buffer能放的資料量變更多，塞滿buffer size的時間更長，更加接近每次poll資料的間隔，從而讓fetch的throughput提升
 
 ### 解法
 
-調整Broker config中的"replica.socket.receive.buffer.bytes"，建議設定為-1，讓OS來決定buffer size大小
+Replica: 調整Broker config中的"replica.socket.receive.buffer.bytes"，建議設定為-1，讓OS來決定buffer size大小
+
+Consumer: 調整Consumer config的"receive.buffer.bytes"，建議設定為-1，讓OS來決定buffer size大小
 
 ### 副作用
 
@@ -25,23 +26,6 @@ Kafka端處理fetch request時，會有一個迴圈，這個迴圈會在跟os的
 [#1518](https://github.com/skiptests/astraea/issues/1516)
 
 
-## 單一partition的Consumer拉取的速度太慢
-
-### 原因
-
-原因跟[單一partition的副本同步速度太慢](#單一partition的副本同步速度太慢)類似，當topic只有一個單一partition時，不會一直連續的做fetch，而是fetch一次之後會先做一些處理，因此每次fetch都會有一些間隔
-
-### 解法
-
-調整Consumer config的"receive.buffer.bytes"，建議設定為-1，讓OS來決定buffer size大小
-
-### 副作用
-
-副作用也與[單一partition的副本同步速度太慢](#單一partition的副本同步速度太慢)類似，當buffer size大到consumer來不及處理時，再增加buffer size也沒辦法提升效能，只會佔用額外的記憶體
-
-### 詳細討論
-
-[#1518](https://github.com/skiptests/astraea/issues/1516)
 
 ## 資料流入較慢的 partitions 會拖慢同節點內其他 partitions 被消費的速度
 

--- a/docs/kafka_Q&A.md
+++ b/docs/kafka_Q&A.md
@@ -3,7 +3,7 @@
 此文件整理 Kafka 使用上可能會遇到的問題，以及解決方法
 
 1. [單一partition的副本同步速度太慢](#單一partition的副本同步速度太慢)
-2. [Consumer poll速度太慢](#consumer-poll速度太慢)
+2. [單一partition的Consumer拉取的速度太慢](#單一partition的Consumer拉取的速度太慢)
 3. [資料流入較慢的 partitions 會拖慢同節點內其他 partitions 被消費的速度](#資料流入較慢的-partitions-會拖慢同節點內其他-partitions-被消費的速度)
 
 ## 單一partition的副本同步速度太慢
@@ -25,11 +25,11 @@ Kafka端處理fetch request時，會有一個迴圈，這個迴圈會在跟os的
 [#1518](https://github.com/skiptests/astraea/issues/1516)
 
 
-## Consumer poll速度太慢
+## 單一partition的Consumer拉取的速度太慢
 
 ### 原因
 
-原因跟[單一partition的副本同步速度太慢](#單一partition的副本同步速度太慢)類似，不會一直連續的做fetch，而是fetch一次之後會先做一些處理，因此每次fetch都會有一些間隔
+原因跟[單一partition的副本同步速度太慢](#單一partition的副本同步速度太慢)類似，當topic只有一個單一partition時，不會一直連續的做fetch，而是fetch一次之後會先做一些處理，因此每次fetch都會有一些間隔
 
 ### 解法
 


### PR DESCRIPTION
#1556 更新Kafka QA的`單一partition的Consumer拉取的速度太慢`