### PR TITLE
[CONNECTOR] Add ClusterInfo serializer and deserializer

### DIFF
--- a/common/src/main/java/org/astraea/common/consumer/Deserializer.java
+++ b/common/src/main/java/org/astraea/common/consumer/Deserializer.java
@@ -16,12 +16,15 @@
  */
 package org.astraea.common.consumer;
 
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.DoubleDeserializer;
@@ -30,6 +33,13 @@ import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.astraea.common.Header;
+import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.admin.Config;
+import org.astraea.common.admin.NodeInfo;
+import org.astraea.common.admin.Replica;
+import org.astraea.common.admin.Topic;
+import org.astraea.common.admin.TopicPartition;
+import org.astraea.common.backup.ByteUtils;
 import org.astraea.common.json.JsonConverter;
 import org.astraea.common.json.TypeRef;
 import org.astraea.common.metrics.BeanObject;
@@ -78,6 +88,10 @@ public interface Deserializer<T> {
   Deserializer<Float> FLOAT = of(new FloatDeserializer());
   Deserializer<Double> DOUBLE = of(new DoubleDeserializer());
   Deserializer<BeanObject> BEAN_OBJECT = new BeanDeserializer();
+  Deserializer<NodeInfo> NODE_INFO = new NodeInfoDeserializer();
+  Deserializer<Topic> TOPIC = new TopicDeserializer();
+  Deserializer<Replica> REPLICA = new ReplicaDeserializer();
+  Deserializer<ClusterInfo> CLUSTER_INFO = new ClusterInfoDeserializer();
 
   /**
    * create Custom JsonDeserializer
@@ -133,6 +147,130 @@ public interface Deserializer<T> {
               .filter(kv -> kv.length >= 2)
               .collect(Collectors.toUnmodifiableMap(kv -> kv[0], kv -> (Object) kv[1]));
       return new BeanObject(domain, properties, attributes);
+    }
+  }
+
+  class NodeInfoDeserializer implements Deserializer<NodeInfo> {
+    @Override
+    public NodeInfo deserialize(String topic, List<Header> headers, byte[] data) {
+      var buffer = ByteBuffer.wrap(data);
+      var id = buffer.getInt();
+      var host = ByteUtils.readString(buffer, buffer.getShort());
+      var port = buffer.getInt();
+      return NodeInfo.of(id, host, port);
+    }
+  }
+
+  class TopicDeserializer implements Deserializer<Topic> {
+
+    @Override
+    public Topic deserialize(String topic, List<Header> headers, byte[] data) {
+      var buffer = ByteBuffer.wrap(data);
+      var name = ByteUtils.readString(buffer, buffer.getShort());
+      var config =
+          IntStream.range(0, buffer.getInt())
+              .boxed()
+              .collect(
+                  Collectors.toMap(
+                      i -> ByteUtils.readString(buffer, buffer.getShort()),
+                      i -> ByteUtils.readString(buffer, buffer.getShort())));
+      var internal = buffer.get() != 0;
+      var topicPartitions =
+          IntStream.range(0, buffer.getInt())
+              .mapToObj(i -> TopicPartition.of(name, buffer.getInt()))
+              .collect(Collectors.toSet());
+      return new Topic() {
+        @Override
+        public String name() {
+          return name;
+        }
+
+        @Override
+        public Config config() {
+          return Config.of(config);
+        }
+
+        @Override
+        public boolean internal() {
+          return internal;
+        }
+
+        @Override
+        public Set<TopicPartition> topicPartitions() {
+          return topicPartitions;
+        }
+      };
+    }
+  }
+
+  class ReplicaDeserializer implements Deserializer<Replica> {
+
+    @Override
+    public Replica deserialize(String topic, List<Header> headers, byte[] data) {
+      var buffer = ByteBuffer.wrap(data);
+      var topicName = ByteUtils.readString(buffer, buffer.getShort());
+      var partition = buffer.getInt();
+      var nodeInfoData = new byte[buffer.getInt()];
+      buffer.get(nodeInfoData);
+      var nodeInfo = Deserializer.NODE_INFO.deserialize(topic, headers, nodeInfoData);
+      var lag = buffer.getLong();
+      var size = buffer.getLong();
+      var isLeader = buffer.get() != 0;
+      var isSync = buffer.get() != 0;
+      var isFuture = buffer.get() != 0;
+      var isOffline = buffer.get() != 0;
+      var isPreferredLeader = buffer.get() != 0;
+      var path = ByteUtils.readString(buffer, buffer.getShort());
+      return Replica.builder()
+          .topic(topicName)
+          .partition(partition)
+          .nodeInfo(nodeInfo)
+          .lag(lag)
+          .size(size)
+          .isLeader(isLeader)
+          .isSync(isSync)
+          .isFuture(isFuture)
+          .isOffline(isOffline)
+          .isPreferredLeader(isPreferredLeader)
+          .path(path)
+          .build();
+    }
+  }
+
+  class ClusterInfoDeserializer implements Deserializer<ClusterInfo> {
+
+    @Override
+    public ClusterInfo deserialize(String topic, List<Header> headers, byte[] data) {
+      var buffer = ByteBuffer.wrap(data);
+      var clusterId = ByteUtils.readString(buffer, buffer.getShort());
+      var nodes =
+          IntStream.range(0, buffer.getInt())
+              .mapToObj(
+                  i -> {
+                    var nodeInfoData = new byte[buffer.getInt()];
+                    buffer.get(nodeInfoData);
+                    return Deserializer.NODE_INFO.deserialize(topic, headers, nodeInfoData);
+                  })
+              .collect(Collectors.toUnmodifiableList());
+      var topics =
+          IntStream.range(0, buffer.getInt())
+              .mapToObj(
+                  i -> {
+                    var topicData = new byte[buffer.getInt()];
+                    buffer.get(topicData);
+                    return Deserializer.TOPIC.deserialize(topic, headers, topicData);
+                  })
+              .collect(Collectors.toMap(Topic::name, s -> s));
+      var replicas =
+          IntStream.range(0, buffer.getInt())
+              .mapToObj(
+                  i -> {
+                    var replicaData = new byte[buffer.getInt()];
+                    buffer.get(replicaData);
+                    return Deserializer.REPLICA.deserialize(topic, headers, replicaData);
+                  })
+              .collect(Collectors.toList());
+      return ClusterInfo.of(clusterId, nodes, topics, replicas);
     }
   }
 }

--- a/common/src/main/java/org/astraea/common/producer/Serializer.java
+++ b/common/src/main/java/org/astraea/common/producer/Serializer.java
@@ -16,9 +16,11 @@
  */
 package org.astraea.common.producer;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.DoubleSerializer;
@@ -28,6 +30,11 @@ import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.astraea.common.Header;
 import org.astraea.common.Utils;
+import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.admin.NodeInfo;
+import org.astraea.common.admin.Replica;
+import org.astraea.common.admin.Topic;
+import org.astraea.common.backup.ByteUtils;
 import org.astraea.common.json.JsonConverter;
 import org.astraea.common.json.TypeRef;
 
@@ -69,6 +76,10 @@ public interface Serializer<T> {
   Serializer<Long> LONG = of(new LongSerializer());
   Serializer<Float> FLOAT = of(new FloatSerializer());
   Serializer<Double> DOUBLE = of(new DoubleSerializer());
+  Serializer<NodeInfo> NODE_INFO = new NodeInfoSerializer();
+  Serializer<Topic> TOPIC = new TopicSerializer();
+  Serializer<Replica> REPLICA = new ReplicaSerializer();
+  Serializer<ClusterInfo> CLUSTER_INFO = new ClusterInfoSerializer();
 
   /**
    * create Custom JsonSerializer
@@ -93,6 +104,147 @@ public interface Serializer<T> {
       }
 
       return Utils.packException(() -> jackson.toJson(data).getBytes(encoding));
+    }
+  }
+
+  class NodeInfoSerializer implements Serializer<NodeInfo> {
+
+    @Override
+    public byte[] serialize(String topic, Collection<Header> headers, NodeInfo data) {
+      var nodeInfoSize =
+          4 // [id]
+              + 2 // [host length]
+              + ByteUtils.toBytes(data.host()).length // [host]
+              + 4; // [port]
+      var buffer = ByteBuffer.allocate(nodeInfoSize);
+      buffer.putInt(data.id());
+      ByteUtils.putLengthString(buffer, data.host());
+      buffer.putInt(data.port());
+      return buffer.array();
+    }
+  }
+
+  class TopicSerializer implements Serializer<Topic> {
+
+    @Override
+    public byte[] serialize(String topic, Collection<Header> headers, Topic data) {
+      var configSize =
+          data.config().raw().entrySet().stream()
+              .mapToInt(
+                  entry ->
+                      2
+                          + ByteUtils.toBytes(entry.getKey()).length
+                          + 2
+                          + ByteUtils.toBytes(entry.getValue()).length)
+              .sum();
+      var topicSize =
+          2 // [topic length]
+              + ByteUtils.toBytes(data.name()).length // [topic]
+              + 4 // [nums of config]
+              + configSize // [config]
+              + 1 // [internal]
+              + 4 // [nums of topicPartitions]
+              + 4 * 4; // [nums * partitions]
+      var buffer = ByteBuffer.allocate(topicSize);
+      ByteUtils.putLengthString(buffer, data.name());
+      buffer.putInt(data.config().raw().size());
+      data.config()
+          .raw()
+          .forEach(
+              (key, value) -> {
+                ByteUtils.putLengthString(buffer, key);
+                ByteUtils.putLengthString(buffer, value);
+              });
+      buffer.put(ByteUtils.toBytes(data.internal()));
+      buffer.putInt(data.topicPartitions().size());
+      data.topicPartitions().forEach(tp -> buffer.putInt(tp.partition()));
+      return buffer.array();
+    }
+  }
+
+  class ReplicaSerializer implements Serializer<Replica> {
+
+    @Override
+    public byte[] serialize(String topic, Collection<Header> headers, Replica data) {
+      var nodeInfo = Serializer.NODE_INFO.serialize(topic, headers, data.nodeInfo());
+      var replicaSize =
+          2 // [topic length]
+              + ByteUtils.toBytes(topic).length // [topic]
+              + 4 // [partition]
+              + 4 // [nodeInfo length]
+              + nodeInfo.length // [nodeInfo]
+              + 8 // [lag]
+              + 8 // [size]
+              + 1 // [isLeader]
+              + 1 // [isSync]
+              + 1 // [isFuture]
+              + 1 // [isOffline]
+              + 1 // [isPreferredLeader]
+              + 2 // [path length]
+              + ByteUtils.toBytes(data.path()).length; // [path]
+      var buffer = ByteBuffer.allocate(replicaSize);
+      ByteUtils.putLengthString(buffer, topic);
+      buffer.putInt(data.partition());
+      buffer.putInt(nodeInfo.length);
+      buffer.put(nodeInfo);
+      buffer.putLong(data.lag());
+      buffer.putLong(data.size());
+      buffer.put(ByteUtils.toBytes(data.isLeader()));
+      buffer.put(ByteUtils.toBytes(data.isSync()));
+      buffer.put(ByteUtils.toBytes(data.isFuture()));
+      buffer.put(ByteUtils.toBytes(data.isOffline()));
+      buffer.put(ByteUtils.toBytes(data.isPreferredLeader()));
+      ByteUtils.putLengthString(buffer, data.path());
+      return buffer.array();
+    }
+  }
+
+  class ClusterInfoSerializer implements Serializer<ClusterInfo> {
+
+    @Override
+    public byte[] serialize(String topic, Collection<Header> headers, ClusterInfo data) {
+      var nodes =
+          data.nodes().stream()
+              .map(nodeInfo -> Serializer.NODE_INFO.serialize(topic, headers, nodeInfo))
+              .collect(Collectors.toList());
+      var topics =
+          data.topics().values().stream()
+              .map(t -> Serializer.TOPIC.serialize(topic, headers, t))
+              .collect(Collectors.toList());
+      var replicas =
+          data.replicas().stream()
+              .map(replica -> Serializer.REPLICA.serialize(replica.topic(), headers, replica))
+              .collect(Collectors.toList());
+      var clusterInfoSize =
+          2 // [clusterId length]
+              + ByteUtils.toBytes(data.clusterId()).length // [clusterId]
+              + 4 // [nums of nodeInfo]
+              + nodes.stream().mapToInt(bytes -> 4 + bytes.length).sum() // [nodeInfo]
+              + 4 // [nums of topic]
+              + topics.stream().mapToInt(bytes -> 4 + bytes.length).sum() // [topics]
+              + 4 // [nums of replica]
+              + replicas.stream().mapToInt(bytes -> 4 + bytes.length).sum(); // [replicas]
+      var buffer = ByteBuffer.allocate(clusterInfoSize);
+      ByteUtils.putLengthString(buffer, data.clusterId());
+      buffer.putInt(nodes.size());
+      nodes.forEach(
+          bytes -> {
+            buffer.putInt(bytes.length);
+            buffer.put(bytes);
+          });
+      buffer.putInt(topics.size());
+      topics.forEach(
+          bytes -> {
+            buffer.putInt(bytes.length);
+            buffer.put(bytes);
+          });
+      buffer.putInt(replicas.size());
+      replicas.forEach(
+          bytes -> {
+            buffer.putInt(bytes.length);
+            buffer.put(bytes);
+          });
+      return buffer.array();
     }
   }
 }

--- a/common/src/test/java/org/astraea/common/serializer/ClusterInfoSerializerTest.java
+++ b/common/src/test/java/org/astraea/common/serializer/ClusterInfoSerializerTest.java
@@ -19,12 +19,15 @@ package org.astraea.common.serializer;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.kafka.common.Node;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
+import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.backup.ByteUtils;
@@ -243,5 +246,17 @@ public class ClusterInfoSerializerTest {
           clusterInfo.topics().keySet(), deserializedClusterInfo.topics().keySet());
       Assertions.assertTrue(deserializedClusterInfo.replicas().containsAll(clusterInfo.replicas()));
     }
+  }
+
+  @Test
+  void testSerializeEmptyClusterInfo(){
+    var clusterInfo = ClusterInfo.empty();
+    var serializedInfo = Serializer.CLUSTER_INFO.serialize("topic", Collections.emptyList(), clusterInfo);
+    var deserializedClusterInfo = Deserializer.CLUSTER_INFO.deserialize("topic", Collections.emptyList(), serializedInfo);
+
+    Assertions.assertEquals(clusterInfo.clusterId(), deserializedClusterInfo.clusterId());
+    Assertions.assertEquals(clusterInfo.nodes(), deserializedClusterInfo.nodes());
+    Assertions.assertEquals(clusterInfo.topics(), deserializedClusterInfo.topics());
+    Assertions.assertEquals(clusterInfo.replicas(), deserializedClusterInfo.replicas());
   }
 }

--- a/common/src/test/java/org/astraea/common/serializer/ClusterInfoSerializerTest.java
+++ b/common/src/test/java/org/astraea/common/serializer/ClusterInfoSerializerTest.java
@@ -19,8 +19,6 @@ package org.astraea.common.serializer;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -249,10 +247,12 @@ public class ClusterInfoSerializerTest {
   }
 
   @Test
-  void testSerializeEmptyClusterInfo(){
+  void testSerializeEmptyClusterInfo() {
     var clusterInfo = ClusterInfo.empty();
-    var serializedInfo = Serializer.CLUSTER_INFO.serialize("topic", Collections.emptyList(), clusterInfo);
-    var deserializedClusterInfo = Deserializer.CLUSTER_INFO.deserialize("topic", Collections.emptyList(), serializedInfo);
+    var serializedInfo =
+        Serializer.CLUSTER_INFO.serialize("topic", Collections.emptyList(), clusterInfo);
+    var deserializedClusterInfo =
+        Deserializer.CLUSTER_INFO.deserialize("topic", Collections.emptyList(), serializedInfo);
 
     Assertions.assertEquals(clusterInfo.clusterId(), deserializedClusterInfo.clusterId());
     Assertions.assertEquals(clusterInfo.nodes(), deserializedClusterInfo.nodes());

--- a/common/src/test/java/org/astraea/common/serializer/ClusterInfoSerializerTest.java
+++ b/common/src/test/java/org/astraea/common/serializer/ClusterInfoSerializerTest.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.serializer;
+
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.kafka.common.Node;
+import org.astraea.common.Utils;
+import org.astraea.common.admin.Admin;
+import org.astraea.common.admin.NodeInfo;
+import org.astraea.common.admin.TopicPartition;
+import org.astraea.common.backup.ByteUtils;
+import org.astraea.common.consumer.Deserializer;
+import org.astraea.common.producer.Serializer;
+import org.astraea.it.Service;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ClusterInfoSerializerTest {
+  private static final Service SERVICE = Service.builder().numberOfBrokers(3).build();
+
+  @AfterAll
+  static void closeService() {
+    SERVICE.close();
+  }
+
+  @Test
+  void testNodeInfoSerializer() {
+    var nodeInfo = NodeInfo.of(new Node(10, "host", 100));
+    var serializedNodeInfo =
+        Serializer.NODE_INFO.serialize("topic", Collections.emptyList(), nodeInfo);
+    var buffer = ByteBuffer.wrap(serializedNodeInfo);
+
+    Assertions.assertEquals(10, buffer.getInt());
+    Assertions.assertEquals("host", ByteUtils.readString(buffer, buffer.getShort()));
+    Assertions.assertEquals(100, buffer.getInt());
+  }
+
+  @Test
+  void testNodeInfoDeserializer() {
+    var nodeInfo = NodeInfo.of(new Node(10, "host", 100));
+    var serializedNodeInfo =
+        Serializer.NODE_INFO.serialize("topic", Collections.emptyList(), nodeInfo);
+    var deserializedNodeInfo =
+        Deserializer.NODE_INFO.deserialize("topic", Collections.emptyList(), serializedNodeInfo);
+
+    Assertions.assertEquals(nodeInfo, deserializedNodeInfo);
+  }
+
+  @Test
+  void testTopicSerializer() {
+    var topicName = Utils.randomString();
+    try (var admin = Admin.of(SERVICE.bootstrapServers())) {
+      admin
+          .creator()
+          .topic(topicName)
+          .numberOfPartitions(3)
+          .numberOfReplicas((short) 1)
+          .run()
+          .toCompletableFuture()
+          .join();
+      Utils.sleep(Duration.ofSeconds(1));
+      var topic = admin.topics(Set.of(topicName)).toCompletableFuture().join().get(0);
+      var serializedTopic = Serializer.TOPIC.serialize("topic", Collections.emptyList(), topic);
+      var buffer = ByteBuffer.wrap(serializedTopic);
+
+      Assertions.assertEquals(topic.name(), ByteUtils.readString(buffer, buffer.getShort()));
+      var config =
+          IntStream.range(0, buffer.getInt())
+              .boxed()
+              .collect(
+                  Collectors.toMap(
+                      i -> ByteUtils.readString(buffer, buffer.getShort()),
+                      i -> ByteUtils.readString(buffer, buffer.getShort())));
+
+      Assertions.assertEquals(topic.config().raw(), config);
+      Assertions.assertEquals(topic.internal(), buffer.get() != 0);
+      var topicPartitions =
+          IntStream.range(0, buffer.getInt())
+              .mapToObj(i -> TopicPartition.of(topicName, buffer.getInt()))
+              .collect(Collectors.toSet());
+
+      Assertions.assertEquals(topic.topicPartitions(), topicPartitions);
+    }
+  }
+
+  @Test
+  void testTopicDeserializer() {
+    var topicName = Utils.randomString();
+    try (var admin = Admin.of(SERVICE.bootstrapServers())) {
+      admin
+          .creator()
+          .topic(topicName)
+          .numberOfPartitions(3)
+          .numberOfReplicas((short) 1)
+          .run()
+          .toCompletableFuture()
+          .join();
+      Utils.sleep(Duration.ofSeconds(1));
+      var topic = admin.topics(Set.of(topicName)).toCompletableFuture().join().get(0);
+      var serializedTopic = Serializer.TOPIC.serialize("topic", Collections.emptyList(), topic);
+      var deserializedTopic =
+          Deserializer.TOPIC.deserialize("topic", Collections.emptyList(), serializedTopic);
+
+      Assertions.assertEquals(topic.name(), deserializedTopic.name());
+      Assertions.assertEquals(topic.config().raw(), deserializedTopic.config().raw());
+      Assertions.assertEquals(topic.internal(), topic.internal());
+      Assertions.assertEquals(topic.topicPartitions(), deserializedTopic.topicPartitions());
+    }
+  }
+
+  @Test
+  void testReplicaSerializer() {
+    var topic = Utils.randomString();
+    try (var admin = Admin.of(SERVICE.bootstrapServers())) {
+      admin
+          .creator()
+          .topic(topic)
+          .numberOfPartitions(1)
+          .numberOfReplicas((short) 1)
+          .run()
+          .toCompletableFuture()
+          .join();
+      Utils.sleep(Duration.ofSeconds(1));
+      var replica = admin.clusterInfo(Set.of(topic)).toCompletableFuture().join().replicas().get(0);
+      var serializedReplica =
+          Serializer.REPLICA.serialize(replica.topic(), Collections.emptyList(), replica);
+      var buffer = ByteBuffer.wrap(serializedReplica);
+
+      Assertions.assertEquals(replica.topic(), ByteUtils.readString(buffer, buffer.getShort()));
+      Assertions.assertEquals(replica.partition(), buffer.getInt());
+      buffer.get(new byte[buffer.getInt()]);
+      Assertions.assertEquals(replica.lag(), buffer.getLong());
+      Assertions.assertEquals(replica.size(), buffer.getLong());
+      Assertions.assertEquals(replica.isLeader(), buffer.get() != 0);
+      Assertions.assertEquals(replica.isSync(), buffer.get() != 0);
+      Assertions.assertEquals(replica.isFuture(), buffer.get() != 0);
+      Assertions.assertEquals(replica.isOffline(), buffer.get() != 0);
+      Assertions.assertEquals(replica.isPreferredLeader(), buffer.get() != 0);
+      Assertions.assertEquals(replica.path(), ByteUtils.readString(buffer, buffer.getShort()));
+    }
+  }
+
+  @Test
+  void testReplicaDeserializer() {
+    var topic = Utils.randomString();
+    try (var admin = Admin.of(SERVICE.bootstrapServers())) {
+      admin
+          .creator()
+          .topic(topic)
+          .numberOfPartitions(1)
+          .numberOfReplicas((short) 1)
+          .run()
+          .toCompletableFuture()
+          .join();
+      Utils.sleep(Duration.ofSeconds(1));
+      var replica = admin.clusterInfo(Set.of(topic)).toCompletableFuture().join().replicas().get(0);
+      var serializedReplica =
+          Serializer.REPLICA.serialize(replica.topic(), Collections.emptyList(), replica);
+      var deserializedReplica =
+          Deserializer.REPLICA.deserialize(
+              replica.topic(), Collections.emptyList(), serializedReplica);
+
+      Assertions.assertEquals(replica, deserializedReplica);
+    }
+  }
+
+  @Test
+  void testClusterInfoSerializer() {
+    var topic = Utils.randomString();
+    try (var admin = Admin.of(SERVICE.bootstrapServers())) {
+      admin
+          .creator()
+          .topic(topic)
+          .numberOfPartitions(1)
+          .numberOfReplicas((short) 3)
+          .run()
+          .toCompletableFuture()
+          .join();
+      Utils.sleep(Duration.ofSeconds(1));
+      var clusterInfo = admin.clusterInfo(Set.of(topic)).toCompletableFuture().join();
+      var serializedClusterInfo =
+          Serializer.CLUSTER_INFO.serialize("topic", Collections.emptyList(), clusterInfo);
+      var buffer = ByteBuffer.wrap(serializedClusterInfo);
+
+      Assertions.assertEquals(
+          clusterInfo.clusterId(), ByteUtils.readString(buffer, buffer.getShort()));
+      Assertions.assertEquals(clusterInfo.nodes().size(), buffer.getInt());
+      IntStream.range(0, clusterInfo.nodes().size())
+          .forEach(i -> buffer.get(new byte[buffer.getInt()]));
+      Assertions.assertEquals(clusterInfo.topics().size(), buffer.getInt());
+      IntStream.range(0, clusterInfo.topics().size())
+          .forEach(i -> buffer.get(new byte[buffer.getInt()]));
+      Assertions.assertEquals(clusterInfo.replicas().size(), buffer.getInt());
+      IntStream.range(0, clusterInfo.replicas().size())
+          .forEach(i -> buffer.get(new byte[buffer.getInt()]));
+      Assertions.assertEquals(0, buffer.remaining());
+    }
+  }
+
+  @Test
+  void testClusterInfoDeserializer() {
+    var topic = Utils.randomString();
+    try (var admin = Admin.of(SERVICE.bootstrapServers())) {
+      admin
+          .creator()
+          .topic(topic)
+          .numberOfPartitions(1)
+          .numberOfReplicas((short) 3)
+          .run()
+          .toCompletableFuture()
+          .join();
+      Utils.sleep(Duration.ofSeconds(1));
+      var clusterInfo = admin.clusterInfo(Set.of(topic)).toCompletableFuture().join();
+      var serializedClusterInfo =
+          Serializer.CLUSTER_INFO.serialize("topic", Collections.emptyList(), clusterInfo);
+      var deserializedClusterInfo =
+          Deserializer.CLUSTER_INFO.deserialize(
+              "topic", Collections.emptyList(), serializedClusterInfo);
+
+      Assertions.assertEquals(clusterInfo.clusterId(), deserializedClusterInfo.clusterId());
+      Assertions.assertTrue(clusterInfo.nodes().containsAll(deserializedClusterInfo.nodes()));
+      Assertions.assertEquals(
+          clusterInfo.topics().keySet(), deserializedClusterInfo.topics().keySet());
+      Assertions.assertTrue(deserializedClusterInfo.replicas().containsAll(clusterInfo.replicas()));
+    }
+  }
+}


### PR DESCRIPTION
related to  #1520

以下為序列化的形式
- ClusterInfo
```
+ 2 // [clusterId length]
+ n // [n bytes of clusterId]
+ 4 // [nums of NodeInfo]

  ┌ 4 + [NodeInfo] // [NodeInfo length + n bytes of NodeInfo]
  +        ⋮
  └ 4 + [NodeInfo]

+ 4 // [nums of Topic]

  ┌ 4 + [Topic] // [Topic length + n bytes of Topic]
  +        ⋮
  └ 4 + [Topic]

+ 4 // [nums of Replica]

  ┌ 4 + [Replica] // [Replica length + n bytes of Replica]
  +        ⋮
  └ 4 + [Replica]
```
- NodeInfo
```
+ 4 // [id]
+ 2 // [host length]
+ n // [n bytes of host]
+ 4 // [port]
```
- Topic
```
+ 2 // [topic length]
+ n // [n bytes of topic]
+ 4 // [nums of config]
+ n // [n bytes of config]
+ 1 // [internal]
+ 4 // [nums of topicPartitions]
+ 4 * 4 // [nums * partitions]
```
- Replica
```
+ 2 // [topic length]
+ n // [n bytes of topic]
+ 4 // [partition]
+ 4 // [nodeInfo length]
+ n // [n bytes of nodeInfo]
+ 8 // [lag]
+ 8 // [size]
+ 1 // [isLeader]
+ 1 // [isSync]
+ 1 // [isFuture]
+ 1 // [isOffline]
+ 1 // [isPreferredLeader]
+ 2 // [path length]
+ n // [n bytes of path]
```