### PR TITLE
[PRODUCER] change Metadata to interface

### DIFF
--- a/app/src/main/java/org/astraea/app/web/RecordHandler.java
+++ b/app/src/main/java/org/astraea/app/web/RecordHandler.java
@@ -379,7 +379,7 @@ public class RecordHandler implements Handler {
     final String topic;
     final int partition;
     final long offset;
-    final long timestamp;
+    final Optional<Long> timestamp;
     final int serializedKeySize;
     final int serializedValueSize;
 

--- a/common/src/main/java/org/astraea/common/producer/Metadata.java
+++ b/common/src/main/java/org/astraea/common/producer/Metadata.java
@@ -16,40 +16,43 @@
  */
 package org.astraea.common.producer;
 
+import java.util.Optional;
 import org.apache.kafka.clients.producer.RecordMetadata;
 
-public final class Metadata {
+public interface Metadata {
 
-  public static Metadata of(RecordMetadata metadata) {
-    return new Metadata(
-        metadata.offset(),
-        metadata.timestamp(),
-        metadata.serializedKeySize(),
-        metadata.serializedValueSize(),
-        metadata.topic(),
-        metadata.partition());
-  }
+  static Metadata of(RecordMetadata metadata) {
+    return new Metadata() {
+      @Override
+      public long offset() {
+        return metadata.offset();
+      }
 
-  private final long offset;
-  private final long timestamp;
-  private final int serializedKeySize;
-  private final int serializedValueSize;
-  private final String topic;
-  private final int partition;
+      @Override
+      public int serializedKeySize() {
+        return metadata.serializedKeySize();
+      }
 
-  Metadata(
-      long offset,
-      long timestamp,
-      int serializedKeySize,
-      int serializedValueSize,
-      String topic,
-      int partition) {
-    this.offset = offset;
-    this.timestamp = timestamp;
-    this.serializedKeySize = serializedKeySize;
-    this.serializedValueSize = serializedValueSize;
-    this.topic = topic;
-    this.partition = partition;
+      @Override
+      public int serializedValueSize() {
+        return metadata.serializedValueSize();
+      }
+
+      @Override
+      public Optional<Long> timestamp() {
+        return metadata.hasTimestamp() ? Optional.of(metadata.timestamp()) : Optional.empty();
+      }
+
+      @Override
+      public String topic() {
+        return metadata.topic();
+      }
+
+      @Override
+      public int partition() {
+        return metadata.partition();
+      }
+    };
   }
 
   /**
@@ -57,44 +60,32 @@ public final class Metadata {
    *
    * @return the offset of the record, or -1
    */
-  public long offset() {
-    return this.offset;
-  }
+  long offset();
 
   /**
    * @return The size of the serialized, uncompressed key in bytes. If key is null, the returned
    *     size is -1.
    */
-  public int serializedKeySize() {
-    return serializedKeySize;
-  }
+  int serializedKeySize();
 
   /**
    * @return The size of the serialized, uncompressed value in bytes. If value is null, the returned
    *     size is -1.
    */
-  public int serializedValueSize() {
-    return serializedValueSize;
-  }
+  int serializedValueSize();
 
   /**
    * @return the timestamp of the record
    */
-  public long timestamp() {
-    return timestamp;
-  }
+  Optional<Long> timestamp();
 
   /**
    * @return The topic the record was appended to
    */
-  public String topic() {
-    return topic;
-  }
+  String topic();
 
   /**
    * @return The partition the record was sent to
    */
-  public int partition() {
-    return partition;
-  }
+  int partition();
 }

--- a/common/src/test/java/org/astraea/common/partitioner/PartitionerTest.java
+++ b/common/src/test/java/org/astraea/common/partitioner/PartitionerTest.java
@@ -138,7 +138,7 @@ public class PartitionerTest {
                       Metadata metadata;
                       metadata = producerSend(producer, topicName, key, value, timestamp, header);
                       assertEquals(topicName, metadata.topic());
-                      assertEquals(timestamp, metadata.timestamp());
+                      assertEquals(timestamp, metadata.timestamp().get());
                       assertEquals(exceptPartition, metadata.partition());
                     });
             Partitioner.endInterdependent(instanceOfProducer(producer));
@@ -158,7 +158,7 @@ public class PartitionerTest {
                 Metadata metadata;
                 metadata = producerSend(producer, topicName, key, value, timestamp, header);
                 assertEquals(topicName, metadata.topic());
-                assertEquals(timestamp, metadata.timestamp());
+                assertEquals(timestamp, metadata.timestamp().get());
                 assertEquals(exceptPartition, metadata.partition());
               });
       Partitioner.endInterdependent(instanceOfProducer(producer));
@@ -189,7 +189,7 @@ public class PartitionerTest {
                 Metadata metadata;
                 metadata = producerSend(producer, topicName, key, value, timestamp, header);
                 assertEquals(topicName, metadata.topic());
-                assertEquals(timestamp, metadata.timestamp());
+                assertEquals(timestamp, metadata.timestamp().get());
               });
       Partitioner.beginInterdependent(instanceOfProducer(producer));
       var exceptPartition =
@@ -200,7 +200,7 @@ public class PartitionerTest {
                 Metadata metadata;
                 metadata = producerSend(producer, topicName, key, value, timestamp, header);
                 assertEquals(topicName, metadata.topic());
-                assertEquals(timestamp, metadata.timestamp());
+                assertEquals(timestamp, metadata.timestamp().get());
                 assertEquals(exceptPartition, metadata.partition());
               });
       Partitioner.endInterdependent(instanceOfProducer(producer));
@@ -210,7 +210,7 @@ public class PartitionerTest {
                 Metadata metadata;
                 metadata = producerSend(producer, topicName, key, value, timestamp, header);
                 assertEquals(topicName, metadata.topic());
-                assertEquals(timestamp, metadata.timestamp());
+                assertEquals(timestamp, metadata.timestamp().get());
               });
       Partitioner.beginInterdependent(instanceOfProducer(producer));
       var exceptPartitionSec =
@@ -221,7 +221,7 @@ public class PartitionerTest {
                 Metadata metadata;
                 metadata = producerSend(producer, topicName, key, value, timestamp, header);
                 assertEquals(topicName, metadata.topic());
-                assertEquals(timestamp, metadata.timestamp());
+                assertEquals(timestamp, metadata.timestamp().get());
                 assertEquals(exceptPartitionSec, metadata.partition());
               });
       Partitioner.endInterdependent(instanceOfProducer(producer));

--- a/common/src/test/java/org/astraea/common/producer/ProducerTest.java
+++ b/common/src/test/java/org/astraea/common/producer/ProducerTest.java
@@ -72,7 +72,7 @@ public class ProducerTest {
               .toCompletableFuture()
               .join();
       Assertions.assertEquals(topicName, metadata.topic());
-      Assertions.assertEquals(timestamp, metadata.timestamp());
+      Assertions.assertEquals(timestamp, metadata.timestamp().get());
     }
 
     try (var consumer =

--- a/gui/src/main/java/org/astraea/gui/tab/ClientNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/ClientNode.java
@@ -432,11 +432,15 @@ public class ClientNode {
                                           result.put("topic", metadata.topic());
                                           result.put("partition", metadata.partition());
                                           result.put("offset", metadata.offset());
-                                          result.put(
-                                              "timestamp",
-                                              LocalDateTime.ofInstant(
-                                                  Instant.ofEpochMilli(metadata.timestamp()),
-                                                  ZoneId.systemDefault()));
+                                          metadata
+                                              .timestamp()
+                                              .ifPresent(
+                                                  t ->
+                                                      result.put(
+                                                          "timestamp",
+                                                          LocalDateTime.ofInstant(
+                                                              Instant.ofEpochMilli(t),
+                                                              ZoneId.systemDefault())));
                                           result.put(
                                               "serializedKeySize",
                                               DataSize.Byte.of(metadata.serializedKeySize()));


### PR DESCRIPTION
related to #1586

`Metadata`是一個常用的資料格式，改成 interface 並搭配 proxy 模式來避免預先建立太多物件