### PR TITLE
[PERF] Enable the use of zero producer

### DIFF
--- a/app/src/main/java/org/astraea/app/performance/DataGenerator.java
+++ b/app/src/main/java/org/astraea/app/performance/DataGenerator.java
@@ -44,6 +44,8 @@ public interface DataGenerator extends AbstractThread {
       List<ArrayBlockingQueue<List<Record<byte[], byte[]>>>> queues,
       Supplier<TopicPartition> partitionSelector,
       Performance.Argument argument) {
+    if (queues.size() == 0) return terminatedGenerator();
+
     var keyDistConfig = Configuration.of(argument.keyDistributionConfig);
     var keySizeDistConfig = Configuration.of(argument.keySizeDistributionConfig);
     var valueDistConfig = Configuration.of(argument.valueDistributionConfig);
@@ -124,6 +126,21 @@ public interface DataGenerator extends AbstractThread {
         closed.set(true);
         waitForDone();
       }
+    };
+  }
+
+  static DataGenerator terminatedGenerator() {
+    return new DataGenerator() {
+      @Override
+      public void waitForDone() {}
+
+      @Override
+      public boolean closed() {
+        return true;
+      }
+
+      @Override
+      public void close() {}
     };
   }
 

--- a/app/src/main/java/org/astraea/app/performance/Performance.java
+++ b/app/src/main/java/org/astraea/app/performance/Performance.java
@@ -46,7 +46,6 @@ import org.astraea.app.argument.PatternField;
 import org.astraea.app.argument.PositiveIntegerField;
 import org.astraea.app.argument.PositiveIntegerListField;
 import org.astraea.app.argument.PositiveLongField;
-import org.astraea.app.argument.PositiveShortField;
 import org.astraea.app.argument.StringListField;
 import org.astraea.app.argument.StringMapField;
 import org.astraea.app.argument.TopicPartitionDataRateMapField;
@@ -211,8 +210,8 @@ public class Performance {
     @Parameter(
         names = {"--producers"},
         description = "Integer: number of producers to produce records",
-        validateWith = PositiveShortField.class,
-        converter = PositiveShortField.class)
+        validateWith = NonNegativeShortField.class,
+        converter = NonNegativeShortField.class)
     int producers = 1;
 
     @Parameter(


### PR DESCRIPTION
Context: https://github.com/skiptests/astraea/issues/1567#issuecomment-1483719688

這個 PR 使 Performance Tool 能夠支援 0 個 Producer 的使用情境。

先前的討論發現 Producer/Consumer 執行在同一臺會有傳輸不順的情況，對此這個 PR 的修正能夠允許 Performance 的 Producer/Consumer 跑在不同的設備上，以繞過這個問題。

當使用 0 個 Producer 可能會發生的爭議是：Performance Tool 不知道什麼時候應該停止，因為沒有一個具體的 Producer 會給他輸入資料，這個部分是使用既有的參數 `read.idle` 來處理，如果經過 `read.idle` 實驗都沒有資料流進來，則視為 consumer 的工作完成。