### PR TITLE
[TEST] fix BalancerHandlerTest#testRebalanceDetectOngoing

### DIFF
--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -562,7 +562,7 @@ public class BalancerHandlerTest {
                       clusterInfo
                           .replicaStream()
                           .noneMatch(r -> r.isFuture() || r.isRemoving() || r.isAdding()),
-                  Duration.ofSeconds(10),
+                  Duration.ofSeconds(20),
                   2)
               .toCompletableFuture()
               .join());


### PR DESCRIPTION
fix #1613 

在我本地端是多給一點時間就會通過，因為現在擷取的metrics較多，會有一段時間找不到足夠的metrics來啟動