### PR TITLE
[METRIC] Move serializer out from producer package

### DIFF
--- a/common/src/main/java/org/astraea/common/consumer/Deserializer.java
+++ b/common/src/main/java/org/astraea/common/consumer/Deserializer.java
@@ -17,12 +17,9 @@
 package org.astraea.common.consumer;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.kafka.common.header.Headers;
@@ -121,35 +118,6 @@ public interface Deserializer<T> {
       else {
         return jackson.fromJson(Deserializer.STRING.deserialize(topic, headers, data), typeRef);
       }
-    }
-  }
-
-  /**
-   * Deserialize byte arrays to string and then parse the string to `BeanObject`. It is inverse of
-   * BeanObject.toString().getBytes(). TODO: Should be replaced by protoBuf
-   */
-  class BeanDeserializer implements Deserializer<BeanObject> {
-    @Override
-    public BeanObject deserialize(String topic, List<Header> headers, byte[] data) {
-      var beanString = new String(data);
-      Pattern p =
-          Pattern.compile("\\[(?<domain>[^:]*):(?<properties>[^]]*)]\n\\{(?<attributes>[^}]*)}");
-      Matcher m = p.matcher(beanString);
-      if (!m.matches()) return null;
-      var domain = m.group("domain");
-      var propertiesPairs = m.group("properties").split("[, ]");
-      var attributesPairs = m.group("attributes").split("[, ]");
-      var properties =
-          Arrays.stream(propertiesPairs)
-              .map(kv -> kv.split("="))
-              .filter(kv -> kv.length >= 2)
-              .collect(Collectors.toUnmodifiableMap(kv -> kv[0], kv -> kv[1]));
-      var attributes =
-          Arrays.stream(attributesPairs)
-              .map(kv -> kv.split("="))
-              .filter(kv -> kv.length >= 2)
-              .collect(Collectors.toUnmodifiableMap(kv -> kv[0], kv -> (Object) kv[1]));
-      return new BeanObject(domain, properties, attributes);
     }
   }
 

--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricFetcher.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricFetcher.java
@@ -100,7 +100,7 @@ public interface MetricFetcher extends AutoCloseable {
           Producer.builder()
               .bootstrapServers(bootstrapServer)
               .keySerializer(Serializer.INTEGER)
-              .valueSerializer(Serializer.STRING)
+              .valueSerializer(Serializer.BEAN_OBJECT)
               .build();
       String METRIC_TOPIC = "__metrics";
       return new Sender() {
@@ -108,13 +108,7 @@ public interface MetricFetcher extends AutoCloseable {
         public CompletionStage<Void> send(int id, Collection<BeanObject> beans) {
           var records =
               beans.stream()
-                  .map(
-                      bean ->
-                          Record.builder()
-                              .topic(METRIC_TOPIC)
-                              .key(id)
-                              .value(bean.toString())
-                              .build())
+                  .map(bean -> Record.builder().topic(METRIC_TOPIC).key(id).value(bean).build())
                   .collect(Collectors.toUnmodifiableList());
           return FutureUtils.sequence(
                   producer.send(records).stream()

--- a/common/src/main/java/org/astraea/common/producer/Serializer.java
+++ b/common/src/main/java/org/astraea/common/producer/Serializer.java
@@ -35,7 +35,6 @@ import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.Replica;
 import org.astraea.common.admin.Topic;
 import org.astraea.common.backup.ByteUtils;
-import org.astraea.common.generated.BeanObjectOuterClass;
 import org.astraea.common.json.JsonConverter;
 import org.astraea.common.json.TypeRef;
 import org.astraea.common.metrics.BeanObject;
@@ -84,6 +83,9 @@ public interface Serializer<T> {
   Serializer<Topic> TOPIC = new TopicSerializer();
   Serializer<Replica> REPLICA = new ReplicaSerializer();
   Serializer<ClusterInfo> CLUSTER_INFO = new ClusterInfoSerializer();
+  Serializer<BeanObject> BEAN_OBJECT =
+      (topic, headers, data) ->
+          org.astraea.common.serialization.Serializer.BEAN_OBJECT_SERIALIZER.serialize(data);
 
   /**
    * create Custom JsonSerializer
@@ -249,40 +251,6 @@ public interface Serializer<T> {
             buffer.put(bytes);
           });
       return buffer.array();
-    }
-  }
-
-  class BeanObjectSerializer implements Serializer<BeanObject> {
-    @Override
-    public byte[] serialize(String topic, Collection<Header> headers, BeanObject data) {
-      var beanBuilder = BeanObjectOuterClass.BeanObject.newBuilder();
-      beanBuilder.setDomain(data.domainName());
-      beanBuilder.putAllProperties(data.properties());
-      data.attributes().forEach((key, val) -> beanBuilder.putAttributes(key, primitive(val)));
-
-      return beanBuilder.build().toByteArray();
-    }
-
-    private static BeanObjectOuterClass.BeanObject.Primitive primitive(Object v) {
-      if (v instanceof Integer)
-        return BeanObjectOuterClass.BeanObject.Primitive.newBuilder().setInt((int) v).build();
-      else if (v instanceof Long)
-        return BeanObjectOuterClass.BeanObject.Primitive.newBuilder().setLong((long) v).build();
-      else if (v instanceof Float)
-        return BeanObjectOuterClass.BeanObject.Primitive.newBuilder().setFloat((float) v).build();
-      else if (v instanceof Double)
-        return BeanObjectOuterClass.BeanObject.Primitive.newBuilder().setDouble((double) v).build();
-      else if (v instanceof Boolean)
-        return BeanObjectOuterClass.BeanObject.Primitive.newBuilder()
-            .setBoolean((boolean) v)
-            .build();
-      else if (v instanceof String)
-        return BeanObjectOuterClass.BeanObject.Primitive.newBuilder().setStr(v.toString()).build();
-      else
-        throw new IllegalArgumentException(
-            "Type "
-                + v.getClass()
-                + " is not supported. Please use Integer, Long, Float, Double, Boolean, String instead.");
     }
   }
 }

--- a/common/src/main/java/org/astraea/common/serialization/Deserializer.java
+++ b/common/src/main/java/org/astraea/common/serialization/Deserializer.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.serialization;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.astraea.common.Utils;
+import org.astraea.common.generated.BeanObjectOuterClass;
+import org.astraea.common.generated.PrimitiveOuterClass;
+import org.astraea.common.metrics.BeanObject;
+
+public interface Deserializer<T> {
+  T deserialize(byte[] data);
+
+  /** Deserialize to BeanObject with protocol buffer */
+  Deserializer<BeanObject> BEAN_OBJECT =
+      data -> {
+        // Pack InvalidProtocolBufferException thrown by protoBuf
+        var outerBean = Utils.packException(() -> BeanObjectOuterClass.BeanObject.parseFrom(data));
+        return new BeanObject(
+            outerBean.getDomain(),
+            outerBean.getPropertiesMap(),
+            outerBean.getAttributesMap().entrySet().stream()
+                .collect(
+                    Collectors.toUnmodifiableMap(
+                        Map.Entry::getKey, e -> Objects.requireNonNull(toObject(e.getValue())))));
+      };
+
+  /** Retrieve field from "one of" field. */
+  static Object toObject(PrimitiveOuterClass.Primitive v) {
+    var oneOfCase = v.getValueCase();
+    switch (oneOfCase) {
+      case INT:
+        return v.getInt();
+      case LONG:
+        return v.getLong();
+      case FLOAT:
+        return v.getFloat();
+      case DOUBLE:
+        return v.getDouble();
+      case BOOLEAN:
+        return v.getBoolean();
+      case STR:
+        return v.getStr();
+      case VALUE_NOT_SET:
+      default:
+        throw new IllegalArgumentException("The value is not set.");
+    }
+  }
+}

--- a/common/src/main/java/org/astraea/common/serialization/Serializer.java
+++ b/common/src/main/java/org/astraea/common/serialization/Serializer.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.serialization;
+
+import org.astraea.common.generated.BeanObjectOuterClass;
+import org.astraea.common.generated.PrimitiveOuterClass;
+import org.astraea.common.metrics.BeanObject;
+
+public interface Serializer<T> {
+  byte[] serialize(T data);
+
+  /** Serialize BeanObject by protocol buffer. */
+  Serializer<BeanObject> BEAN_OBJECT_SERIALIZER =
+      beanObject -> {
+        var beanBuilder = BeanObjectOuterClass.BeanObject.newBuilder();
+        beanBuilder.setDomain(beanObject.domainName());
+        beanBuilder.putAllProperties(beanObject.properties());
+        beanObject
+            .attributes()
+            .forEach((key, val) -> beanBuilder.putAttributes(key, primitive(val)));
+        return beanBuilder.build().toByteArray();
+      };
+
+  /** Convert java primitive type to "one of" protocol buffer primitive type. */
+  static PrimitiveOuterClass.Primitive primitive(Object v) {
+    if (v instanceof Integer)
+      return PrimitiveOuterClass.Primitive.newBuilder().setInt((int) v).build();
+    else if (v instanceof Long)
+      return PrimitiveOuterClass.Primitive.newBuilder().setLong((long) v).build();
+    else if (v instanceof Float)
+      return PrimitiveOuterClass.Primitive.newBuilder().setFloat((float) v).build();
+    else if (v instanceof Double)
+      return PrimitiveOuterClass.Primitive.newBuilder().setDouble((double) v).build();
+    else if (v instanceof Boolean)
+      return PrimitiveOuterClass.Primitive.newBuilder().setBoolean((boolean) v).build();
+    else if (v instanceof String)
+      return PrimitiveOuterClass.Primitive.newBuilder().setStr(v.toString()).build();
+    else
+      throw new IllegalArgumentException(
+          "Type "
+              + v.getClass()
+              + " is not supported. Please use Integer, Long, Float, Double, Boolean, String instead.");
+  }
+}

--- a/common/src/main/proto/org/astraea/common/generated/BeanObject.proto
+++ b/common/src/main/proto/org/astraea/common/generated/BeanObject.proto
@@ -2,18 +2,10 @@ syntax = "proto3";
 
 package org.astraea.common.generated;
 
+import "org/astraea/common/generated/Primitive.proto";
+
 message BeanObject {
   string domain = 1;
   map<string, string> properties = 2;
   map<string, Primitive> attributes = 3;
-  message Primitive {
-    oneof value {
-      string str = 1;
-      int32 int = 2;
-      int64 long = 3;
-      float float = 4;
-      double double = 5;
-      bool boolean = 6;
-    }
-  }
 }

--- a/common/src/main/proto/org/astraea/common/generated/Primitive.proto
+++ b/common/src/main/proto/org/astraea/common/generated/Primitive.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package org.astraea.common.generated;
+
+message Primitive {
+  oneof value {
+    string str = 1;
+    int32 int = 2;
+    int64 long = 3;
+    float float = 4;
+    double double = 5;
+    bool boolean = 6;
+  }
+}

--- a/common/src/test/java/org/astraea/common/metrics/collector/MetricFetcherTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/collector/MetricFetcherTest.java
@@ -157,13 +157,16 @@ public class MetricFetcherTest {
       try (var consumer =
           Consumer.forTopics(Set.of("__metrics"))
               .bootstrapServers(SERVICE.bootstrapServers())
-              .valueDeserializer(Deserializer.STRING)
+              .valueDeserializer(Deserializer.BEAN_OBJECT)
               .seek(SeekStrategy.DISTANCE_FROM_BEGINNING, 0)
               .build()) {
         var records =
             consumer.poll(Duration.ofSeconds(5)).stream().collect(Collectors.toUnmodifiableList());
         Assertions.assertEquals(1, records.size());
-        Assertions.assertEquals(testBean.toString(), records.get(0).value());
+        var getBean = records.get(0).value();
+        Assertions.assertEquals(testBean.domainName(), getBean.domainName());
+        Assertions.assertEquals(testBean.properties(), getBean.properties());
+        Assertions.assertEquals(testBean.attributes(), getBean.attributes());
       }
     }
   }

--- a/common/src/test/java/org/astraea/common/serializer/BeanObjectSerializerTest.java
+++ b/common/src/test/java/org/astraea/common/serializer/BeanObjectSerializerTest.java
@@ -44,14 +44,14 @@ public class BeanObjectSerializerTest {
             "String",
             "str");
     var bean = new BeanObject(domain, properties, attributes);
-    var serializer = new Serializer.BeanObjectSerializer();
-    var deserializer = new Deserializer.BeanObjectDeserializer();
 
     // Valid arguments should not throw
-    Assertions.assertDoesNotThrow(() -> serializer.serialize("ignore", List.of(), bean));
-    var bytes = serializer.serialize("ignore", List.of(), bean);
-    Assertions.assertDoesNotThrow(() -> deserializer.deserialize("ignore", List.of(), bytes));
-    var beanObj = deserializer.deserialize("ignore", List.of(), bytes);
+    Assertions.assertDoesNotThrow(
+        () -> Serializer.BEAN_OBJECT.serialize("ignore", List.of(), bean));
+    var bytes = Serializer.BEAN_OBJECT.serialize("ignore", List.of(), bean);
+    Assertions.assertDoesNotThrow(
+        () -> Deserializer.BEAN_OBJECT.deserialize("ignore", List.of(), bytes));
+    var beanObj = Deserializer.BEAN_OBJECT.deserialize("ignore", List.of(), bytes);
 
     // Check serialization correctness
     Assertions.assertEquals("domain", beanObj.domainName());
@@ -65,8 +65,8 @@ public class BeanObjectSerializerTest {
     var properties = Map.of("name", "wrongType");
     var attributes = Map.of("map", (Object) Map.of("k", "v"));
     var bean = new BeanObject(domain, properties, attributes);
-    var serializer = new Serializer.BeanObjectSerializer();
     Assertions.assertThrows(
-        IllegalArgumentException.class, () -> serializer.serialize("ignore", List.of(), bean));
+        IllegalArgumentException.class,
+        () -> Serializer.BEAN_OBJECT.serialize("ignore", List.of(), bean));
   }
 }


### PR DESCRIPTION
Related to #1581 

如 #1581 所述，專案中有多方序列化的需求，這隻 PR 將序列化介面獨立，各元件再各自封裝自己的介面。

另外，也把`MetricFetcher`, `MetricStore` 內， `BeanObject` 的序列化方法(toString -> getBytes) 替換成新的(toProtoObj -> toBytes)。