### PR TITLE
[COST] Enable to tune the estimation method of `NetworkCost`

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/EstimationMethod.java
+++ b/common/src/main/java/org/astraea/common/cost/EstimationMethod.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.cost;
+
+import org.astraea.common.EnumInfo;
+
+/** Method to estimate the partition bandwidth */
+enum EstimationMethod implements EnumInfo {
+  BROKER_TOPIC_ONE_MINUTE_RATE,
+  BROKER_TOPIC_FIVE_MINUTE_RATE,
+  BROKER_TOPIC_FIFTEEN_MINUTE_RATE;
+
+  static EstimationMethod ofAlias(String alias) {
+    return EnumInfo.ignoreCaseEnum(EstimationMethod.class, alias);
+  }
+
+  @Override
+  public String alias() {
+    return name();
+  }
+
+  @Override
+  public String toString() {
+    return alias();
+  }
+}

--- a/common/src/main/java/org/astraea/common/cost/NetworkCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NetworkCost.java
@@ -328,27 +328,6 @@ public abstract class NetworkCost implements HasClusterCost {
     }
   }
 
-  /** Method to estimate the partition bandwidth */
-  enum EstimationMethod implements EnumInfo {
-    BROKER_TOPIC_ONE_MINUTE_RATE,
-    BROKER_TOPIC_FIVE_MINUTE_RATE,
-    BROKER_TOPIC_FIFTEEN_MINUTE_RATE;
-
-    static EstimationMethod ofAlias(String alias) {
-      return EnumInfo.ignoreCaseEnum(EstimationMethod.class, alias);
-    }
-
-    @Override
-    public String alias() {
-      return name();
-    }
-
-    @Override
-    public String toString() {
-      return alias();
-    }
-  }
-
   private class CachedCalculation {
     private final Map<TopicPartition, Long> partitionIngressRate;
     private final Map<TopicPartition, Long> partitionEgressRate;

--- a/common/src/main/java/org/astraea/common/cost/NetworkCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NetworkCost.java
@@ -85,7 +85,7 @@ public abstract class NetworkCost implements HasClusterCost {
         config
             .string(NETWORK_COST_ESTIMATION_METHOD)
             .map(EstimationMethod::ofAlias)
-            .orElse(EstimationMethod.BrokerTopicOneMinuteRate);
+            .orElse(EstimationMethod.BROKER_TOPIC_ONE_MINUTE_RATE);
   }
 
   void noMetricCheck(ClusterBean clusterBean) {
@@ -239,11 +239,11 @@ public abstract class NetworkCost implements HasClusterCost {
                           .map(
                               hasRate -> {
                                 switch (estimationMethod) {
-                                  case BrokerTopicOneMinuteRate:
+                                  case BROKER_TOPIC_ONE_MINUTE_RATE:
                                     return hasRate.oneMinuteRate();
-                                  case BrokerTopicFiveMinuteRate:
+                                  case BROKER_TOPIC_FIVE_MINUTE_RATE:
                                     return hasRate.fiveMinuteRate();
-                                  case BrokerTopicFifteenMinuteRate:
+                                  case BROKER_TOPIC_FIFTEEN_MINUTE_RATE:
                                     return hasRate.fifteenMinuteRate();
                                   default:
                                     throw new IllegalStateException(
@@ -330,9 +330,9 @@ public abstract class NetworkCost implements HasClusterCost {
 
   /** Method to estimate the partition bandwidth */
   enum EstimationMethod implements EnumInfo {
-    BrokerTopicOneMinuteRate,
-    BrokerTopicFiveMinuteRate,
-    BrokerTopicFifteenMinuteRate;
+    BROKER_TOPIC_ONE_MINUTE_RATE,
+    BROKER_TOPIC_FIVE_MINUTE_RATE,
+    BROKER_TOPIC_FIFTEEN_MINUTE_RATE;
 
     static EstimationMethod ofAlias(String alias) {
       return EnumInfo.ignoreCaseEnum(EstimationMethod.class, alias);

--- a/common/src/main/java/org/astraea/common/cost/NetworkCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NetworkCost.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.astraea.common.Configuration;
 import org.astraea.common.DataRate;
 import org.astraea.common.EnumInfo;
 import org.astraea.common.admin.BrokerTopic;
@@ -36,7 +37,6 @@ import org.astraea.common.admin.Replica;
 import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.cost.utils.ClusterInfoSensor;
 import org.astraea.common.metrics.HasBeanObject;
-import org.astraea.common.metrics.broker.HasRate;
 import org.astraea.common.metrics.broker.LogMetrics;
 import org.astraea.common.metrics.broker.ServerMetrics;
 import org.astraea.common.metrics.collector.MetricSensor;
@@ -60,17 +60,32 @@ import org.astraea.common.metrics.platform.HostMetrics;
  *       every consumer fetches data from the leader(which is the default behavior of Kafka). For
  *       more detail about consumer rack awareness or how consumer can fetch data from the closest
  *       replica, see <a href="https://cwiki.apache.org/confluence/x/go_zBQ">KIP-392<a>.
+ *   <li>NetworkCost implementation use broker-topic bandwidth rate and some other info to estimate
+ *       the broker-topic-partition bandwidth rate. The implementation assume the broker-topic
+ *       bandwidth is correct and steadily reflect the actual resource usage. This is generally true
+ *       when the broker has reach its steady state, but to reach that state might takes awhile. And
+ *       based on our observation this probably won't happen at the early broker start (see <a
+ *       href="https://github.com/skiptests/astraea/issues/1641">Issue #1641</a>). We suggest use
+ *       this cost with metrics from the servers in steady state.
  * </ol>
  */
 public abstract class NetworkCost implements HasClusterCost {
 
+  public static final String NETWORK_COST_ESTIMATION_METHOD = "network.cost.estimation.method";
+
+  private final EstimationMethod estimationMethod;
   private final BandwidthType bandwidthType;
   private final Map<ClusterBean, CachedCalculation> calculationCache;
   private final ClusterInfoSensor clusterInfoSensor = new ClusterInfoSensor();
 
-  NetworkCost(BandwidthType bandwidthType) {
+  NetworkCost(Configuration config, BandwidthType bandwidthType) {
     this.bandwidthType = bandwidthType;
     this.calculationCache = new ConcurrentHashMap<>();
+    this.estimationMethod =
+        config
+            .string(NETWORK_COST_ESTIMATION_METHOD)
+            .map(EstimationMethod::ofAlias)
+            .orElse(EstimationMethod.BrokerTopicOneMinuteRate);
   }
 
   void noMetricCheck(ClusterBean clusterBean) {
@@ -221,7 +236,20 @@ public abstract class NetworkCost implements HasClusterCost {
                           .brokerTopicMetrics(bt, ServerMetrics.Topic.Meter.class)
                           .filter(bean -> bean.type().equals(metric))
                           .max(Comparator.comparingLong(HasBeanObject::createdTimestamp))
-                          .map(HasRate::fifteenMinuteRate)
+                          .map(
+                              hasRate -> {
+                                switch (estimationMethod) {
+                                  case BrokerTopicOneMinuteRate:
+                                    return hasRate.oneMinuteRate();
+                                  case BrokerTopicFiveMinuteRate:
+                                    return hasRate.fiveMinuteRate();
+                                  case BrokerTopicFifteenMinuteRate:
+                                    return hasRate.fifteenMinuteRate();
+                                  default:
+                                    throw new IllegalStateException(
+                                        "Unknown estimation method: " + estimationMethod);
+                                }
+                              })
                           // no load metric for this partition, treat as zero load
                           .orElse(0.0);
               if (Double.isNaN(totalShare) || totalShare < 0)
@@ -287,6 +315,27 @@ public abstract class NetworkCost implements HasClusterCost {
 
     static BandwidthType ofAlias(String alias) {
       return EnumInfo.ignoreCaseEnum(BandwidthType.class, alias);
+    }
+
+    @Override
+    public String alias() {
+      return name();
+    }
+
+    @Override
+    public String toString() {
+      return alias();
+    }
+  }
+
+  /** Method to estimate the partition bandwidth */
+  enum EstimationMethod implements EnumInfo {
+    BrokerTopicOneMinuteRate,
+    BrokerTopicFiveMinuteRate,
+    BrokerTopicFifteenMinuteRate;
+
+    static EstimationMethod ofAlias(String alias) {
+      return EnumInfo.ignoreCaseEnum(EstimationMethod.class, alias);
     }
 
     @Override

--- a/common/src/main/java/org/astraea/common/cost/NetworkEgressCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NetworkEgressCost.java
@@ -16,13 +16,15 @@
  */
 package org.astraea.common.cost;
 
+import org.astraea.common.Configuration;
+
 /**
  * A cost function to evaluate cluster load balance score in terms of message egress data rate. See
  * {@link NetworkCost} for further detail.
  */
 public class NetworkEgressCost extends NetworkCost {
-  public NetworkEgressCost() {
-    super(BandwidthType.Egress);
+  public NetworkEgressCost(Configuration config) {
+    super(config, BandwidthType.Egress);
   }
 
   @Override

--- a/common/src/main/java/org/astraea/common/cost/NetworkIngressCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NetworkIngressCost.java
@@ -37,7 +37,7 @@ public class NetworkIngressCost extends NetworkCost implements HasPartitionCost 
   private static final String TRAFFIC_INTERVAL = "traffic.interval";
 
   public NetworkIngressCost(Configuration config) {
-    super(BandwidthType.Ingress);
+    super(config, BandwidthType.Ingress);
     this.config = config;
   }
 

--- a/common/src/main/java/org/astraea/common/metrics/broker/HasRate.java
+++ b/common/src/main/java/org/astraea/common/metrics/broker/HasRate.java
@@ -21,19 +21,19 @@ import org.astraea.common.metrics.HasBeanObject;
 
 public interface HasRate extends HasBeanObject {
   default double meanRate() {
-    return (double) beanObject().attributes().getOrDefault("MeanRate", 0);
+    return (double) beanObject().attributes().getOrDefault("MeanRate", 0.0);
   }
 
   default double oneMinuteRate() {
-    return (double) beanObject().attributes().getOrDefault("OneMinuteRate", 0);
+    return (double) beanObject().attributes().getOrDefault("OneMinuteRate", 0.0);
   }
 
   default double fiveMinuteRate() {
-    return (double) beanObject().attributes().getOrDefault("FiveMinuteRate", 0);
+    return (double) beanObject().attributes().getOrDefault("FiveMinuteRate", 0.0);
   }
 
   default double fifteenMinuteRate() {
-    return (double) beanObject().attributes().getOrDefault("FifteenMinuteRate", 0);
+    return (double) beanObject().attributes().getOrDefault("FifteenMinuteRate", 0.0);
   }
 
   default TimeUnit rateUnit() {

--- a/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
@@ -526,18 +526,21 @@ class NetworkCostTest {
         Utils.construct(
             clz,
             Configuration.of(
-                Map.of(NetworkCost.NETWORK_COST_ESTIMATION_METHOD, "BrokerTopicOneMinuteRate")));
+                Map.of(
+                    NetworkCost.NETWORK_COST_ESTIMATION_METHOD, "BROKER_TOPIC_ONE_MINUTE_RATE")));
     var fiveCost =
         Utils.construct(
             clz,
             Configuration.of(
-                Map.of(NetworkCost.NETWORK_COST_ESTIMATION_METHOD, "BrokerTopicFiveMinuteRate")));
+                Map.of(
+                    NetworkCost.NETWORK_COST_ESTIMATION_METHOD, "BROKER_TOPIC_FIVE_MINUTE_RATE")));
     var fifteenCost =
         Utils.construct(
             clz,
             Configuration.of(
                 Map.of(
-                    NetworkCost.NETWORK_COST_ESTIMATION_METHOD, "BrokerTopicFifteenMinuteRate")));
+                    NetworkCost.NETWORK_COST_ESTIMATION_METHOD,
+                    "BROKER_TOPIC_FIFTEEN_MINUTE_RATE")));
 
     Assertions.assertEquals(
         one, oneCost.estimateRate(cluster, beans, metric).get(partition).doubleValue());

--- a/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NetworkCostTest.java
@@ -32,6 +32,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.astraea.common.Configuration;
 import org.astraea.common.DataRate;
+import org.astraea.common.Utils;
 import org.astraea.common.admin.BrokerTopic;
 import org.astraea.common.admin.ClusterBean;
 import org.astraea.common.admin.ClusterInfo;
@@ -54,6 +55,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -104,7 +106,7 @@ class NetworkCostTest {
             Map.entry(TopicPartition.of("Pipeline-0"), 455730337L));
     Assertions.assertEquals(
         expected,
-        new NetworkEgressCost()
+        new NetworkEgressCost(Configuration.EMPTY)
             .estimateRate(t.clusterInfo(), t.clusterBean(), ServerMetrics.Topic.BYTES_OUT_PER_SEC));
   }
 
@@ -118,10 +120,14 @@ class NetworkCostTest {
             new NetworkIngressCost(Configuration.EMPTY), new LargeTestCase(10, 200, 0xcafebabe)),
         Arguments.of(
             new NetworkIngressCost(Configuration.EMPTY), new LargeTestCase(15, 300, 0xfee1dead)),
-        Arguments.of(new NetworkEgressCost(), new LargeTestCase(5, 100, 0xfa11fa11)),
-        Arguments.of(new NetworkEgressCost(), new LargeTestCase(6, 100, 0xf001f001)),
-        Arguments.of(new NetworkEgressCost(), new LargeTestCase(8, 200, 0xba1aba1a)),
-        Arguments.of(new NetworkEgressCost(), new LargeTestCase(14, 300, 0xdd0000bb)));
+        Arguments.of(
+            new NetworkEgressCost(Configuration.EMPTY), new LargeTestCase(5, 100, 0xfa11fa11)),
+        Arguments.of(
+            new NetworkEgressCost(Configuration.EMPTY), new LargeTestCase(6, 100, 0xf001f001)),
+        Arguments.of(
+            new NetworkEgressCost(Configuration.EMPTY), new LargeTestCase(8, 200, 0xba1aba1a)),
+        Arguments.of(
+            new NetworkEgressCost(Configuration.EMPTY), new LargeTestCase(14, 300, 0xdd0000bb)));
   }
 
   @ParameterizedTest
@@ -152,7 +158,7 @@ class NetworkCostTest {
         HasClusterCost.of(
             Map.of(
                 new NetworkIngressCost(Configuration.EMPTY), 1.0,
-                new NetworkEgressCost(), 1.0));
+                new NetworkEgressCost(Configuration.EMPTY), 1.0));
     testOptimization(costFunction, testCase);
   }
 
@@ -237,7 +243,8 @@ class NetworkCostTest {
         (expectedEgress3 - expectedEgress2) / Math.max(ingressSum, egressSum);
     double ingressScore =
         new NetworkIngressCost(Configuration.EMPTY).clusterCost(cluster, beans).value();
-    double egressScore = new NetworkEgressCost().clusterCost(cluster, beans).value();
+    double egressScore =
+        new NetworkEgressCost(Configuration.EMPTY).clusterCost(cluster, beans).value();
     Assertions.assertTrue(
         around.apply(expectedIngressScore).test(ingressScore),
         "Ingress score should be " + expectedIngressScore + " but it is " + ingressScore);
@@ -299,11 +306,12 @@ class NetworkCostTest {
         () -> new NetworkIngressCost(Configuration.EMPTY).clusterCost(cluster, beans),
         "Metric sampled but no load value, treat as zero load");
     Assertions.assertDoesNotThrow(
-        () -> new NetworkEgressCost().clusterCost(cluster, beans),
+        () -> new NetworkEgressCost(Configuration.EMPTY).clusterCost(cluster, beans),
         "Metric sampled but no load value, treat as zero load");
     Assertions.assertEquals(
         0, new NetworkIngressCost(Configuration.EMPTY).clusterCost(cluster, beans).value());
-    Assertions.assertEquals(0, new NetworkEgressCost().clusterCost(cluster, beans).value());
+    Assertions.assertEquals(
+        0, new NetworkEgressCost(Configuration.EMPTY).clusterCost(cluster, beans).value());
 
     Assertions.assertThrows(
         NoSufficientMetricsException.class,
@@ -315,7 +323,7 @@ class NetworkCostTest {
     Assertions.assertThrows(
         NoSufficientMetricsException.class,
         () ->
-            new NetworkEgressCost()
+            new NetworkEgressCost(Configuration.EMPTY)
                 .clusterCost(
                     cluster, ClusterBean.of(Map.of(1, List.of(), 2, List.of(), 3, List.of()))),
         "Should raise a exception since we don't know if first sample is performed or not");
@@ -334,7 +342,11 @@ class NetworkCostTest {
         new ShuffleTweaker(() -> ThreadLocalRandom.current().nextInt(1, 31), (x) -> true);
     var costFunction =
         HasClusterCost.of(
-            Map.of(new NetworkIngressCost(Configuration.EMPTY), 1.0, new NetworkEgressCost(), 1.0));
+            Map.of(
+                new NetworkIngressCost(Configuration.EMPTY),
+                1.0,
+                new NetworkEgressCost(Configuration.EMPTY),
+                1.0));
     var originalCost = costFunction.clusterCost(clusterInfo, clusterBean);
 
     Function<ShuffleTweaker, Double> experiment =
@@ -406,7 +418,8 @@ class NetworkCostTest {
     Assertions.assertEquals(2, costI.brokerRate.size());
     Assertions.assertEquals(0L, costI.brokerRate.get(node.id()));
     var costE =
-        (NetworkCost.NetworkClusterCost) new NetworkEgressCost().clusterCost(scaledCluster, beans);
+        (NetworkCost.NetworkClusterCost)
+            new NetworkEgressCost(Configuration.EMPTY).clusterCost(scaledCluster, beans);
     Assertions.assertEquals(2, costE.brokerRate.size());
     Assertions.assertEquals(0L, costE.brokerRate.get(node.id()));
   }
@@ -465,6 +478,73 @@ class NetworkCostTest {
     Assertions.assertEquals(ingressPartitionCost.get(TopicPartition.of("test-6")), (double) 7 / 12);
     Assertions.assertEquals(ingressPartitionCost.get(TopicPartition.of("test-7")), (double) 8 / 15);
     Assertions.assertEquals(ingressPartitionCost.get(TopicPartition.of("test-8")), (double) 9 / 18);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "BYTES_IN_PER_SEC, org.astraea.common.cost.NetworkIngressCost",
+    "BYTES_IN_PER_SEC, org.astraea.common.cost.NetworkEgressCost",
+    "BYTES_OUT_PER_SEC, org.astraea.common.cost.NetworkEgressCost",
+    "BYTES_OUT_PER_SEC, org.astraea.common.cost.NetworkEgressCost",
+  })
+  void testEstimationMethod(ServerMetrics.Topic metric, Class<? extends NetworkCost> clz) {
+    var cluster =
+        ClusterInfoBuilder.builder()
+            .addNode(Set.of(1))
+            .addFolders(Map.of(1, Set.of("/folder")))
+            .addTopic("Topic", 1, (short) 1)
+            .mapLog(r -> Replica.builder(r).size(100).build())
+            .build();
+    var partition = TopicPartition.of("Topic", 0);
+
+    var domainName = "kafka.server";
+    var one = (double) ThreadLocalRandom.current().nextInt(1, 10000);
+    var five = (double) ThreadLocalRandom.current().nextInt(1, 10000);
+    var fifteen = (double) ThreadLocalRandom.current().nextInt(1, 10000);
+    var beans =
+        ClusterBean.of(
+            Map.of(
+                1,
+                List.of(
+                    MetricFactory.ofPartitionMetric(partition.topic(), partition.partition(), 1),
+                    new ServerMetrics.Topic.Meter(
+                        new BeanObject(
+                            domainName,
+                            Map.of(
+                                "type",
+                                "BrokerTopicMetrics",
+                                "topic",
+                                "Topic",
+                                "name",
+                                metric.alias()),
+                            Map.of(
+                                "OneMinuteRate", one,
+                                "FiveMinuteRate", five,
+                                "FifteenMinuteRate", fifteen))))));
+
+    var oneCost =
+        Utils.construct(
+            clz,
+            Configuration.of(
+                Map.of(NetworkCost.NETWORK_COST_ESTIMATION_METHOD, "BrokerTopicOneMinuteRate")));
+    var fiveCost =
+        Utils.construct(
+            clz,
+            Configuration.of(
+                Map.of(NetworkCost.NETWORK_COST_ESTIMATION_METHOD, "BrokerTopicFiveMinuteRate")));
+    var fifteenCost =
+        Utils.construct(
+            clz,
+            Configuration.of(
+                Map.of(
+                    NetworkCost.NETWORK_COST_ESTIMATION_METHOD, "BrokerTopicFifteenMinuteRate")));
+
+    Assertions.assertEquals(
+        one, oneCost.estimateRate(cluster, beans, metric).get(partition).doubleValue());
+    Assertions.assertEquals(
+        five, fiveCost.estimateRate(cluster, beans, metric).get(partition).doubleValue());
+    Assertions.assertEquals(
+        fifteen, fifteenCost.estimateRate(cluster, beans, metric).get(partition).doubleValue());
   }
 
   interface TestCase {
@@ -543,6 +623,20 @@ class NetworkCostTest {
                           .builder()
                           .topic(topic)
                           .time(time.toEpochSecond(ZoneOffset.UTC))
+                          .oneMinuteRate(
+                              clusterInfo
+                                  .replicaStream(BrokerTopic.of(broker, topic))
+                                  .filter(Replica::isLeader)
+                                  .filter(Replica::isOnline)
+                                  .mapToDouble(r -> rate.get(r.topicPartition()))
+                                  .sum())
+                          .fiveMinuteRate(
+                              clusterInfo
+                                  .replicaStream(BrokerTopic.of(broker, topic))
+                                  .filter(Replica::isLeader)
+                                  .filter(Replica::isOnline)
+                                  .mapToDouble(r -> rate.get(r.topicPartition()))
+                                  .sum())
                           .fifteenMinuteRate(
                               clusterInfo
                                   .replicaStream(BrokerTopic.of(broker, topic))
@@ -557,6 +651,26 @@ class NetworkCostTest {
                           .builder()
                           .topic(topic)
                           .time(time.toEpochSecond(ZoneOffset.UTC))
+                          .oneMinuteRate(
+                              clusterInfo
+                                  .replicaStream(BrokerTopic.of(broker, topic))
+                                  .filter(Replica::isLeader)
+                                  .filter(Replica::isOnline)
+                                  .mapToDouble(
+                                      r ->
+                                          rate.get(r.topicPartition())
+                                              * consumerFanout.get(r.topicPartition()))
+                                  .sum())
+                          .fiveMinuteRate(
+                              clusterInfo
+                                  .replicaStream(BrokerTopic.of(broker, topic))
+                                  .filter(Replica::isLeader)
+                                  .filter(Replica::isOnline)
+                                  .mapToDouble(
+                                      r ->
+                                          rate.get(r.topicPartition())
+                                              * consumerFanout.get(r.topicPartition()))
+                                  .sum())
                           .fifteenMinuteRate(
                               clusterInfo
                                   .replicaStream(BrokerTopic.of(broker, topic))
@@ -615,12 +729,16 @@ class NetworkCostTest {
   }
 
   static ServerMetrics.Topic.Meter bandwidth(
-      ServerMetrics.Topic metric, String topic, double fifteenRate) {
+      ServerMetrics.Topic metric, String topic, double steadyStateRate) {
     if (metric == null) return noise(0);
     var domainName = "kafka.server";
     var properties =
-        Map.of("type", "BrokerTopicMetric", "topic", topic, "name", metric.metricName());
-    var attributes = Map.<String, Object>of("FifteenMinuteRate", fifteenRate);
+        Map.of("type", "BrokerTopicMetrics", "topic", topic, "name", metric.metricName());
+    var attributes =
+        Map.<String, Object>of(
+            "OneMinuteRate", steadyStateRate,
+            "FiveMinuteRate", steadyStateRate,
+            "FifteenMinuteRate", steadyStateRate);
     return new ServerMetrics.Topic.Meter(new BeanObject(domainName, properties, attributes));
   }
 


### PR DESCRIPTION
Context: https://github.com/skiptests/astraea/issues/1641#issuecomment-1500000107

因為 FifteenMinuteRate 的等待時間有點長，要在短時間內使用他當做判斷依據有點困難，如果在 Rate 還沒收斂時就拿來當判斷依據，會有誤差出現，詳情參見 #1641 的測試。

這個 PR 允許使用者調整 network cost 要使用的衡量方法，目前提供 One/Five/Fifteen Minute Rate，預設會使用 One Minute Rate，他收斂的速度會比較快，但相對來說也會比較難反映稍微長遠的變化。

另外，雖然 FifteenMinuteRate 可以反映更長的流量行為，但根據 #1641 的測試最長似乎也就 1 小時左右，如果真的要考量長遠的流量行為，可能 NetworkCost 不適合。
