### PR TITLE
[SERIALIZATION] Serialize `BeanObject` by protoBuf

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation libs["slf4j-nop"]
     implementation libs["opencsv"]
     implementation libs["commons-math3"]
-    implementation 'com.google.protobuf:protobuf-java:3.6.1'
+    implementation 'com.google.protobuf:protobuf-java:3.22.2'
 }
 
 java {
@@ -61,7 +61,7 @@ protobuf {
     // Configure the protoc executable
     protoc {
         // Download from repositories
-        artifact = 'com.google.protobuf:protoc:3.6.1'
+        artifact = 'com.google.protobuf:protoc:3.22.2'
     }
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -17,6 +17,7 @@
 plugins {
     id 'java'
     id 'maven-publish'
+    id "com.google.protobuf" version "0.9.2"
 }
 
 apply from: "$rootDir/gradle/dependencies.gradle"
@@ -42,6 +43,7 @@ dependencies {
     implementation libs["slf4j-nop"]
     implementation libs["opencsv"]
     implementation libs["commons-math3"]
+    implementation 'com.google.protobuf:protobuf-java:3.6.1'
 }
 
 java {
@@ -54,6 +56,14 @@ ext {
 }
 
 archivesBaseName = "astraea-common"
+
+protobuf {
+    // Configure the protoc executable
+    protoc {
+        // Download from repositories
+        artifact = 'com.google.protobuf:protoc:3.6.1'
+    }
+}
 
 tasks.named('test') {
     // Use JUnit Platform for unit tests.

--- a/common/src/main/java/org/astraea/common/consumer/Deserializer.java
+++ b/common/src/main/java/org/astraea/common/consumer/Deserializer.java
@@ -20,6 +20,8 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -32,7 +34,9 @@ import org.apache.kafka.common.serialization.FloatDeserializer;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.astraea.common.BeanObjectOuterClass;
 import org.astraea.common.Header;
+import org.astraea.common.Utils;
 import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.admin.Config;
 import org.astraea.common.admin.NodeInfo;
@@ -124,7 +128,7 @@ public interface Deserializer<T> {
 
   /**
    * Deserialize byte arrays to string and then parse the string to `BeanObject`. It is inverse of
-   * BeanObject.toString().getBytes().
+   * BeanObject.toString().getBytes(). TODO: Should be replaced by protoBuf
    */
   class BeanDeserializer implements Deserializer<BeanObject> {
     @Override
@@ -272,6 +276,42 @@ public interface Deserializer<T> {
                   })
               .collect(Collectors.toList());
       return ClusterInfo.of(clusterId, nodes, topics, replicas);
+    }
+  }
+
+  class BeanObjectDeserializer implements Deserializer<BeanObject> {
+    @Override
+    public BeanObject deserialize(String topic, List<Header> headers, byte[] data) {
+      // Pack InvalidProtocolBufferException thrown by protoBuf
+      var outerBean = Utils.packException(() -> BeanObjectOuterClass.BeanObject.parseFrom(data));
+      return new BeanObject(
+          outerBean.getDomain(),
+          outerBean.getPropertiesMap(),
+          outerBean.getAttributesMap().entrySet().stream()
+              .collect(
+                  Collectors.toUnmodifiableMap(
+                      Map.Entry::getKey, e -> Objects.requireNonNull(toObject(e.getValue())))));
+    }
+
+    private Object toObject(BeanObjectOuterClass.BeanObject.Primitive primitive) {
+      var oneOfCase = primitive.getValueCase();
+      switch (oneOfCase) {
+        case INT:
+          return primitive.getInt();
+        case LONG:
+          return primitive.getLong();
+        case FLOAT:
+          return primitive.getFloat();
+        case DOUBLE:
+          return primitive.getDouble();
+        case BOOLEAN:
+          return primitive.getBoolean();
+        case STR:
+          return primitive.getStr();
+        case VALUE_NOT_SET:
+        default:
+          return null;
+      }
     }
   }
 }

--- a/common/src/main/java/org/astraea/common/consumer/Deserializer.java
+++ b/common/src/main/java/org/astraea/common/consumer/Deserializer.java
@@ -34,7 +34,6 @@ import org.apache.kafka.common.serialization.FloatDeserializer;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.astraea.common.BeanObjectOuterClass;
 import org.astraea.common.Header;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.ClusterInfo;
@@ -44,6 +43,7 @@ import org.astraea.common.admin.Replica;
 import org.astraea.common.admin.Topic;
 import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.backup.ByteUtils;
+import org.astraea.common.generated.BeanObjectOuterClass;
 import org.astraea.common.json.JsonConverter;
 import org.astraea.common.json.TypeRef;
 import org.astraea.common.metrics.BeanObject;
@@ -293,24 +293,24 @@ public interface Deserializer<T> {
                       Map.Entry::getKey, e -> Objects.requireNonNull(toObject(e.getValue())))));
     }
 
-    private Object toObject(BeanObjectOuterClass.BeanObject.Primitive primitive) {
-      var oneOfCase = primitive.getValueCase();
+    private Object toObject(BeanObjectOuterClass.BeanObject.Primitive v) {
+      var oneOfCase = v.getValueCase();
       switch (oneOfCase) {
         case INT:
-          return primitive.getInt();
+          return v.getInt();
         case LONG:
-          return primitive.getLong();
+          return v.getLong();
         case FLOAT:
-          return primitive.getFloat();
+          return v.getFloat();
         case DOUBLE:
-          return primitive.getDouble();
+          return v.getDouble();
         case BOOLEAN:
-          return primitive.getBoolean();
+          return v.getBoolean();
         case STR:
-          return primitive.getStr();
+          return v.getStr();
         case VALUE_NOT_SET:
         default:
-          return null;
+          throw new IllegalArgumentException("The value is not set.");
       }
     }
   }

--- a/common/src/main/java/org/astraea/common/producer/Serializer.java
+++ b/common/src/main/java/org/astraea/common/producer/Serializer.java
@@ -28,7 +28,6 @@ import org.apache.kafka.common.serialization.FloatSerializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.astraea.common.BeanObjectOuterClass;
 import org.astraea.common.Header;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.ClusterInfo;
@@ -36,6 +35,7 @@ import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.Replica;
 import org.astraea.common.admin.Topic;
 import org.astraea.common.backup.ByteUtils;
+import org.astraea.common.generated.BeanObjectOuterClass;
 import org.astraea.common.json.JsonConverter;
 import org.astraea.common.json.TypeRef;
 import org.astraea.common.metrics.BeanObject;
@@ -263,22 +263,26 @@ public interface Serializer<T> {
       return beanBuilder.build().toByteArray();
     }
 
-    private BeanObjectOuterClass.BeanObject.Primitive primitive(Object v) {
-      if (v instanceof Integer) {
+    private static BeanObjectOuterClass.BeanObject.Primitive primitive(Object v) {
+      if (v instanceof Integer)
         return BeanObjectOuterClass.BeanObject.Primitive.newBuilder().setInt((int) v).build();
-      } else if (v instanceof Long) {
+      else if (v instanceof Long)
         return BeanObjectOuterClass.BeanObject.Primitive.newBuilder().setLong((long) v).build();
-      } else if (v instanceof Float) {
+      else if (v instanceof Float)
         return BeanObjectOuterClass.BeanObject.Primitive.newBuilder().setFloat((float) v).build();
-      } else if (v instanceof Double) {
+      else if (v instanceof Double)
         return BeanObjectOuterClass.BeanObject.Primitive.newBuilder().setDouble((double) v).build();
-      } else if (v instanceof Boolean) {
+      else if (v instanceof Boolean)
         return BeanObjectOuterClass.BeanObject.Primitive.newBuilder()
             .setBoolean((boolean) v)
             .build();
-      } else {
+      else if (v instanceof String)
         return BeanObjectOuterClass.BeanObject.Primitive.newBuilder().setStr(v.toString()).build();
-      }
+      else
+        throw new IllegalArgumentException(
+            "Type "
+                + v.getClass()
+                + " is not supported. Please use Integer, Long, Float, Double, Boolean, String instead.");
     }
   }
 }

--- a/common/src/main/proto/org/astraea/common/BeanObject.proto
+++ b/common/src/main/proto/org/astraea/common/BeanObject.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package org.astraea.common;
+
+message BeanObject {
+  string domain = 1;
+  map<string, string> properties = 2;
+  map<string, Primitive> attributes = 3;
+  message Primitive {
+    oneof value {
+      string str = 1;
+      int32 int = 2;
+      int64 long = 3;
+      float float = 4;
+      double double = 5;
+      bool boolean = 6;
+    }
+  }
+}

--- a/common/src/main/proto/org/astraea/common/generated/BeanObject.proto
+++ b/common/src/main/proto/org/astraea/common/generated/BeanObject.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package org.astraea.common;
+package org.astraea.common.generated;
 
 message BeanObject {
   string domain = 1;

--- a/common/src/test/java/org/astraea/common/EnumInfoTest.java
+++ b/common/src/test/java/org/astraea/common/EnumInfoTest.java
@@ -56,13 +56,12 @@ class EnumInfoTest {
     Assertions.assertEquals(MyTestEnum.BANANA, EnumInfo.ignoreCaseEnum(MyTestEnum.class, "Banana"));
   }
 
-  public static final Set<Class<?>> EXCLUSION_CLASS =
-      Set.of(BeanObjectOuterClass.BeanObject.Primitive.ValueCase.class);
+  public static final Set<String> EXCLUSION_PACKAGE = Set.of("org.astraea.common.generated");
 
   @ParameterizedTest
   @ArgumentsSource(EnumClassProvider.class)
   void testExtendEnumInfo(Class<?> cls) {
-    if (!EXCLUSION_CLASS.contains(cls)) {
+    if (EXCLUSION_PACKAGE.stream().noneMatch(prefix -> cls.getPackageName().startsWith(prefix))) {
       Assertions.assertTrue(
           EnumInfo.class.isAssignableFrom(cls), String.format("Fail class %s", cls));
     }
@@ -71,7 +70,7 @@ class EnumInfoTest {
   @ParameterizedTest
   @ArgumentsSource(EnumClassProvider.class)
   void testOfAlias(Class<?> cls) {
-    if (!EXCLUSION_CLASS.contains(cls)) {
+    if (EXCLUSION_PACKAGE.stream().noneMatch(prefix -> cls.getPackageName().startsWith(prefix))) {
       var method =
           Assertions.assertDoesNotThrow(
               () -> cls.getDeclaredMethod("ofAlias", String.class),
@@ -83,7 +82,7 @@ class EnumInfoTest {
   @ParameterizedTest
   @ArgumentsSource(EnumClassProvider.class)
   void testToString(Class<?> cls) {
-    if (!EXCLUSION_CLASS.contains(cls)) {
+    if (EXCLUSION_PACKAGE.stream().noneMatch(prefix -> cls.getPackageName().startsWith(prefix))) {
       var enumConstants = (EnumInfo[]) cls.getEnumConstants();
       Assertions.assertDoesNotThrow(() -> cls.getDeclaredMethod("toString"));
       Assertions.assertTrue(

--- a/common/src/test/java/org/astraea/common/EnumInfoTest.java
+++ b/common/src/test/java/org/astraea/common/EnumInfoTest.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
@@ -55,30 +56,39 @@ class EnumInfoTest {
     Assertions.assertEquals(MyTestEnum.BANANA, EnumInfo.ignoreCaseEnum(MyTestEnum.class, "Banana"));
   }
 
+  public static final Set<Class<?>> EXCLUSION_CLASS =
+      Set.of(BeanObjectOuterClass.BeanObject.Primitive.ValueCase.class);
+
   @ParameterizedTest
   @ArgumentsSource(EnumClassProvider.class)
   void testExtendEnumInfo(Class<?> cls) {
-    Assertions.assertTrue(
-        EnumInfo.class.isAssignableFrom(cls), String.format("Fail class %s", cls));
+    if (!EXCLUSION_CLASS.contains(cls)) {
+      Assertions.assertTrue(
+          EnumInfo.class.isAssignableFrom(cls), String.format("Fail class %s", cls));
+    }
   }
 
   @ParameterizedTest
   @ArgumentsSource(EnumClassProvider.class)
   void testOfAlias(Class<?> cls) {
-    var method =
-        Assertions.assertDoesNotThrow(
-            () -> cls.getDeclaredMethod("ofAlias", String.class),
-            String.format("Fail class %s", cls));
-    Assertions.assertEquals(cls, method.getReturnType());
+    if (!EXCLUSION_CLASS.contains(cls)) {
+      var method =
+          Assertions.assertDoesNotThrow(
+              () -> cls.getDeclaredMethod("ofAlias", String.class),
+              String.format("Fail class %s", cls));
+      Assertions.assertEquals(cls, method.getReturnType());
+    }
   }
 
   @ParameterizedTest
   @ArgumentsSource(EnumClassProvider.class)
   void testToString(Class<?> cls) {
-    var enumConstants = (EnumInfo[]) cls.getEnumConstants();
-    Assertions.assertDoesNotThrow(() -> cls.getDeclaredMethod("toString"));
-    Assertions.assertTrue(
-        Arrays.stream(enumConstants).allMatch(x -> x.toString().equals(x.alias())));
+    if (!EXCLUSION_CLASS.contains(cls)) {
+      var enumConstants = (EnumInfo[]) cls.getEnumConstants();
+      Assertions.assertDoesNotThrow(() -> cls.getDeclaredMethod("toString"));
+      Assertions.assertTrue(
+          Arrays.stream(enumConstants).allMatch(x -> x.toString().equals(x.alias())));
+    }
   }
 
   enum MyTestEnum implements EnumInfo {

--- a/common/src/test/java/org/astraea/common/serializer/BeanObjectSerializerTest.java
+++ b/common/src/test/java/org/astraea/common/serializer/BeanObjectSerializerTest.java
@@ -58,4 +58,15 @@ public class BeanObjectSerializerTest {
     Assertions.assertEquals(properties, beanObj.properties());
     Assertions.assertEquals(attributes, beanObj.attributes());
   }
+
+  @Test
+  public void testUnsupportedType() {
+    var domain = "domain";
+    var properties = Map.of("name", "wrongType");
+    var attributes = Map.of("map", (Object) Map.of("k", "v"));
+    var bean = new BeanObject(domain, properties, attributes);
+    var serializer = new Serializer.BeanObjectSerializer();
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> serializer.serialize("ignore", List.of(), bean));
+  }
 }

--- a/common/src/test/java/org/astraea/common/serializer/BeanObjectSerializerTest.java
+++ b/common/src/test/java/org/astraea/common/serializer/BeanObjectSerializerTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.serializer;
+
+import java.util.List;
+import java.util.Map;
+import org.astraea.common.consumer.Deserializer;
+import org.astraea.common.metrics.BeanObject;
+import org.astraea.common.producer.Serializer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class BeanObjectSerializerTest {
+  @Test
+  public void testSerializationDeserialization() {
+    var domain = "domain";
+    var properties = Map.of("name", "DifferentType");
+    var attributes =
+        Map.of(
+            "Integer",
+            (Object) 1,
+            "Long",
+            2L,
+            "Float",
+            (float) 3.4,
+            "Double",
+            4.4,
+            "Boolean",
+            true,
+            "String",
+            "str");
+    var bean = new BeanObject(domain, properties, attributes);
+    var serializer = new Serializer.BeanObjectSerializer();
+    var deserializer = new Deserializer.BeanObjectDeserializer();
+
+    // Valid arguments should not throw
+    Assertions.assertDoesNotThrow(() -> serializer.serialize("ignore", List.of(), bean));
+    var bytes = serializer.serialize("ignore", List.of(), bean);
+    Assertions.assertDoesNotThrow(() -> deserializer.deserialize("ignore", List.of(), bytes));
+    var beanObj = deserializer.deserialize("ignore", List.of(), bytes);
+
+    // Check serialization correctness
+    Assertions.assertEquals("domain", beanObj.domainName());
+    Assertions.assertEquals(properties, beanObj.properties());
+    Assertions.assertEquals(attributes, beanObj.attributes());
+  }
+}


### PR DESCRIPTION
related to #1581 

這隻 PR 引入一個函式庫--protobuf，並且嘗試於 `BeanObject` 上。

這隻 PR 改動了 `EnumInfoTest` ，針對例外類別不做檢查。
因為 protobuf 如果在定義的時候使用到 `oneof` type 時，編譯的時候就會編出 enum 的類別，而 protobuf 編譯出的類別，我們不應該修改，也不應該是我們檢查 (EnumInfoTest) 的對象，所以修改 `EnumInfoTest`。