### PR TITLE
[PARTITIONER] Catch exception in `StrictCostPartitioner`

### DIFF
--- a/common/src/test/java/org/astraea/common/partitioner/StrictCostPartitionerTest.java
+++ b/common/src/test/java/org/astraea/common/partitioner/StrictCostPartitionerTest.java
@@ -33,10 +33,12 @@ import org.astraea.common.admin.Replica;
 import org.astraea.common.cost.BrokerCost;
 import org.astraea.common.cost.BrokerInputCost;
 import org.astraea.common.cost.HasBrokerCost;
+import org.astraea.common.cost.NoSufficientMetricsException;
 import org.astraea.common.cost.NodeThroughputCost;
 import org.astraea.common.cost.ReplicaLeaderCost;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class StrictCostPartitionerTest {
 
@@ -261,6 +263,32 @@ public class StrictCostPartitionerTest {
       partitioner.roundRobinKeeper.tryToUpdate(ClusterInfo.empty(), Map::of);
       // rr is updated already
       Assertions.assertNotEquals(t, partitioner.roundRobinKeeper.lastUpdated.get());
+    }
+  }
+
+  @Test
+  void testCostNoSufficientMetricException() {
+    try (var partitioner = new StrictCostPartitioner()) {
+      partitioner.configure(Configuration.EMPTY);
+      // The cost function always throws exception
+      partitioner.costFunction =
+          new HasBrokerCost() {
+            @Override
+            public BrokerCost brokerCost(ClusterInfo clusterInfo, ClusterBean clusterBean) {
+              throw new NoSufficientMetricsException(this, Duration.ZERO);
+            }
+          };
+      var clusterInfo = Mockito.mock(ClusterInfo.class);
+      var replicaLeader1 = Mockito.mock(Replica.class);
+      var replicaLeader2 = Mockito.mock(Replica.class);
+      Mockito.when(clusterInfo.replicaLeaders("topicA"))
+          .thenReturn(List.of(replicaLeader1, replicaLeader2));
+
+      try {
+        partitioner.partition("topic", new byte[0], new byte[0], clusterInfo);
+      } catch (NoSufficientMetricsException e) {
+        Assertions.fail();
+      }
     }
   }
 }


### PR DESCRIPTION
resolve #1111 

cost function 若遇到數據不夠，可能會丟出 `NoSufficientException`，我認為這個錯誤應該要在 StrictCostPartitioner 內處理。

對此錯誤的處理方式，這裡選擇忽略，原因是 cost 在 partitioner 內是一個分配方式的參考，不應為了 "取得 cost" 而等待。
而忽略錯誤對 StrictCostPartitioner 的影響在於 "拿不到最新的數據，只能用舊有數據繼續判斷"。