### PR TITLE
[COST] move cluster-related cost to ClusterInfo

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/RecordSizeCost.java
+++ b/common/src/main/java/org/astraea/common/cost/RecordSizeCost.java
@@ -17,9 +17,7 @@
 package org.astraea.common.cost;
 
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.astraea.common.Configuration;
 import org.astraea.common.DataSize;
 import org.astraea.common.admin.ClusterBean;
@@ -53,18 +51,7 @@ public class RecordSizeCost
 
   @Override
   public MoveCost moveCost(ClusterInfo before, ClusterInfo after, ClusterBean clusterBean) {
-    var moveCost =
-        Stream.concat(before.nodes().stream(), after.nodes().stream())
-            .map(NodeInfo::id)
-            .distinct()
-            .parallel()
-            .collect(
-                Collectors.toUnmodifiableMap(
-                    Function.identity(),
-                    id ->
-                        DataSize.Byte.of(
-                            after.replicaStream(id).mapToLong(Replica::size).sum()
-                                - before.replicaStream(id).mapToLong(Replica::size).sum())));
+    var moveCost = ClusterInfo.changedRecordSize(before, after, ignored -> true);
     var maxMigratedSize =
         config
             .string(MAX_MIGRATE_SIZE_KEY)

--- a/common/src/main/java/org/astraea/common/cost/ReplicaLeaderSizeCost.java
+++ b/common/src/main/java/org/astraea/common/cost/ReplicaLeaderSizeCost.java
@@ -18,14 +18,11 @@ package org.astraea.common.cost;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.astraea.common.Configuration;
 import org.astraea.common.DataSize;
 import org.astraea.common.admin.ClusterBean;
 import org.astraea.common.admin.ClusterInfo;
-import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.Replica;
 import org.astraea.common.metrics.collector.MetricSensor;
 
@@ -61,18 +58,7 @@ public class ReplicaLeaderSizeCost
 
   @Override
   public MoveCost moveCost(ClusterInfo before, ClusterInfo after, ClusterBean clusterBean) {
-    var moveCost =
-        Stream.concat(before.nodes().stream(), after.nodes().stream())
-            .map(NodeInfo::id)
-            .distinct()
-            .parallel()
-            .collect(
-                Collectors.toUnmodifiableMap(
-                    Function.identity(),
-                    id ->
-                        DataSize.Byte.of(
-                            after.replicaStream(id).mapToLong(Replica::size).sum()
-                                - before.replicaStream(id).mapToLong(Replica::size).sum())));
+    var moveCost = ClusterInfo.changedRecordSize(before, after, Replica::isLeader);
     var maxMigratedLeaderSize =
         config.string(COST_LIMIT_KEY).map(DataSize::of).map(DataSize::bytes).orElse(Long.MAX_VALUE);
     var overflow =

--- a/common/src/main/java/org/astraea/common/cost/ReplicaNumberCost.java
+++ b/common/src/main/java/org/astraea/common/cost/ReplicaNumberCost.java
@@ -18,9 +18,7 @@ package org.astraea.common.cost;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.astraea.common.Configuration;
 import org.astraea.common.admin.ClusterBean;
 import org.astraea.common.admin.ClusterInfo;
@@ -48,35 +46,7 @@ public class ReplicaNumberCost implements HasClusterCost, HasMoveCost {
 
   @Override
   public MoveCost moveCost(ClusterInfo before, ClusterInfo after, ClusterBean clusterBean) {
-    var moveCost =
-        Stream.concat(before.nodes().stream(), after.nodes().stream())
-            .map(NodeInfo::id)
-            .distinct()
-            .parallel()
-            .collect(
-                Collectors.toUnmodifiableMap(
-                    Function.identity(),
-                    id -> {
-                      var removedReplicas =
-                          (int)
-                              before
-                                  .replicaStream(id)
-                                  .filter(
-                                      r ->
-                                          after.replicaStream(r.topicPartitionReplica()).count()
-                                              == 0)
-                                  .count();
-                      var newReplicas =
-                          (int)
-                              after
-                                  .replicaStream(id)
-                                  .filter(
-                                      r ->
-                                          before.replicaStream(r.topicPartitionReplica()).count()
-                                              == 0)
-                                  .count();
-                      return newReplicas - removedReplicas;
-                    }));
+    var moveCost = ClusterInfo.changedReplicaNumber(before, after, ignored -> true);
     var maxMigratedReplicas =
         config.string(COST_LIMIT_KEY).map(Long::parseLong).orElse(Long.MAX_VALUE);
     var overflow =

--- a/common/src/test/java/org/astraea/common/cost/ReplicaLeaderSizeCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/ReplicaLeaderSizeCostTest.java
@@ -65,7 +65,7 @@ class ReplicaLeaderSizeCostTest {
     Assertions.assertEquals(
         3, moveCost.movedReplicaLeaderSize().size(), moveCost.movedReplicaLeaderSize().toString());
     Assertions.assertEquals(700000, moveCost.movedReplicaLeaderSize().get(0).bytes());
-    Assertions.assertEquals(-6700000, moveCost.movedReplicaLeaderSize().get(1).bytes());
+    Assertions.assertEquals(-700000, moveCost.movedReplicaLeaderSize().get(1).bytes());
     Assertions.assertEquals(6000000, moveCost.movedReplicaLeaderSize().get(2).bytes());
   }
 

--- a/common/src/test/java/org/astraea/common/cost/ReplicaLeaderSizeCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/ReplicaLeaderSizeCostTest.java
@@ -66,7 +66,7 @@ class ReplicaLeaderSizeCostTest {
         3, moveCost.movedReplicaLeaderSize().size(), moveCost.movedReplicaLeaderSize().toString());
     Assertions.assertEquals(700000, moveCost.movedReplicaLeaderSize().get(0).bytes());
     Assertions.assertEquals(-700000, moveCost.movedReplicaLeaderSize().get(1).bytes());
-    Assertions.assertEquals(6000000, moveCost.movedReplicaLeaderSize().get(2).bytes());
+    Assertions.assertEquals(0, moveCost.movedReplicaLeaderSize().get(2).bytes());
   }
 
   /*


### PR DESCRIPTION
不同成本考量中有許多程式碼非常類似，這隻PR將該些邏輯移動到`ClusterInfo`方便重複利用