### PR TITLE
[Metric] Metric publisher failed when fetching many beans

### DIFF
--- a/app/src/main/java/org/astraea/app/publisher/MetricPublisher.java
+++ b/app/src/main/java/org/astraea/app/publisher/MetricPublisher.java
@@ -136,9 +136,9 @@ public class MetricPublisher {
                         try {
                           var delayedClient = clients.poll(5, TimeUnit.SECONDS);
                           if (delayedClient != null) {
-                            delayedClient.mBeanClient.beans(BeanQuery.all()).stream()
-                                .map(bean -> new IdBean(delayedClient.id, bean))
-                                .forEach(bean -> Utils.packException(() -> beanQueue.put(bean)));
+                            for (var bean : delayedClient.mBeanClient.beans(BeanQuery.all())) {
+                              beanQueue.put(new IdBean(delayedClient.id, bean));
+                            }
                             clients.put(
                                 new DelayedIdClient(
                                     duration, delayedClient.id, delayedClient.mBeanClient));

--- a/app/src/main/java/org/astraea/app/publisher/MetricPublisher.java
+++ b/app/src/main/java/org/astraea/app/publisher/MetricPublisher.java
@@ -136,10 +136,9 @@ public class MetricPublisher {
                         try {
                           var delayedClient = clients.poll(5, TimeUnit.SECONDS);
                           if (delayedClient != null) {
-                            beanQueue.addAll(
-                                delayedClient.mBeanClient.beans(BeanQuery.all()).stream()
-                                    .map(bean -> new IdBean(delayedClient.id, bean))
-                                    .collect(Collectors.toList()));
+                            delayedClient.mBeanClient.beans(BeanQuery.all()).stream()
+                                .map(bean -> new IdBean(delayedClient.id, bean))
+                                .forEach(bean -> Utils.packException(() -> beanQueue.put(bean)));
                             clients.put(
                                 new DelayedIdClient(
                                     duration, delayedClient.id, delayedClient.mBeanClient));

--- a/app/src/main/java/org/astraea/app/publisher/MetricPublisher.java
+++ b/app/src/main/java/org/astraea/app/publisher/MetricPublisher.java
@@ -183,7 +183,7 @@ public class MetricPublisher {
                 (Runnable)
                     () -> {
                       try (var publisher = JMXPublisher.create(bootstrap)) {
-                        while (!closed.get()) {
+                        while (!closed.get() || !beanQueue.isEmpty()) {
                           try {
                             var idBean = beanQueue.poll(5, TimeUnit.SECONDS);
                             if (idBean != null) {

--- a/app/src/main/java/org/astraea/app/publisher/MetricPublisher.java
+++ b/app/src/main/java/org/astraea/app/publisher/MetricPublisher.java
@@ -67,7 +67,7 @@ public class MetricPublisher {
     var targetClients = new DelayQueue<DelayedIdClient>();
     // queue of fetched beans
     var beanQueue = new ArrayBlockingQueue<IdBean>(2000);
-    var fetchRateSensor = Sensor.builder().addStat(RATE_PROPERTY, Rate.count()).build();
+    var fetchRateSensor = Sensor.builder().addStat(RATE_PROPERTY, Rate.of()).build();
     var close = new AtomicBoolean(false);
     MBeanRegister.local()
         .domainName(DOMAIN_NAME)

--- a/common/src/main/java/org/astraea/common/metrics/stats/Rate.java
+++ b/common/src/main/java/org/astraea/common/metrics/stats/Rate.java
@@ -17,6 +17,7 @@
 package org.astraea.common.metrics.stats;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.LongAdder;
 import org.astraea.common.DataSize;
 
 /** By contrast to {@link Avg}, {@link Rate} measure the value by time instead of "count". */
@@ -40,6 +41,24 @@ public interface Rate<T> extends Stat<T> {
         var diff = System.currentTimeMillis() - start;
         if (diff <= 0) return DataSize.Byte.of(0);
         return size.dataRate(Duration.ofMillis(diff)).dataSize();
+      }
+    };
+  }
+
+  static Rate<Double> count() {
+    final long start = System.currentTimeMillis();
+    var adder = new LongAdder();
+    return new Rate<>() {
+      @Override
+      public void record(Double ignore) {
+        adder.add(1);
+      }
+
+      @Override
+      public Double measure() {
+        var diff = System.currentTimeMillis() - start;
+        if (diff <= 0) return 0.0;
+        return ((double) adder.sum()) / diff * 1000;
       }
     };
   }

--- a/common/src/main/java/org/astraea/common/metrics/stats/Rate.java
+++ b/common/src/main/java/org/astraea/common/metrics/stats/Rate.java
@@ -17,14 +17,13 @@
 package org.astraea.common.metrics.stats;
 
 import java.time.Duration;
-import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.atomic.DoubleAdder;
 import org.astraea.common.DataSize;
 
 /** By contrast to {@link Avg}, {@link Rate} measure the value by time instead of "count". */
 public interface Rate<T> extends Stat<T> {
   /**
-   * @return sum of recorded size / (time of last record - start time). Noted that the unit is
-   *     second
+   * @return sum of recorded size / (current time - start time). Noted that the unit is second
    */
   static Rate<DataSize> sizeRate() {
     return new Rate<>() {
@@ -45,20 +44,23 @@ public interface Rate<T> extends Stat<T> {
     };
   }
 
-  static Rate<Double> count() {
+  /**
+   * @return sum of recorded value / (current time - start time). Noted that the unit is second.
+   */
+  static Rate<Double> of() {
     final long start = System.currentTimeMillis();
-    var adder = new LongAdder();
+    var adder = new DoubleAdder();
     return new Rate<>() {
       @Override
-      public void record(Double ignore) {
-        adder.add(1);
+      public void record(Double value) {
+        adder.add(value);
       }
 
       @Override
       public Double measure() {
         var diff = System.currentTimeMillis() - start;
         if (diff <= 0) return 0.0;
-        return ((double) adder.sum()) / diff * 1000;
+        return adder.sum() / diff * 1000;
       }
     };
   }

--- a/common/src/test/java/org/astraea/common/metrics/stats/RateTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/stats/RateTest.java
@@ -31,4 +31,16 @@ public class RateTest {
     Utils.sleep(Duration.ofSeconds(1));
     Assertions.assertTrue(rate.measure().bytes() < 100);
   }
+
+  @Test
+  void testCountMeasure() {
+    var rate = Rate.count();
+    Assertions.assertDoesNotThrow(rate::measure);
+    Assertions.assertEquals(0.0, rate.measure());
+    rate.record(1.0);
+    rate.record(1.0);
+    Utils.sleep(Duration.ofSeconds(1));
+    Assertions.assertTrue(rate.measure() < 2);
+    Assertions.assertTrue(rate.measure() > 1.5);
+  }
 }

--- a/common/src/test/java/org/astraea/common/metrics/stats/RateTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/stats/RateTest.java
@@ -34,7 +34,7 @@ public class RateTest {
 
   @Test
   void testCountMeasure() {
-    var rate = Rate.count();
+    var rate = Rate.of();
     Assertions.assertDoesNotThrow(rate::measure);
     Assertions.assertEquals(0.0, rate.measure());
     rate.record(1.0);


### PR DESCRIPTION
使用 Metric Publisher 收集&發布 "有 60000 個 partition 的叢集" 的 mbean，但是 producer thread 還來不及發布 `beanQueue` 裡面的資料，`beanQueue` 就被塞滿了。

這裡改成讓 `fetcherThread` 使用 blocking call，把所有 fetch 到的 mbean 都塞進去，而不是拋出錯誤。