### PR TITLE
Provide exception handler construction for MetricSensors

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/NeutralIntegratedCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NeutralIntegratedCost.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.astraea.common.EnumInfo;
 import org.astraea.common.admin.ClusterBean;
@@ -167,11 +166,12 @@ public class NeutralIntegratedCost implements HasBrokerCost {
 
   @Override
   public Optional<MetricSensor> metricSensor() {
-    Consumer<Exception> e = (x) -> {};
     return MetricSensor.of(
         metricsCost.stream()
-            .map(c -> Map.entry(c.metricSensor(), e))
-            .collect(Collectors.toUnmodifiableMap(x -> x.getKey().get(), Map.Entry::getValue)));
+            .map(CostFunction::metricSensor)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(Collectors.toUnmodifiableList()));
   }
 
   @Override

--- a/common/src/main/java/org/astraea/common/cost/NeutralIntegratedCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NeutralIntegratedCost.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.astraea.common.EnumInfo;
 import org.astraea.common.admin.ClusterBean;
@@ -166,12 +167,11 @@ public class NeutralIntegratedCost implements HasBrokerCost {
 
   @Override
   public Optional<MetricSensor> metricSensor() {
+    Consumer<Exception> e = (x) -> {};
     return MetricSensor.of(
         metricsCost.stream()
-            .map(CostFunction::metricSensor)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .collect(Collectors.toUnmodifiableList()));
+            .map(c -> Map.entry(c.metricSensor(), e))
+            .collect(Collectors.toUnmodifiableMap(x -> x.getKey().get(), Map.Entry::getValue)));
   }
 
   @Override

--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricSensor.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricSensor.java
@@ -17,7 +17,6 @@
 package org.astraea.common.metrics.collector;
 
 import java.util.Collection;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -36,7 +35,7 @@ public interface MetricSensor {
    */
   static Optional<MetricSensor> of(Collection<MetricSensor> metricSensors) {
     if (metricSensors.isEmpty()) return Optional.empty();
-    return of(metricSensors, (ex) -> {});
+    return of(metricSensors, ignore -> {});
   }
 
   /**
@@ -55,7 +54,7 @@ public interface MetricSensor {
                     ms -> {
                       try {
                         return ms.fetch(client, clusterBean).stream();
-                      } catch (NoSuchElementException ex) {
+                      } catch (Exception ex) {
                         exceptionHandler.accept(ex);
                         return Stream.empty();
                       }

--- a/common/src/test/java/org/astraea/common/metrics/collector/MetricSensorTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/collector/MetricSensorTest.java
@@ -17,7 +17,6 @@
 package org.astraea.common.metrics.collector;
 
 import java.util.List;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.astraea.common.admin.ClusterBean;
@@ -77,14 +76,16 @@ public class MetricSensorTest {
           throw new RuntimeException();
         };
 
-    var sensor = MetricSensor.of(Map.of(metricSensor0, e -> {}, metricSensor1, e -> {})).get();
+    var sensor = MetricSensor.of(List.of(metricSensor0, metricSensor1)).get();
     Assertions.assertDoesNotThrow(
         () -> sensor.fetch(Mockito.mock(MBeanClient.class), ClusterBean.EMPTY));
+    Assertions.assertEquals(
+        1, sensor.fetch(Mockito.mock(MBeanClient.class), ClusterBean.EMPTY).size());
 
     Assertions.assertThrows(
         RuntimeException.class,
         () ->
-            MetricSensor.of(Map.of(metricSensor0, e -> {}, metricSensor2, e -> {}))
+            MetricSensor.of(List.of(metricSensor0, metricSensor2))
                 .get()
                 .fetch(Mockito.mock(MBeanClient.class), ClusterBean.EMPTY));
   }


### PR DESCRIPTION
related https://github.com/skiptests/astraea/issues/1509#issue-1593324651

此 PR 想解決 SmoothWeightRoundRobinPartitioner 撈不到 localBean 的問題，這是因為在撈的過程發生 exception，導致同個節點的其他 cost 也跟著 exception 噴掉

### 原因
SmoothWeightRoundRobinPartitioner 目前預設使用的 cost function 有四種，分別是
1. BrokerInputCost
2. BrokerOutputCost
3. CpuCost
4. MemoryCost

而如果 local 端沒有 BrokerInput、BrokerOutput 的 metrics，mBean client 在撈回來的時候就會噴 exception，導致 CpuCost 與 MemoryCost 也跟著噴掉

### 目前版本
![修改前](https://user-images.githubusercontent.com/90374678/225269057-c5493cc9-a3c2-403d-9c9a-7faeac5523cd.png)

目前測試使用六台節點，因為都有開啟 Kafka server 所以都能正常拉取上述 metrics，而 Local 因為沒有 Broker 相關 metrics 所以跟著 exception 一起噴了

### 修改後
![修改後](https://user-images.githubusercontent.com/90374678/225269708-bb652c7e-ecc0-4797-8a14-b7f600cb1755.png)
