### PR TITLE
Rename the classes that related assignor

### DIFF
--- a/common/src/main/java/org/astraea/common/assignor/Assignor.java
+++ b/common/src/main/java/org/astraea/common/assignor/Assignor.java
@@ -67,7 +67,7 @@ public abstract class Assignor implements ConsumerPartitionAssignor, Configurabl
    * @return Map from each member to the list of partitions assigned to them.
    */
   protected abstract Map<String, List<TopicPartition>> assign(
-      Map<String, org.astraea.common.assignor.Subscription> subscriptions, ClusterInfo clusterInfo);
+      Map<String, SubscriptionInfo> subscriptions, ClusterInfo clusterInfo);
   // TODO: replace the topicPartitions by ClusterInfo after Assignor is able to handle Admin
   // https://github.com/skiptests/astraea/issues/1409
 
@@ -107,8 +107,7 @@ public abstract class Assignor implements ConsumerPartitionAssignor, Configurabl
   public final GroupAssignment assign(Cluster metadata, GroupSubscription groupSubscription) {
     var clusterInfo = updateClusterInfo();
     // convert Kafka's data structure to ours
-    var subscriptionsPerMember =
-        org.astraea.common.assignor.GroupSubscription.from(groupSubscription).groupSubscription();
+    var subscriptionsPerMember = GroupSubscriptionInfo.from(groupSubscription).groupSubscription();
 
     // TODO: Detected if consumers subscribed to the same topics.
     // For now, assume that the consumers only subscribed to identical topics

--- a/common/src/main/java/org/astraea/common/assignor/GroupSubscriptionInfo.java
+++ b/common/src/main/java/org/astraea/common/assignor/GroupSubscriptionInfo.java
@@ -20,22 +20,23 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 
-public final class GroupSubscription {
-  private final Map<String, Subscription> subscriptions;
+public final class GroupSubscriptionInfo {
+  private final Map<String, SubscriptionInfo> subscriptions;
 
-  public GroupSubscription(Map<String, Subscription> subscriptions) {
+  public GroupSubscriptionInfo(Map<String, SubscriptionInfo> subscriptions) {
     this.subscriptions = subscriptions;
   }
 
-  public Map<String, Subscription> groupSubscription() {
+  public Map<String, SubscriptionInfo> groupSubscription() {
     return subscriptions;
   }
 
-  public static GroupSubscription from(
+  public static GroupSubscriptionInfo from(
       ConsumerPartitionAssignor.GroupSubscription groupSubscription) {
-    return new GroupSubscription(
+    return new GroupSubscriptionInfo(
         groupSubscription.groupSubscription().entrySet().stream()
-            .collect(Collectors.toMap(Map.Entry::getKey, e -> Subscription.from(e.getValue()))));
+            .collect(
+                Collectors.toMap(Map.Entry::getKey, e -> SubscriptionInfo.from(e.getValue()))));
   }
 
   @Override

--- a/common/src/main/java/org/astraea/common/assignor/RandomAssignor.java
+++ b/common/src/main/java/org/astraea/common/assignor/RandomAssignor.java
@@ -29,14 +29,13 @@ public class RandomAssignor extends Assignor {
 
   @Override
   public Map<String, List<TopicPartition>> assign(
-      Map<String, org.astraea.common.assignor.Subscription> subscriptions,
-      ClusterInfo clusterInfo) {
+      Map<String, SubscriptionInfo> subscriptions, ClusterInfo clusterInfo) {
     var assignments = new HashMap<String, List<TopicPartition>>();
     var consumers = new ArrayList<>(subscriptions.keySet());
     Set<String> topics = new HashSet<>();
     consumers.forEach(consumer -> assignments.put(consumer, new ArrayList<>()));
 
-    for (org.astraea.common.assignor.Subscription subscription : subscriptions.values())
+    for (SubscriptionInfo subscription : subscriptions.values())
       topics.addAll(subscription.topics());
 
     clusterInfo.topicPartitions().stream()

--- a/common/src/main/java/org/astraea/common/assignor/SubscriptionInfo.java
+++ b/common/src/main/java/org/astraea/common/assignor/SubscriptionInfo.java
@@ -25,13 +25,13 @@ import java.util.stream.Collectors;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.astraea.common.admin.TopicPartition;
 
-public final class Subscription {
+public final class SubscriptionInfo {
   private final List<String> topics;
   private final Map<String, String> userData;
   private final List<TopicPartition> ownedPartitions;
   private Optional<String> groupInstanceId;
 
-  public Subscription(
+  public SubscriptionInfo(
       List<String> topics, Map<String, String> userData, List<TopicPartition> ownedPartitions) {
     this.topics = topics;
     this.userData = userData;
@@ -39,7 +39,7 @@ public final class Subscription {
     this.groupInstanceId = Optional.empty();
   }
 
-  public Subscription(List<String> topics, List<TopicPartition> ownedPartitions) {
+  public SubscriptionInfo(List<String> topics, List<TopicPartition> ownedPartitions) {
     this.topics = topics;
     this.ownedPartitions = ownedPartitions;
     this.userData = null;
@@ -66,8 +66,8 @@ public final class Subscription {
     return groupInstanceId;
   }
 
-  public static Subscription from(ConsumerPartitionAssignor.Subscription subscription) {
-    Subscription ourSubscription;
+  public static SubscriptionInfo from(ConsumerPartitionAssignor.Subscription subscription) {
+    SubscriptionInfo ourSubscription;
     // convert astraea topic-partition into Kafka topic-partition
     var ownPartitions =
         subscription.ownedPartitions() == null
@@ -80,8 +80,8 @@ public final class Subscription {
     // convert ByteBuffer into Map<String,String>
     if (kafkaUserData != null) {
       var ourUserData = convert(StandardCharsets.UTF_8.decode(kafkaUserData).toString());
-      ourSubscription = new Subscription(subscription.topics(), ourUserData, ownPartitions);
-    } else ourSubscription = new Subscription(subscription.topics(), ownPartitions);
+      ourSubscription = new SubscriptionInfo(subscription.topics(), ourUserData, ownPartitions);
+    } else ourSubscription = new SubscriptionInfo(subscription.topics(), ownPartitions);
 
     // check groupInstanceId if it's empty or not
     if (!subscription.groupInstanceId().equals(Optional.empty()))

--- a/common/src/test/java/org/astraea/common/assignor/AssignorTest.java
+++ b/common/src/test/java/org/astraea/common/assignor/AssignorTest.java
@@ -42,7 +42,7 @@ public class AssignorTest {
     var userData = ByteBuffer.wrap(data.getBytes(StandardCharsets.UTF_8));
     var kafkaSubscription =
         new ConsumerPartitionAssignor.Subscription(List.of("test"), userData, null);
-    var ourSubscription = Subscription.from(kafkaSubscription);
+    var ourSubscription = SubscriptionInfo.from(kafkaSubscription);
 
     Assertions.assertEquals(kafkaSubscription.topics(), ourSubscription.topics());
     Assertions.assertNull(kafkaSubscription.ownedPartitions());
@@ -66,7 +66,7 @@ public class AssignorTest {
     var kafkaGroupSubscription =
         new ConsumerPartitionAssignor.GroupSubscription(
             Map.of("user1", kafkaUser1Subscription, "user2", kafkaUser2Subscription));
-    var ourGroupSubscription = GroupSubscription.from(kafkaGroupSubscription);
+    var ourGroupSubscription = GroupSubscriptionInfo.from(kafkaGroupSubscription);
 
     var ourUser1Subscription = ourGroupSubscription.groupSubscription().get("user1");
     var ourUser2Subscription = ourGroupSubscription.groupSubscription().get("user2");


### PR DESCRIPTION
related https://github.com/skiptests/astraea/pull/1524#discussion_r1167741379

為了遵照專案引用物件的風格，此 PR 重新命名了 `Assignor` 相關的 class：
* Subscription 修改成 Subscription**Info**
* GroupSubscription 修改成 GroupSubscription**Info**

修改前的風格：
```java
Map<String, org.astraea.common.assignor.Subscription> subscriptions
```

修改後的風格：
```java
Map<String, SubscriptionInfo> subscriptions
```