### PR TITLE
[METRICS] rename MetricsStore to MetricStore and rename MetricsFetche…

### DIFF
--- a/app/src/main/java/org/astraea/app/publisher/MetricPublisher.java
+++ b/app/src/main/java/org/astraea/app/publisher/MetricPublisher.java
@@ -27,7 +27,7 @@ import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.metrics.MBeanClient;
-import org.astraea.common.metrics.collector.MetricsFetcher;
+import org.astraea.common.metrics.collector.MetricFetcher;
 
 /** Keep fetching all kinds of metrics and publish to inner topics. */
 public class MetricPublisher {
@@ -44,9 +44,9 @@ public class MetricPublisher {
   // Valid for testing
   static void execute(Arguments arguments) {
     var admin = Admin.of(arguments.bootstrapServers());
-    var topicSender = MetricsFetcher.Sender.topic(arguments.bootstrapServers());
+    var topicSender = MetricFetcher.Sender.topic(arguments.bootstrapServers());
     try (var metricFetcher =
-        MetricsFetcher.builder()
+        MetricFetcher.builder()
             .clientSupplier(
                 () ->
                     admin

--- a/app/src/main/java/org/astraea/app/web/BalancerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BalancerHandler.java
@@ -50,7 +50,7 @@ import org.astraea.common.cost.HasMoveCost;
 import org.astraea.common.json.TypeRef;
 import org.astraea.common.metrics.MBeanClient;
 import org.astraea.common.metrics.collector.MetricSensor;
-import org.astraea.common.metrics.collector.MetricsStore;
+import org.astraea.common.metrics.collector.MetricStore;
 
 class BalancerHandler implements Handler, AutoCloseable {
 
@@ -63,7 +63,7 @@ class BalancerHandler implements Handler, AutoCloseable {
 
   private final Collection<MetricSensor> sensors = new ConcurrentLinkedQueue<>();
 
-  private final MetricsStore metricsStore;
+  private final MetricStore metricStore;
 
   BalancerHandler(Admin admin, Function<Integer, Integer> jmxPortMapper) {
     this.admin = admin;
@@ -79,8 +79,8 @@ class BalancerHandler implements Handler, AutoCloseable {
                                 Collectors.toUnmodifiableMap(
                                     NodeInfo::id,
                                     b -> MBeanClient.jndi(b.host(), jmxPortMapper.apply(b.id())))));
-    this.metricsStore =
-        MetricsStore.builder()
+    this.metricStore =
+        MetricStore.builder()
             .beanExpiration(Duration.ofSeconds(1))
             .localReceiver(clientSupplier)
             .sensorsSupplier(
@@ -126,7 +126,7 @@ class BalancerHandler implements Handler, AutoCloseable {
               .setTaskId(taskId)
               .setBalancer(balancer)
               .setAlgorithmConfig(request.algorithmConfig)
-              .setClusterBeanSource(metricsStore::clusterBean)
+              .setClusterBeanSource(metricStore::clusterBean)
               .checkNoOngoingMigration(true)
               .generate();
       task.whenComplete(
@@ -517,6 +517,6 @@ class BalancerHandler implements Handler, AutoCloseable {
   // handle manually
   @Override
   public void close() {
-    metricsStore.close();
+    metricStore.close();
   }
 }

--- a/common/src/main/java/org/astraea/common/assignor/Assignor.java
+++ b/common/src/main/java/org/astraea/common/assignor/Assignor.java
@@ -40,7 +40,7 @@ import org.astraea.common.consumer.ConsumerConfigs;
 import org.astraea.common.cost.HasPartitionCost;
 import org.astraea.common.cost.ReplicaLeaderSizeCost;
 import org.astraea.common.metrics.MBeanClient;
-import org.astraea.common.metrics.collector.MetricsStore;
+import org.astraea.common.metrics.collector.MetricStore;
 import org.astraea.common.partitioner.PartitionerUtils;
 
 /** Abstract assignor implementation which does some common work (e.g., configuration). */
@@ -55,7 +55,7 @@ public abstract class Assignor implements ConsumerPartitionAssignor, Configurabl
   // TODO: metric collector may be configured by user in the future.
   // TODO: need to track the performance when using the assignor in large scale consumers, see
   // https://github.com/skiptests/astraea/pull/1162#discussion_r1036285677
-  protected MetricsStore metricStore = null;
+  protected MetricStore metricStore = null;
 
   protected Admin admin = null;
 
@@ -170,7 +170,7 @@ public abstract class Assignor implements ConsumerPartitionAssignor, Configurabl
                       return Collections.unmodifiableMap(map);
                     });
     metricStore =
-        MetricsStore.builder()
+        MetricStore.builder()
             .localReceiver(clientSupplier)
             .sensorsSupplier(
                 () ->

--- a/common/src/main/java/org/astraea/common/metrics/collector/LocalSenderReceiver.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/LocalSenderReceiver.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 import org.astraea.common.Utils;
 import org.astraea.common.metrics.BeanObject;
 
-public class LocalSenderReceiver implements MetricsFetcher.Sender, MetricsStore.Receiver {
+public class LocalSenderReceiver implements MetricFetcher.Sender, MetricStore.Receiver {
 
   public static LocalSenderReceiver of() {
     return new LocalSenderReceiver();

--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricFetcher.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricFetcher.java
@@ -44,7 +44,7 @@ import org.astraea.common.producer.Producer;
 import org.astraea.common.producer.Record;
 import org.astraea.common.producer.Serializer;
 
-public interface MetricsFetcher extends AutoCloseable {
+public interface MetricFetcher extends AutoCloseable {
 
   static Builder builder() {
     return new Builder();
@@ -147,8 +147,8 @@ public interface MetricsFetcher extends AutoCloseable {
       return this;
     }
 
-    public MetricsFetcher build() {
-      return new MetricsFetcherImpl(
+    public MetricFetcher build() {
+      return new MetricFetcherImpl(
           threads,
           Objects.requireNonNull(fetchBeanDelay, "fetchBeanDelay can't be null"),
           Objects.requireNonNull(fetchMetadataDelay, "fetchMetadataDelay can't be null"),
@@ -157,7 +157,7 @@ public interface MetricsFetcher extends AutoCloseable {
     }
   }
 
-  class MetricsFetcherImpl implements MetricsFetcher {
+  class MetricFetcherImpl implements MetricFetcher {
     private volatile Map<Integer, MBeanClient> clients = new HashMap<>();
 
     private final Map<Integer, Collection<BeanObject>> latest = new ConcurrentHashMap<>();
@@ -176,7 +176,7 @@ public interface MetricsFetcher extends AutoCloseable {
 
     private final Duration fetchBeanDelay;
 
-    private MetricsFetcherImpl(
+    private MetricFetcherImpl(
         int threads,
         Duration fetchBeanDelay,
         Duration fetchMetadataDelay,

--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
@@ -45,7 +45,7 @@ import org.astraea.common.metrics.BeanQuery;
 import org.astraea.common.metrics.HasBeanObject;
 import org.astraea.common.metrics.MBeanClient;
 
-public interface MetricsStore extends AutoCloseable {
+public interface MetricStore extends AutoCloseable {
 
   static Builder builder() {
     return new Builder();
@@ -72,7 +72,7 @@ public interface MetricsStore extends AutoCloseable {
 
   interface Receiver extends AutoCloseable {
 
-    static MetricsFetcher.Sender local() {
+    static MetricFetcher.Sender local() {
       return LocalSenderReceiver.of();
     }
 
@@ -144,7 +144,7 @@ public interface MetricsStore extends AutoCloseable {
     public Builder localReceiver(
         Supplier<CompletionStage<Map<Integer, MBeanClient>>> clientSupplier) {
       var cache = LocalSenderReceiver.of();
-      var fetcher = MetricsFetcher.builder().clientSupplier(clientSupplier).sender(cache).build();
+      var fetcher = MetricFetcher.builder().clientSupplier(clientSupplier).sender(cache).build();
       return receiver(
           new Receiver() {
             @Override
@@ -168,15 +168,15 @@ public interface MetricsStore extends AutoCloseable {
       return this;
     }
 
-    public MetricsStore build() {
-      return new MetricsStoreImpl(
+    public MetricStore build() {
+      return new MetricStoreImpl(
           Objects.requireNonNull(sensorsSupplier, "sensorsSupplier can't be null"),
           Objects.requireNonNull(receiver, "receiver can't be null"),
           Objects.requireNonNull(beanExpiration, "beanExpiration can't be null"));
     }
   }
 
-  class MetricsStoreImpl implements MetricsStore {
+  class MetricStoreImpl implements MetricStore {
 
     private final Map<Integer, Collection<HasBeanObject>> beans = new ConcurrentHashMap<>();
 
@@ -194,7 +194,7 @@ public interface MetricsStore extends AutoCloseable {
 
     private volatile Map<MetricSensor, BiConsumer<Integer, Exception>> lastSensors = Map.of();
 
-    private MetricsStoreImpl(
+    private MetricStoreImpl(
         Supplier<Map<MetricSensor, BiConsumer<Integer, Exception>>> sensorsSupplier,
         Receiver receiver,
         Duration beanExpiration) {

--- a/common/src/main/java/org/astraea/common/partitioner/SmoothWeightRoundRobinPartitioner.java
+++ b/common/src/main/java/org/astraea/common/partitioner/SmoothWeightRoundRobinPartitioner.java
@@ -34,7 +34,7 @@ import org.astraea.common.admin.BrokerTopic;
 import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.cost.NeutralIntegratedCost;
 import org.astraea.common.metrics.MBeanClient;
-import org.astraea.common.metrics.collector.MetricsStore;
+import org.astraea.common.metrics.collector.MetricStore;
 
 public class SmoothWeightRoundRobinPartitioner extends Partitioner {
   private static final int ROUND_ROBIN_LENGTH = 400;
@@ -44,7 +44,7 @@ public class SmoothWeightRoundRobinPartitioner extends Partitioner {
 
   private final NeutralIntegratedCost neutralIntegratedCost = new NeutralIntegratedCost();
 
-  MetricsStore metricsStore = null;
+  MetricStore metricStore = null;
 
   private SmoothWeightCal<Integer> smoothWeightCal;
   private RoundRobinKeeper roundRobinKeeper;
@@ -66,7 +66,7 @@ public class SmoothWeightRoundRobinPartitioner extends Partitioner {
     Supplier<Map<Integer, Double>> supplier =
         () ->
             // fetch the latest beans for each node
-            neutralIntegratedCost.brokerCost(clusterInfo, metricsStore.clusterBean()).value();
+            neutralIntegratedCost.brokerCost(clusterInfo, metricStore.clusterBean()).value();
 
     smoothWeightCal.refresh(supplier);
 
@@ -86,7 +86,7 @@ public class SmoothWeightRoundRobinPartitioner extends Partitioner {
 
   @Override
   public void close() {
-    metricsStore.close();
+    metricStore.close();
   }
 
   @Override
@@ -135,8 +135,8 @@ public class SmoothWeightRoundRobinPartitioner extends Partitioner {
                     });
 
     // put local mbean client first
-    metricsStore =
-        MetricsStore.builder()
+    metricStore =
+        MetricStore.builder()
             .localReceiver(clientSupplier)
             .sensorsSupplier(
                 () ->

--- a/common/src/main/java/org/astraea/common/partitioner/StrictCostPartitioner.java
+++ b/common/src/main/java/org/astraea/common/partitioner/StrictCostPartitioner.java
@@ -35,7 +35,7 @@ import org.astraea.common.cost.BrokerCost;
 import org.astraea.common.cost.HasBrokerCost;
 import org.astraea.common.cost.NodeLatencyCost;
 import org.astraea.common.metrics.MBeanClient;
-import org.astraea.common.metrics.collector.MetricsStore;
+import org.astraea.common.metrics.collector.MetricStore;
 
 /**
  * this partitioner scores the nodes by multiples cost functions. Each function evaluate the target
@@ -57,7 +57,7 @@ public class StrictCostPartitioner extends Partitioner {
   static final String JMX_PORT = "jmx.port";
   static final String ROUND_ROBIN_LEASE_KEY = "round.robin.lease";
   // visible for testing
-  MetricsStore metricsStore = null;
+  MetricStore metricStore = null;
 
   private Duration roundRobinLease = Duration.ofSeconds(4);
   HasBrokerCost costFunction = new NodeLatencyCost();
@@ -78,7 +78,7 @@ public class StrictCostPartitioner extends Partitioner {
 
     roundRobinKeeper.tryToUpdate(
         clusterInfo,
-        () -> costToScore(costFunction.brokerCost(clusterInfo, metricsStore.clusterBean())));
+        () -> costToScore(costFunction.brokerCost(clusterInfo, metricStore.clusterBean())));
 
     var target = roundRobinKeeper.next();
 
@@ -147,8 +147,8 @@ public class StrictCostPartitioner extends Partitioner {
                     });
 
     // put local mbean client first
-    metricsStore =
-        MetricsStore.builder()
+    metricStore =
+        MetricStore.builder()
             .localReceiver(clientSupplier)
             .sensorsSupplier(
                 () ->
@@ -162,7 +162,7 @@ public class StrictCostPartitioner extends Partitioner {
 
   @Override
   public void close() {
-    metricsStore.close();
+    metricStore.close();
     super.close();
   }
 }

--- a/common/src/test/java/org/astraea/common/metrics/collector/LocalMetricsTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/collector/LocalMetricsTest.java
@@ -40,7 +40,7 @@ public class LocalMetricsTest {
   @Test
   void test() {
     try (var store =
-        MetricsStore.builder()
+        MetricStore.builder()
             .beanExpiration(Duration.ofSeconds(1))
             .localReceiver(() -> CompletableFuture.completedStage(Map.of(-1, MBeanClient.local())))
             .build()) {

--- a/common/src/test/java/org/astraea/common/metrics/collector/MetricFetcherTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/collector/MetricFetcherTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class MetricsFetcherTest {
+public class MetricFetcherTest {
   static Service SERVICE = Service.builder().numberOfWorkers(0).build();
 
   @AfterAll
@@ -53,7 +53,7 @@ public class MetricsFetcherTest {
     var beans = List.of(new BeanObject(Utils.randomString(), Map.of(), Map.of()));
     var client = Mockito.mock(MBeanClient.class);
     Mockito.when(client.beans(Mockito.any(), Mockito.any())).thenReturn(beans);
-    var sender = Mockito.mock(MetricsFetcher.Sender.class);
+    var sender = Mockito.mock(MetricFetcher.Sender.class);
     var queue = new ConcurrentHashMap<Integer, Collection<BeanObject>>();
     Mockito.when(sender.send(Mockito.anyInt(), Mockito.any()))
         .thenAnswer(
@@ -64,7 +64,7 @@ public class MetricsFetcherTest {
               return CompletableFuture.completedStage(null);
             });
     try (var fetcher =
-        MetricsFetcher.builder()
+        MetricFetcher.builder()
             .sender(sender)
             .clientSupplier(() -> CompletableFuture.completedStage(Map.of(-1000, client)))
             .fetchBeanDelay(Duration.ofSeconds(1))
@@ -86,9 +86,9 @@ public class MetricsFetcherTest {
 
   @Test
   void testNullCheck() {
-    var builder = MetricsFetcher.builder();
+    var builder = MetricFetcher.builder();
     Assertions.assertThrows(NullPointerException.class, builder::build);
-    builder.sender(MetricsFetcher.Sender.local());
+    builder.sender(MetricFetcher.Sender.local());
     Assertions.assertThrows(NullPointerException.class, builder::build);
     builder.clientSupplier(() -> CompletableFuture.completedStage(Map.of()));
     var fetcher = builder.build();
@@ -99,8 +99,8 @@ public class MetricsFetcherTest {
   void testFetchBeanDelay() {
     var client = Mockito.mock(MBeanClient.class);
     try (var fetcher =
-        MetricsFetcher.builder()
-            .sender(MetricsFetcher.Sender.local())
+        MetricFetcher.builder()
+            .sender(MetricFetcher.Sender.local())
             .clientSupplier(() -> CompletableFuture.completedStage(Map.of(-1000, client)))
             .fetchBeanDelay(Duration.ofSeconds(1000))
             .build()) {
@@ -119,8 +119,8 @@ public class MetricsFetcherTest {
     Mockito.when(supplier.get())
         .thenReturn(CompletableFuture.completedStage(Map.of(-1000, client)));
     try (var fetcher =
-        MetricsFetcher.builder()
-            .sender(MetricsFetcher.Sender.local())
+        MetricFetcher.builder()
+            .sender(MetricFetcher.Sender.local())
             .clientSupplier(supplier)
             .fetchMetadataDelay(Duration.ofSeconds(1000))
             .build()) {
@@ -135,7 +135,7 @@ public class MetricsFetcherTest {
   @Test
   void testTopic() throws InterruptedException, ExecutionException {
     var testBean = new BeanObject("java.lang", Map.of("name", "n1"), Map.of("value", "v1"));
-    try (var topicSender = MetricsFetcher.Sender.topic(SERVICE.bootstrapServers())) {
+    try (var topicSender = MetricFetcher.Sender.topic(SERVICE.bootstrapServers())) {
       topicSender.send(1, List.of(testBean));
 
       // Test topic creation

--- a/common/src/test/java/org/astraea/common/metrics/collector/MetricStoreTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/collector/MetricStoreTest.java
@@ -29,18 +29,18 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class MetricsStoreTest {
+public class MetricStoreTest {
 
   @Test
   void testReceiveAndClose() {
     var bean = new BeanObject(Utils.randomString(), Map.of(), Map.of());
     var queue = new LinkedBlockingQueue<Map<Integer, Collection<BeanObject>>>();
     queue.add(Map.of(1000, List.of(bean)));
-    var receiver = Mockito.mock(MetricsStore.Receiver.class);
+    var receiver = Mockito.mock(MetricStore.Receiver.class);
     Mockito.when(receiver.receive(Mockito.any()))
         .thenAnswer(invocation -> Utils.packException(queue::take));
     try (var store =
-        MetricsStore.builder().receiver(receiver).beanExpiration(Duration.ofSeconds(100)).build()) {
+        MetricStore.builder().receiver(receiver).beanExpiration(Duration.ofSeconds(100)).build()) {
       Utils.sleep(Duration.ofSeconds(3));
       Assertions.assertEquals(1, store.clusterBean().all().size());
       Assertions.assertEquals(Set.of(1000), store.clusterBean().all().keySet());
@@ -54,7 +54,7 @@ public class MetricsStoreTest {
 
   @Test
   void testNullCheck() {
-    var builder = MetricsStore.builder();
+    var builder = MetricStore.builder();
     Assertions.assertThrows(NullPointerException.class, builder::build);
     builder.receiver(timeout -> Map.of());
     var store = builder.build();
@@ -67,7 +67,7 @@ public class MetricsStoreTest {
     queue.add(Map.of(1000, List.of(new BeanObject(Utils.randomString(), Map.of(), Map.of()))));
     var count = new AtomicInteger(0);
     try (var store =
-        MetricsStore.builder()
+        MetricStore.builder()
             .receiver(
                 timeout -> {
                   count.incrementAndGet();

--- a/common/src/test/java/org/astraea/common/metrics/collector/TopicMetricTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/collector/TopicMetricTest.java
@@ -45,7 +45,7 @@ public class TopicMetricTest {
 
   @Test
   void test() {
-    try (var receiver = MetricsStore.Receiver.topic(SERVICE.bootstrapServers())) {
+    try (var receiver = MetricStore.Receiver.topic(SERVICE.bootstrapServers())) {
       Assertions.assertEquals(Map.of(), receiver.receive(Duration.ofSeconds(1)));
 
       try (var admin = Admin.of(SERVICE.bootstrapServers())) {

--- a/common/src/test/java/org/astraea/common/partitioner/StrictCostPartitionerTest.java
+++ b/common/src/test/java/org/astraea/common/partitioner/StrictCostPartitionerTest.java
@@ -154,7 +154,7 @@ public class StrictCostPartitionerTest {
           new byte[0],
           new byte[0],
           ClusterInfoTest.of(List.of(replicaInfo0, replicaInfo1)));
-      Assertions.assertEquals(0, partitioner.metricsStore.sensors().size());
+      Assertions.assertEquals(0, partitioner.metricStore.sensors().size());
     }
   }
 
@@ -214,7 +214,7 @@ public class StrictCostPartitionerTest {
     try (var partitioner = new StrictCostPartitioner()) {
       partitioner.configure(Configuration.of(Map.of()));
       Assertions.assertNotEquals(HasBrokerCost.EMPTY, partitioner.costFunction);
-      Utils.waitFor(() -> partitioner.metricsStore.sensors().size() == 1);
+      Utils.waitFor(() -> partitioner.metricStore.sensors().size() == 1);
     }
   }
 


### PR DESCRIPTION
在命名上我們之前大多是用`metric`，所以後面的類別從善如流