### PR TITLE
[METRICS] Remove default value of attribute function for `HasCount` & `HasRate`

### DIFF
--- a/common/src/main/java/org/astraea/common/metrics/broker/HasCount.java
+++ b/common/src/main/java/org/astraea/common/metrics/broker/HasCount.java
@@ -20,6 +20,6 @@ import org.astraea.common.metrics.HasBeanObject;
 
 public interface HasCount extends HasBeanObject {
   default long count() {
-    return (long) beanObject().attributes().getOrDefault("Count", 0);
+    return (long) beanObject().attributes().get("Count");
   }
 }

--- a/common/src/main/java/org/astraea/common/metrics/broker/HasRate.java
+++ b/common/src/main/java/org/astraea/common/metrics/broker/HasRate.java
@@ -21,19 +21,19 @@ import org.astraea.common.metrics.HasBeanObject;
 
 public interface HasRate extends HasBeanObject {
   default double meanRate() {
-    return (double) beanObject().attributes().getOrDefault("MeanRate", 0.0);
+    return (double) beanObject().attributes().get("MeanRate");
   }
 
   default double oneMinuteRate() {
-    return (double) beanObject().attributes().getOrDefault("OneMinuteRate", 0.0);
+    return (double) beanObject().attributes().get("OneMinuteRate");
   }
 
   default double fiveMinuteRate() {
-    return (double) beanObject().attributes().getOrDefault("FiveMinuteRate", 0.0);
+    return (double) beanObject().attributes().get("FiveMinuteRate");
   }
 
   default double fifteenMinuteRate() {
-    return (double) beanObject().attributes().getOrDefault("FifteenMinuteRate", 0.0);
+    return (double) beanObject().attributes().get("FifteenMinuteRate");
   }
 
   default TimeUnit rateUnit() {

--- a/common/src/test/java/org/astraea/common/cost/NetworkIngressCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NetworkIngressCostTest.java
@@ -25,7 +25,6 @@ import org.astraea.common.DataRate;
 import org.astraea.common.admin.ClusterBean;
 import org.astraea.common.admin.ClusterInfoBuilder;
 import org.astraea.common.admin.Replica;
-import org.astraea.common.metrics.BeanObject;
 import org.astraea.common.metrics.broker.ServerMetrics;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -57,13 +56,13 @@ public class NetworkIngressCostTest {
             Map.of(
                 1,
                 List.of(
-                    bandwidth(
+                    NetworkCostTest.bandwidth(
                         ServerMetrics.Topic.BYTES_IN_PER_SEC,
                         "a",
                         DataRate.MB.of(60).perSecond().byteRate())),
                 2,
                 List.of(
-                    bandwidth(
+                    NetworkCostTest.bandwidth(
                         ServerMetrics.Topic.BYTES_IN_PER_SEC,
                         "a",
                         DataRate.MB.of(60).perSecond().byteRate()))));
@@ -115,11 +114,11 @@ public class NetworkIngressCostTest {
             Map.of(
                 1,
                 List.of(
-                    bandwidth(
+                    NetworkCostTest.bandwidth(
                         ServerMetrics.Topic.BYTES_IN_PER_SEC,
                         "a",
                         DataRate.MB.of(100).perSecond().byteRate()),
-                    bandwidth(
+                    NetworkCostTest.bandwidth(
                         ServerMetrics.Topic.BYTES_IN_PER_SEC,
                         "b",
                         DataRate.MB.of(100).perSecond().byteRate()))));
@@ -133,14 +132,5 @@ public class NetworkIngressCostTest {
           if (tp.topic().equals("a") && tp.partition() == 0) Assertions.assertEquals(3, set.size());
           else Assertions.assertEquals(1, set.size());
         });
-  }
-
-  static ServerMetrics.Topic.Meter bandwidth(
-      ServerMetrics.Topic metric, String topic, double fifteenRate) {
-    var domainName = "kafka.server";
-    var properties =
-        Map.of("type", "BrokerTopicMetric", "topic", topic, "name", metric.metricName());
-    var attributes = Map.<String, Object>of("FifteenMinuteRate", fifteenRate);
-    return new ServerMetrics.Topic.Meter(new BeanObject(domainName, properties, attributes));
   }
 }


### PR DESCRIPTION
Context: https://github.com/skiptests/astraea/pull/1643#discussion_r1161066272

把 `HasCount` 和 `HasRate` 內的部分 attribute 在讀取時會自動在 attribute 不存在時帶入 0 當預設值，這個行為可能會造成一些誤會，比如該 BeanObject 沒有這個 attribute 卻依然回傳值。

這個 PR 移除這個行為，現在當讀取欄位的 attribute 不存在時，會觸發 `NullPointerException` 而非回傳預設值 0