### PR TITLE
[BALANCER][COST] `ClusterInfoSensor` throw inappropriate exception when supplied with partial info

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/utils/ClusterInfoSensor.java
+++ b/common/src/main/java/org/astraea/common/cost/utils/ClusterInfoSensor.java
@@ -47,6 +47,14 @@ public class ClusterInfoSensor implements MetricSensor {
         .collect(Collectors.toUnmodifiableList());
   }
 
+  /**
+   * Create a {@link ClusterInfo} from the metrics of a given {@link ClusterBean}. The {@link
+   * ClusterInfo} might lack some information due to the incompetent metrics info.
+   *
+   * @param clusterBean the cluster bean.
+   * @throws IllegalStateException when there is some conflict information within the cluster bean
+   * @return a {@link ClusterInfo}.
+   */
   public static ClusterInfo metricViewCluster(ClusterBean clusterBean) {
     var nodes =
         clusterBean.brokerIds().stream()
@@ -82,7 +90,12 @@ public class ClusterInfoSensor implements MetricSensor {
                                             .max(
                                                 Comparator.comparingLong(
                                                     HasBeanObject::createdTimestamp))
-                                            .orElseThrow()
+                                            .orElseThrow(
+                                                () ->
+                                                    new IllegalStateException(
+                                                        "Partition "
+                                                            + tp
+                                                            + " detected, but its size metric doesn't exists. Maybe the given cluster bean is partially sampled"))
                                             .value();
                                     var build =
                                         Replica.builder()

--- a/common/src/test/java/org/astraea/common/cost/utils/ClusterInfoSensorTest.java
+++ b/common/src/test/java/org/astraea/common/cost/utils/ClusterInfoSensorTest.java
@@ -264,4 +264,14 @@ class ClusterInfoSensorTest {
     Assertions.assertEquals(1, info.nodes().size());
     Assertions.assertEquals(id, info.clusterId());
   }
+
+  @Test
+  void testPartialMetricsException() {
+    Assertions.assertThrows(
+        IllegalStateException.class,
+        () ->
+            ClusterInfoSensor.metricViewCluster(
+                ClusterBean.of(
+                    Map.of(1, List.of(MetricFactory.ofPartitionMetric("topic", 0, 0))))));
+  }
 }


### PR DESCRIPTION
`ClusterInfoSensor#metricClusterView` 提供一個從 ClusterBean 重建 ClusterInfo 的手法，但這個函數在給定的 ClusterBean 裡面存在衝突訊息時丟出某些錯誤，而這個錯誤沒有被 CostFunction 特別處理（包裝成 `NoSufficientMetricException` 重複丟出），因此讓外部的 Balancer 認為計劃發生無法被重試的錯誤，這進而導致計劃無法生成。

這個 PR 給 

* `ClusterInfoSensor#metricClusterView` 函數的 Javadoc 特別標註這個例外 case
* `NetworkCost` 裡面使用 `ClusterInfoSensor#metricClusterView` 時，如果遇到這個錯誤，會把它包裝成 `NoSufficientMetricsException` 來確保 Balancer 後續嘗試 retry 生成。