### PR TITLE
[METRICS] a new infra for metrics collector

### DIFF
--- a/common/src/main/java/org/astraea/common/metrics/MBeanClient.java
+++ b/common/src/main/java/org/astraea/common/metrics/MBeanClient.java
@@ -22,7 +22,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.management.MBeanFeatureInfo;
 import javax.management.MBeanServerConnection;
@@ -46,6 +49,44 @@ import org.astraea.common.Utils;
  * }</pre>
  */
 public interface MBeanClient extends AutoCloseable {
+  static MBeanClient of(Collection<BeanObject> objs) {
+    return new MBeanClient() {
+
+      @Override
+      public BeanObject bean(BeanQuery beanQuery) {
+        return beans(beanQuery).stream().findAny().orElseThrow(NoSuchElementException::new);
+      }
+
+      @Override
+      public Collection<BeanObject> beans(BeanQuery beanQuery) {
+        // The queried domain name (or properties) may contain wildcard. Change wildcard to regular
+        // expression.
+        var wildCardDomain =
+            Pattern.compile(beanQuery.domainName().replaceAll("[*]", ".*").replaceAll("[?]", "."));
+        var wildCardProperties =
+            beanQuery.properties().entrySet().stream()
+                .collect(
+                    Collectors.toUnmodifiableMap(
+                        Map.Entry::getKey,
+                        e ->
+                            Pattern.compile(
+                                e.getValue().replaceAll("[*]", ".*").replaceAll("[?]", "."))));
+        // Filtering out beanObject that match the query
+        return objs.stream()
+            .filter(storedEntry -> wildCardDomain.matcher(storedEntry.domainName()).matches())
+            .filter(
+                storedEntry ->
+                    wildCardProperties.entrySet().stream()
+                        .allMatch(
+                            e ->
+                                storedEntry.properties().containsKey(e.getKey())
+                                    && e.getValue()
+                                        .matcher(storedEntry.properties().get(e.getKey()))
+                                        .matches()))
+            .collect(Collectors.toUnmodifiableList());
+      }
+    };
+  }
 
   /**
    * @param host the address of jmx server
@@ -67,7 +108,7 @@ public interface MBeanClient extends AutoCloseable {
     return Utils.packException(
         () -> {
           var jmxConnector = JMXConnectorFactory.connect(jmxServiceURL);
-          return new AbstractMBeanClient(
+          return new BasicMBeanClient(
               jmxConnector.getMBeanServerConnection(),
               jmxServiceURL.getHost(),
               jmxServiceURL.getPort()) {
@@ -80,11 +121,7 @@ public interface MBeanClient extends AutoCloseable {
   }
 
   static MBeanClient local() {
-    return new AbstractMBeanClient(
-        ManagementFactory.getPlatformMBeanServer(), Utils.hostname(), -1) {
-      @Override
-      public void close() {}
-    };
+    return new BasicMBeanClient(ManagementFactory.getPlatformMBeanServer(), Utils.hostname(), -1);
   }
 
   /**
@@ -113,16 +150,16 @@ public interface MBeanClient extends AutoCloseable {
   Collection<BeanObject> beans(BeanQuery beanQuery);
 
   @Override
-  void close();
+  default void close() {}
 
-  abstract class AbstractMBeanClient implements MBeanClient {
+  class BasicMBeanClient implements MBeanClient {
 
     private final MBeanServerConnection connection;
     final String host;
 
     final int port;
 
-    AbstractMBeanClient(MBeanServerConnection connection, String host, int port) {
+    BasicMBeanClient(MBeanServerConnection connection, String host, int port) {
       this.connection = connection;
       this.host = host;
       this.port = port;

--- a/common/src/main/java/org/astraea/common/metrics/collector/LocalSenderReceiver.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/LocalSenderReceiver.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.metrics.collector;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.astraea.common.Utils;
+import org.astraea.common.metrics.BeanObject;
+
+public class LocalSenderReceiver implements MetricsFetcher.Sender, MetricsStore.Receiver {
+
+  public static LocalSenderReceiver of() {
+    return new LocalSenderReceiver();
+  }
+
+  private final BlockingQueue<Map.Entry<Integer, Collection<BeanObject>>> queue =
+      new LinkedBlockingQueue<>();
+
+  private LocalSenderReceiver() {}
+
+  @Override
+  public CompletionStage<Void> send(int id, Collection<BeanObject> beans) {
+    queue.add(Map.entry(id, beans));
+    return CompletableFuture.completedStage(null);
+  }
+
+  @Override
+  public Map<Integer, Collection<BeanObject>> receive(Duration timeout) {
+    var entry = Utils.packException(() -> queue.poll(timeout.toMillis(), TimeUnit.MILLISECONDS));
+    if (entry == null) return Map.of();
+    return Map.ofEntries(entry);
+  }
+
+  public Collection<Map.Entry<Integer, Collection<BeanObject>>> current() {
+    return List.copyOf(queue);
+  }
+
+  @Override
+  public void close() {}
+}

--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricsFetcher.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricsFetcher.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.metrics.collector;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.DelayQueue;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import org.astraea.common.Utils;
+import org.astraea.common.metrics.BeanObject;
+import org.astraea.common.metrics.BeanQuery;
+import org.astraea.common.metrics.MBeanClient;
+
+public interface MetricsFetcher extends AutoCloseable {
+
+  static Builder builder() {
+    return new Builder();
+  }
+
+  Map<Integer, Collection<BeanObject>> latest();
+
+  Set<Integer> clientIds();
+
+  @Override
+  void close();
+
+  interface Sender extends AutoCloseable {
+
+    static Sender local() {
+      return LocalSenderReceiver.of();
+    }
+
+    CompletionStage<Void> send(int id, Collection<BeanObject> beans);
+
+    @Override
+    default void close() {}
+  }
+
+  class Builder {
+
+    private int threads = 4;
+
+    private Duration fetchBeanDelay = Duration.ofSeconds(1);
+    private Duration fetchMetadataDelay = Duration.ofMinutes(5);
+    private Sender sender;
+    private Supplier<Map<Integer, MBeanClient>> clientSupplier;
+
+    private Builder() {}
+
+    public Builder threads(int threads) {
+      this.threads = threads;
+      return this;
+    }
+
+    public Builder fetchBeanDelay(Duration fetchBeanDelay) {
+      this.fetchBeanDelay = fetchBeanDelay;
+      return this;
+    }
+
+    public Builder fetchMetadataDelay(Duration fetchMetadataDelay) {
+      this.fetchMetadataDelay = fetchMetadataDelay;
+      return this;
+    }
+
+    public Builder sender(Sender sender) {
+      this.sender = sender;
+      return this;
+    }
+
+    public Builder clientSupplier(Supplier<Map<Integer, MBeanClient>> clientSupplier) {
+      this.clientSupplier = clientSupplier;
+      return this;
+    }
+
+    public MetricsFetcher build() {
+      return new MetricsFetcherImpl(
+          threads,
+          Objects.requireNonNull(fetchBeanDelay, "fetchBeanDelay can't be null"),
+          Objects.requireNonNull(fetchMetadataDelay, "fetchMetadataDelay can't be null"),
+          Objects.requireNonNull(sender, "sends can't be null"),
+          Objects.requireNonNull(clientSupplier, "clientSupplier can't be null"));
+    }
+  }
+
+  class MetricsFetcherImpl implements MetricsFetcher {
+    private volatile Map<Integer, MBeanClient> clients = new HashMap<>();
+
+    private final Map<Integer, Collection<BeanObject>> latest = new ConcurrentHashMap<>();
+
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private final DelayQueue<DelayedIdentity> works = new DelayQueue<>();
+
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+    private final Sender sender;
+
+    private final ExecutorService executor;
+
+    private final Supplier<Map<Integer, MBeanClient>> clientSupplier;
+
+    private final Duration fetchBeanDelay;
+
+    private MetricsFetcherImpl(
+        int threads,
+        Duration fetchBeanDelay,
+        Duration fetchMetadataDelay,
+        Sender sender,
+        Supplier<Map<Integer, MBeanClient>> clientSupplier) {
+      this.fetchBeanDelay = fetchBeanDelay;
+      this.sender = sender;
+      this.clientSupplier = clientSupplier;
+      this.executor = Executors.newFixedThreadPool(threads);
+      var metadataUpdateId = -((int) System.currentTimeMillis());
+      works.put(new DelayedIdentity(Duration.ZERO, metadataUpdateId));
+      Runnable job =
+          () -> {
+            try {
+              while (!closed.get()) {
+                var identity = works.take();
+                try {
+                  if (identity.id == metadataUpdateId) {
+                    updateMetadata();
+                    continue;
+                  }
+                  updateData(identity);
+                } catch (Exception e) {
+                  // TODO: it needs better error handling
+                  e.printStackTrace();
+                } finally {
+                  works.put(
+                      new DelayedIdentity(
+                          identity.id == metadataUpdateId ? fetchMetadataDelay : fetchBeanDelay,
+                          identity.id));
+                }
+              }
+            } catch (InterruptedException ex) {
+              // swallow
+            }
+          };
+
+      IntStream.range(0, threads).forEach(ignored -> executor.execute(job));
+    }
+
+    private void updateMetadata() {
+      lock.writeLock().lock();
+      Map<Integer, MBeanClient> old;
+      try {
+        old = clients;
+        clients = clientSupplier.get();
+        clients.forEach((id, client) -> works.put(new DelayedIdentity(fetchBeanDelay, id)));
+      } finally {
+        lock.writeLock().unlock();
+      }
+      old.values().forEach(c -> Utils.swallowException(c::close));
+    }
+
+    private void updateData(DelayedIdentity identity) {
+      lock.readLock().lock();
+      Collection<BeanObject> beans;
+      try {
+        beans = clients.get(identity.id).beans(BeanQuery.all());
+      } finally {
+        lock.readLock().unlock();
+      }
+      latest.put(identity.id, beans);
+      sender.send(identity.id, beans);
+    }
+
+    @Override
+    public Map<Integer, Collection<BeanObject>> latest() {
+      return Map.copyOf(latest);
+    }
+
+    @Override
+    public Set<Integer> clientIds() {
+      return Set.copyOf(clients.keySet());
+    }
+
+    @Override
+    public void close() {
+      closed.set(true);
+      executor.shutdownNow();
+      Utils.packException(() -> executor.awaitTermination(30, TimeUnit.SECONDS));
+      clients.values().forEach(c -> Utils.swallowException(c::close));
+      sender.close();
+    }
+  }
+
+  class DelayedIdentity implements Delayed {
+    private final long deadlineNs;
+    private final int id;
+
+    private DelayedIdentity(Duration delay, int id) {
+      this.deadlineNs = delay.toNanos() + System.nanoTime();
+      this.id = id;
+    }
+
+    @Override
+    public long getDelay(TimeUnit timeUnit) {
+      return timeUnit.convert(deadlineNs - System.nanoTime(), TimeUnit.NANOSECONDS);
+    }
+
+    @Override
+    public int compareTo(Delayed delayed) {
+      return Long.compare(
+          this.getDelay(TimeUnit.NANOSECONDS), delayed.getDelay(TimeUnit.NANOSECONDS));
+    }
+  }
+}

--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricsStore.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricsStore.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.metrics.collector;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.astraea.common.Utils;
+import org.astraea.common.admin.ClusterBean;
+import org.astraea.common.metrics.BeanObject;
+import org.astraea.common.metrics.BeanQuery;
+import org.astraea.common.metrics.HasBeanObject;
+import org.astraea.common.metrics.MBeanClient;
+
+public interface MetricsStore extends AutoCloseable {
+
+  static Builder builder() {
+    return new Builder();
+  }
+
+  ClusterBean clusterBean();
+
+  @Override
+  void close();
+
+  interface Receiver extends AutoCloseable {
+
+    static MetricsFetcher.Sender local() {
+      return LocalSenderReceiver.of();
+    }
+
+    Map<Integer, Collection<BeanObject>> receive(Duration timeout);
+
+    @Override
+    default void close() {}
+  }
+
+  class Builder {
+
+    // default impl returns all input metrics
+    private Supplier<Map<MetricSensor, BiConsumer<Integer, Exception>>> sensorSupplier =
+        () ->
+            Map.of(
+                (MetricSensor)
+                    (client, bean) ->
+                        client.beans(BeanQuery.all()).stream()
+                            .map(bs -> (HasBeanObject) () -> bs)
+                            .collect(Collectors.toUnmodifiableList()),
+                (id, ignored) -> {});
+
+    private Receiver receiver;
+    private Duration beanExpiration = Duration.ofSeconds(5);
+
+    public Builder sensorSupplier(
+        Supplier<Map<MetricSensor, BiConsumer<Integer, Exception>>> sensorSupplier) {
+      this.sensorSupplier = sensorSupplier;
+      return this;
+    }
+
+    public Builder receiver(Receiver receiver) {
+      this.receiver = receiver;
+      return this;
+    }
+
+    /**
+     * Using an embedded fetcher build the receiver. The fetcher will keep fetching beans
+     * background, and it pushes all beans to store internally.
+     */
+    public Builder localReceiver() {
+      var cache = LocalSenderReceiver.of();
+      var fetcher =
+          MetricsFetcher.builder()
+              .clientSupplier(() -> Map.of(-1, MBeanClient.local()))
+              // local mode so we don't need to update metadata
+              .fetchMetadataDelay(Duration.ofDays(300))
+              .sender(cache)
+              .build();
+      return receiver(
+          new Receiver() {
+            @Override
+            public Map<Integer, Collection<BeanObject>> receive(Duration timeout) {
+              return cache.receive(timeout);
+            }
+
+            @Override
+            public void close() {
+              fetcher.close();
+            }
+          });
+    }
+
+    public Builder beanExpiration(Duration beanExpiration) {
+      this.beanExpiration = beanExpiration;
+      return this;
+    }
+
+    public MetricsStore build() {
+      return new MetricsStoreImpl(
+          Objects.requireNonNull(sensorSupplier, "sensorSupplier can't be null"),
+          Objects.requireNonNull(receiver, "receiver can't be null"),
+          Objects.requireNonNull(beanExpiration, "beanExpiration can't be null"));
+    }
+  }
+
+  class MetricsStoreImpl implements MetricsStore {
+
+    private final Map<Integer, Collection<HasBeanObject>> beans = new ConcurrentHashMap<>();
+
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private final Receiver receiver;
+
+    private final ExecutorService executor;
+
+    private MetricsStoreImpl(
+        Supplier<Map<MetricSensor, BiConsumer<Integer, Exception>>> sensorSupplier,
+        Receiver receiver,
+        Duration beanExpiration) {
+      this.receiver = receiver;
+      // receiver + cleaner
+      this.executor = Executors.newFixedThreadPool(2);
+      Runnable cleanerJob =
+          () -> {
+            while (!closed.get()) {
+              try {
+                var before = System.currentTimeMillis() - beanExpiration.toMillis();
+                this.beans
+                    .values()
+                    .forEach(
+                        bs ->
+                            bs.removeIf(
+                                hasBeanObject -> hasBeanObject.createdTimestamp() < before));
+                TimeUnit.MILLISECONDS.sleep(beanExpiration.toMillis());
+              } catch (Exception e) {
+                // TODO: it needs better error handling
+                e.printStackTrace();
+              }
+            }
+          };
+      Runnable receiverJob =
+          () -> {
+            while (!closed.get()) {
+              try {
+                var allBeans = receiver.receive(Duration.ofSeconds(3));
+                allBeans.forEach(
+                    (id, bs) -> {
+                      var client = MBeanClient.of(bs);
+                      var clusterBean = clusterBean();
+                      sensorSupplier
+                          .get()
+                          .forEach(
+                              (sensor, errorHandler) -> {
+                                try {
+                                  beans
+                                      .computeIfAbsent(id, ignored -> new ConcurrentLinkedQueue<>())
+                                      .addAll(sensor.fetch(client, clusterBean));
+                                } catch (Exception e) {
+                                  errorHandler.accept(id, e);
+                                }
+                              });
+                    });
+              } catch (Exception e) {
+                // TODO: it needs better error handling
+                e.printStackTrace();
+              }
+            }
+          };
+      executor.execute(cleanerJob);
+      executor.execute(receiverJob);
+    }
+
+    @Override
+    public ClusterBean clusterBean() {
+      return ClusterBean.of(
+          beans.entrySet().stream()
+              .filter(entry -> !entry.getValue().isEmpty())
+              .collect(
+                  Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> List.copyOf(e.getValue()))));
+    }
+
+    @Override
+    public void close() {
+      closed.set(true);
+      executor.shutdownNow();
+      Utils.packException(() -> executor.awaitTermination(30, TimeUnit.SECONDS));
+      receiver.close();
+    }
+  }
+}

--- a/common/src/test/java/org/astraea/common/metrics/MBeanClientTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/MBeanClientTest.java
@@ -152,7 +152,7 @@ class MBeanClientTest {
   @Test
   void testFetchSelectedAttributes() {
     // arrange
-    try (var client = (MBeanClient.AbstractMBeanClient) MBeanClient.of(jmxServer.getAddress())) {
+    try (var client = (MBeanClient.BasicMBeanClient) MBeanClient.of(jmxServer.getAddress())) {
       BeanQuery beanQuery =
           BeanQuery.builder().domainName("java.lang").property("type", "Memory").build();
       List<String> selectedAttribute = List.of("HeapMemoryUsage");
@@ -223,7 +223,7 @@ class MBeanClientTest {
   @Test
   void testFetchNonExistsBeans() {
     // arrange
-    try (var client = (MBeanClient.AbstractMBeanClient) MBeanClient.of(jmxServer.getAddress())) {
+    try (var client = (MBeanClient.BasicMBeanClient) MBeanClient.of(jmxServer.getAddress())) {
       BeanQuery beanQuery =
           BeanQuery.builder().domainName("java.lang").property("type", "Something").build();
 
@@ -357,7 +357,7 @@ class MBeanClientTest {
   @Test
   void testListDomains() {
     // arrange
-    try (var client = (MBeanClient.AbstractMBeanClient) MBeanClient.of(jmxServer.getAddress())) {
+    try (var client = (MBeanClient.BasicMBeanClient) MBeanClient.of(jmxServer.getAddress())) {
 
       // act
       List<String> domains = client.domains();
@@ -371,7 +371,7 @@ class MBeanClientTest {
   @Test
   void testHostAndPort() {
     // arrange
-    try (var client = (MBeanClient.AbstractMBeanClient) MBeanClient.of(jmxServer.getAddress())) {
+    try (var client = (MBeanClient.BasicMBeanClient) MBeanClient.of(jmxServer.getAddress())) {
       assertEquals(jmxServer.getAddress().getHost(), client.host);
       assertEquals(jmxServer.getAddress().getPort(), client.port);
     }

--- a/common/src/test/java/org/astraea/common/metrics/collector/LocalMetricsTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/collector/LocalMetricsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.metrics.collector;
+
+import java.time.Duration;
+import java.util.Collection;
+import org.astraea.common.Utils;
+import org.astraea.it.Service;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class LocalMetricsTest {
+
+  private static final Service SERVICE =
+      Service.builder().numberOfWorkers(1).numberOfBrokers(1).build();
+
+  @AfterAll
+  static void closeService() {
+    SERVICE.close();
+  }
+
+  @Test
+  void test() {
+    try (var store =
+        MetricsStore.builder().beanExpiration(Duration.ofSeconds(1)).localReceiver().build()) {
+      Utils.sleep(Duration.ofSeconds(3));
+      Assertions.assertNotEquals(0, store.clusterBean().all().size());
+      Assertions.assertNotEquals(
+          0, store.clusterBean().all().values().stream().mapToInt(Collection::size).sum());
+    }
+  }
+}

--- a/common/src/test/java/org/astraea/common/metrics/collector/MetricsFetcherTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/collector/MetricsFetcherTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.metrics.collector;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import org.astraea.common.Utils;
+import org.astraea.common.metrics.BeanObject;
+import org.astraea.common.metrics.MBeanClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class MetricsFetcherTest {
+
+  @Test
+  void testPublishAndClose() {
+    var beans = List.of(new BeanObject(Utils.randomString(), Map.of(), Map.of()));
+    var client = Mockito.mock(MBeanClient.class);
+    Mockito.when(client.beans(Mockito.any())).thenReturn(beans);
+    var sender = Mockito.mock(MetricsFetcher.Sender.class);
+    var queue = new ConcurrentHashMap<Integer, Collection<BeanObject>>();
+    Mockito.when(sender.send(Mockito.anyInt(), Mockito.any()))
+        .thenAnswer(
+            invocation -> {
+              queue.put(
+                  invocation.getArgument(0, Integer.class),
+                  invocation.getArgument(1, Collection.class));
+              return CompletableFuture.completedStage(null);
+            });
+    try (var fetcher =
+        MetricsFetcher.builder()
+            .sender(sender)
+            .clientSupplier(() -> Map.of(-1000, client))
+            .fetchBeanDelay(Duration.ofSeconds(1))
+            .build()) {
+      Utils.sleep(Duration.ofSeconds(3));
+      Assertions.assertEquals(Set.of(-1000), fetcher.clientIds());
+      Assertions.assertNotEquals(0, queue.size());
+      queue.values().forEach(es -> Assertions.assertEquals(beans, es));
+
+      var latest = fetcher.latest();
+      Assertions.assertEquals(1, latest.size());
+      latest.values().forEach(bs -> Assertions.assertEquals(beans, bs));
+    }
+    // make sure client get closed
+    Mockito.verify(client, Mockito.times(1)).close();
+    // make sure sender get closed
+    Mockito.verify(sender, Mockito.times(1)).close();
+  }
+
+  @Test
+  void testNullCheck() {
+    var builder = MetricsFetcher.builder();
+    Assertions.assertThrows(NullPointerException.class, builder::build);
+    builder.sender(MetricsFetcher.Sender.local());
+    Assertions.assertThrows(NullPointerException.class, builder::build);
+    builder.clientSupplier(Map::of);
+    var fetcher = builder.build();
+    fetcher.close();
+  }
+
+  @Test
+  void testFetchBeanDelay() {
+    var client = Mockito.mock(MBeanClient.class);
+    try (var fetcher =
+        MetricsFetcher.builder()
+            .sender(MetricsFetcher.Sender.local())
+            .clientSupplier(() -> Map.of(-1000, client))
+            .fetchBeanDelay(Duration.ofSeconds(1000))
+            .build()) {
+      Utils.sleep(Duration.ofSeconds(3));
+      Assertions.assertEquals(1, fetcher.clientIds().size());
+      Assertions.assertEquals(0, fetcher.latest().size());
+      // make sure client is not called
+      Mockito.verify(client, Mockito.never()).beans(Mockito.any());
+    }
+  }
+
+  @Test
+  void testFetchMetadataDelay() {
+    var client = Mockito.mock(MBeanClient.class);
+    Supplier<Map<Integer, MBeanClient>> supplier = Mockito.mock(Supplier.class);
+    Mockito.when(supplier.get()).thenReturn(Map.of(-1000, client));
+    try (var fetcher =
+        MetricsFetcher.builder()
+            .sender(MetricsFetcher.Sender.local())
+            .clientSupplier(supplier)
+            .fetchMetadataDelay(Duration.ofSeconds(1000))
+            .build()) {
+      Utils.sleep(Duration.ofSeconds(3));
+      // the metadata is get updated immediately
+      Assertions.assertEquals(1, fetcher.clientIds().size());
+      // the delay is too larger to see next update
+      Mockito.verify(supplier, Mockito.times(1)).get();
+    }
+  }
+}

--- a/common/src/test/java/org/astraea/common/metrics/collector/MetricsStoreTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/collector/MetricsStoreTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.metrics.collector;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.astraea.common.Utils;
+import org.astraea.common.metrics.BeanObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class MetricsStoreTest {
+
+  @Test
+  void testReceiveAndClose() {
+    var bean = new BeanObject(Utils.randomString(), Map.of(), Map.of());
+    var queue = new LinkedBlockingQueue<Map<Integer, Collection<BeanObject>>>();
+    queue.add(Map.of(1000, List.of(bean)));
+    var receiver = Mockito.mock(MetricsStore.Receiver.class);
+    Mockito.when(receiver.receive(Mockito.any()))
+        .thenAnswer(invocation -> Utils.packException(queue::take));
+    try (var store =
+        MetricsStore.builder().receiver(receiver).beanExpiration(Duration.ofSeconds(100)).build()) {
+      Utils.sleep(Duration.ofSeconds(3));
+      Assertions.assertEquals(1, store.clusterBean().all().size());
+      Assertions.assertEquals(Set.of(1000), store.clusterBean().all().keySet());
+      Assertions.assertEquals(1, store.clusterBean().all().get(1000).size());
+      Assertions.assertEquals(
+          bean, store.clusterBean().all().get(1000).iterator().next().beanObject());
+    }
+    // make sure receiver get closed
+    Mockito.verify(receiver, Mockito.times(1)).close();
+  }
+
+  @Test
+  void testNullCheck() {
+    var builder = MetricsStore.builder();
+    Assertions.assertThrows(NullPointerException.class, builder::build);
+    builder.receiver(timeout -> Map.of());
+    var store = builder.build();
+    store.close();
+  }
+
+  @Test
+  void testBeanExpiration() {
+    var queue = new LinkedBlockingQueue<Map<Integer, Collection<BeanObject>>>();
+    queue.add(Map.of(1000, List.of(new BeanObject(Utils.randomString(), Map.of(), Map.of()))));
+    var count = new AtomicInteger(0);
+    try (var store =
+        MetricsStore.builder()
+            .receiver(
+                timeout -> {
+                  count.incrementAndGet();
+                  return Utils.packException(queue::take);
+                })
+            .beanExpiration(Duration.ofSeconds(1))
+            .build()) {
+      Utils.sleep(Duration.ofSeconds(3));
+      Assertions.assertNotEquals(0, count.get());
+      Assertions.assertEquals(0, store.clusterBean().all().size());
+    }
+  }
+}


### PR DESCRIPTION
related to #1594

這隻PR新增兩個元件：

1. `MetricsFetcher`：用多執行緒資料從眾多`MBeanClient`取出，並且透過`Sender`送到某個地方。`Sender`可以用 producer實作讓資料傳到遠端 topic
2. `MetricsStore`：將資料從`Receiver`中取出，並且經過`MetricsSensor`篩選產生出要保存在本地的metrics。`Receiver`可以用consumer實作來從遠端 topic 拉取資料

這次的目的是將 local/remote(topic) 兩種 metrics 體系統一，使用者可以有三種用法：

1. local mode：使用者可以透過簡單的方式快速建構一個`MetricsStore` with embedded `MetricsFetcher`，兩者的資料交換都透過記憶體交換，類似於原本的 local MetricsCollector
2. publisher：一個獨立的應用程式負責將資料從遠端server收集完後，並且丟到 topic，這時可以只用`MetricsFetcher`，必且搭配 producer版本的`Sender`
3. remote (topic) mode，正式環境上 producer/assignor/balancer 都可以用，只需要建構`MetricsStore`搭配 consumer版本的`receiver`