### PR TITLE
[TEST] Fix flaky `ReplicaNumberCostTest#testClusterCost`

### DIFF
--- a/common/src/test/java/org/astraea/common/cost/ReplicaNumberCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/ReplicaNumberCostTest.java
@@ -66,7 +66,7 @@ class ReplicaNumberCostTest {
             .build();
     Assertions.assertEquals(0, cost.clusterCost(singleNodeCluster, ClusterBean.EMPTY).value());
 
-    // (all > 2, 0, 0, 0, 0, 0)
+    // (all >= 2, 0, 0, 0, 0, 0)
     var expandedCluster =
         ClusterInfoBuilder.builder(BASE_1)
             .addTopic("topic", ThreadLocalRandom.current().nextInt(2, 100), (short) 1)

--- a/common/src/test/java/org/astraea/common/cost/ReplicaNumberCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/ReplicaNumberCostTest.java
@@ -66,10 +66,10 @@ class ReplicaNumberCostTest {
             .build();
     Assertions.assertEquals(0, cost.clusterCost(singleNodeCluster, ClusterBean.EMPTY).value());
 
-    // (all, 0, 0, 0, 0, 0)
+    // (all > 2, 0, 0, 0, 0, 0)
     var expandedCluster =
         ClusterInfoBuilder.builder(BASE_1)
-            .addTopic("topic", ThreadLocalRandom.current().nextInt(1, 100), (short) 1)
+            .addTopic("topic", ThreadLocalRandom.current().nextInt(2, 100), (short) 1)
             .addNode(Set.of(2, 3, 4, 5, 6))
             .build();
     Assertions.assertEquals(1, cost.clusterCost(expandedCluster, ClusterBean.EMPTY).value());


### PR DESCRIPTION
Error: https://github.com/garyparrot/astraea/actions/runs/4618986593/jobs/8167122525#step:5:3529

`ReplicaNumberCostTest#testClusterCost` 這隻測試有 1/99 的機會出錯

https://github.com/skiptests/astraea/blob/b337e5cfc4ee3624e568750c3a5d8ee61c231c61/common/src/test/java/org/astraea/common/cost/ReplicaNumberCostTest.java#L69-L75

這個情境是所有 Partition 都擠在同一個節點的情況，而 Partition 數量可能是 1 ~ 99 個，當 Partition 數正好出現 1 的時候，整個情境是 `(1, 0, 0, 0, 0, 0)`，這個符合 completely balance in terms of integer 的情況

https://github.com/skiptests/astraea/blob/573f7f7e64f0b8a8c29a24e0b364fafbf161e721/common/src/main/java/org/astraea/common/cost/ReplicaNumberCost.java#L78-L84

因為整個情境基本上已經沒辦法被調整得更平衡，被視為是 0.0 的正好狀態，所以回傳 `0` 而非測試原先預期的 `1`。