### PR TITLE
[PERF] remove duplicate argument from ProducerThread#create

### DIFF
--- a/app/src/main/java/org/astraea/app/performance/Performance.java
+++ b/app/src/main/java/org/astraea/app/performance/Performance.java
@@ -87,8 +87,7 @@ public class Performance {
 
     System.out.println("creating threads");
     var producerThreads =
-        ProducerThread.create(
-            blockingQueues, param.producers, param::createProducer, param.interdependent);
+        ProducerThread.create(blockingQueues, param::createProducer, param.interdependent);
     var consumerThreads =
         param.monkeys != null
             ? Collections.synchronizedList(new ArrayList<>(consumers(param, latestOffsets)))

--- a/app/src/main/java/org/astraea/app/performance/ProducerThread.java
+++ b/app/src/main/java/org/astraea/app/performance/ProducerThread.java
@@ -46,9 +46,9 @@ public interface ProducerThread extends AbstractThread {
 
   static List<ProducerThread> create(
       List<ArrayBlockingQueue<List<Record<byte[], byte[]>>>> queues,
-      int producers,
       Supplier<Producer<byte[], byte[]>> producerSupplier,
       int interdependent) {
+    var producers = queues.size();
     if (producers <= 0) return List.of();
     var closeLatches =
         IntStream.range(0, producers)


### PR DESCRIPTION
審查#1602時注意到，queue的總量在邏輯上會等同於producers數量，所以可以選一個當輸入參數就好