### PR TITLE
[CONSUMER] Make consumer naming static/fixed

### DIFF
--- a/app/src/main/java/org/astraea/app/performance/ConsumerThread.java
+++ b/app/src/main/java/org/astraea/app/performance/ConsumerThread.java
@@ -84,7 +84,7 @@ public interface ConsumerThread extends AbstractThread {
     return IntStream.range(0, consumers)
         .mapToObj(
             index -> {
-              var clientId = Utils.randomString();
+              var clientId = "consumer-" + index;
               var consumer = consumerSupplier.apply(clientId, new PartitionRatioListener(clientId));
               var closed = new AtomicBoolean(false);
               var closeLatch = closeLatches.get(index);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39105714/227532964-f473602d-646a-4601-aa19-2415d941a831.png)

Consumer 目前的命名是隨機取的，這個 PR 把它改成固定的值。

* Consumer 使用固定的名稱，如此一來即使 Performance Tool 重開， Java Mission Control 內先前建立的效能圖表可以繼續使用，不會因為 consumer 名稱變動而找不到對應的 attribute。
* 避免 Prometheus 內儲存的 time-series 種類過多 （每個隨機值都被視為一個不同的 series，圖表內的顏色和 label 會變很繽紛...）
