### PR TITLE
add PartitionMigrateTimeCost and revise MetricSensor#fetch

### DIFF
--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -1221,7 +1221,7 @@ public class BalancerHandlerTest {
 
     @Override
     public Optional<MetricSensor> metricSensor() {
-      return Optional.of((c, ignored) -> List.of(HostMetrics.jvmMemory(c)));
+      return Optional.of((ignore, c, ignored) -> List.of(HostMetrics.jvmMemory(c)));
     }
 
     @Override

--- a/common/src/main/java/org/astraea/common/admin/ClusterBean.java
+++ b/common/src/main/java/org/astraea/common/admin/ClusterBean.java
@@ -50,7 +50,9 @@ public interface ClusterBean {
                     Map.Entry::getKey,
                     entry ->
                         sensor.fetch(
-                            MBeanClient.of(entry.getValue().beans(BeanQuery.all())), EMPTY))));
+                            entry.getKey(),
+                            MBeanClient.of(entry.getValue().beans(BeanQuery.all())),
+                            EMPTY))));
   }
 
   static ClusterBean masked(ClusterBean clusterBean, Predicate<Integer> nodeFilter) {

--- a/common/src/main/java/org/astraea/common/cost/BrokerInputCost.java
+++ b/common/src/main/java/org/astraea/common/cost/BrokerInputCost.java
@@ -46,7 +46,8 @@ public class BrokerInputCost implements HasBrokerCost, HasClusterCost {
   @Override
   public Optional<MetricSensor> metricSensor() {
     return Optional.of(
-        (client, ignored) -> List.of(ServerMetrics.BrokerTopic.BYTES_IN_PER_SEC.fetch(client)));
+        (ignore, client, ignored) ->
+            List.of(ServerMetrics.BrokerTopic.BYTES_IN_PER_SEC.fetch(client)));
   }
 
   @Override

--- a/common/src/main/java/org/astraea/common/cost/BrokerOutputCost.java
+++ b/common/src/main/java/org/astraea/common/cost/BrokerOutputCost.java
@@ -45,7 +45,8 @@ public class BrokerOutputCost implements HasBrokerCost, HasClusterCost {
   @Override
   public Optional<MetricSensor> metricSensor() {
     return Optional.of(
-        (client, ignored) -> List.of(ServerMetrics.BrokerTopic.BYTES_OUT_PER_SEC.fetch(client)));
+        (ignore, client, ignored) ->
+            List.of(ServerMetrics.BrokerTopic.BYTES_OUT_PER_SEC.fetch(client)));
   }
 
   @Override

--- a/common/src/main/java/org/astraea/common/cost/CpuCost.java
+++ b/common/src/main/java/org/astraea/common/cost/CpuCost.java
@@ -57,7 +57,7 @@ public class CpuCost implements HasBrokerCost {
 
   @Override
   public Optional<MetricSensor> metricSensor() {
-    return Optional.of((client, ignored) -> List.of(HostMetrics.operatingSystem(client)));
+    return Optional.of((ignore, client, ignored) -> List.of(HostMetrics.operatingSystem(client)));
   }
 
   @Override

--- a/common/src/main/java/org/astraea/common/cost/LoadCost.java
+++ b/common/src/main/java/org/astraea/common/cost/LoadCost.java
@@ -150,7 +150,7 @@ public class LoadCost implements HasBrokerCost {
   @Override
   public Optional<MetricSensor> metricSensor() {
     return Optional.of(
-        (client, ignored) ->
+        (ignore, client, ignored) ->
             List.of(
                 ServerMetrics.BrokerTopic.BYTES_IN_PER_SEC.fetch(client),
                 ServerMetrics.BrokerTopic.BYTES_OUT_PER_SEC.fetch(client)));

--- a/common/src/main/java/org/astraea/common/cost/MemoryCost.java
+++ b/common/src/main/java/org/astraea/common/cost/MemoryCost.java
@@ -57,7 +57,7 @@ public class MemoryCost implements HasBrokerCost {
 
   @Override
   public Optional<MetricSensor> metricSensor() {
-    return Optional.of((client, ignored) -> List.of(HostMetrics.jvmMemory(client)));
+    return Optional.of((ignore, client, ignored) -> List.of(HostMetrics.jvmMemory(client)));
   }
 
   @Override

--- a/common/src/main/java/org/astraea/common/cost/NetworkCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NetworkCost.java
@@ -196,13 +196,13 @@ public abstract class NetworkCost implements HasClusterCost {
     //  obtain the replica info, so we intentionally sample log size but never use it.
     //  https://github.com/skiptests/astraea/pull/1240#discussion_r1044487473
     return Optional.of(
-        (client, clusterBean) ->
+        (identity, client, clusterBean) ->
             Stream.of(
                     List.of(HostMetrics.jvmMemory(client)),
                     ServerMetrics.Topic.BYTES_IN_PER_SEC.fetch(client),
                     ServerMetrics.Topic.BYTES_OUT_PER_SEC.fetch(client),
                     LogMetrics.Log.SIZE.fetch(client),
-                    clusterInfoSensor.fetch(client, clusterBean))
+                    clusterInfoSensor.fetch(identity, client, clusterBean))
                 .flatMap(Collection::stream)
                 .collect(Collectors.toUnmodifiableList()));
   }

--- a/common/src/main/java/org/astraea/common/cost/NodeMetricsCost.java
+++ b/common/src/main/java/org/astraea/common/cost/NodeMetricsCost.java
@@ -72,6 +72,6 @@ public abstract class NodeMetricsCost implements HasBrokerCost {
 
   @Override
   public Optional<MetricSensor> metricSensor() {
-    return Optional.of((client, clusterBean) -> ProducerMetrics.node(client));
+    return Optional.of((ignore, client, clusterBean) -> ProducerMetrics.node(client));
   }
 }

--- a/common/src/main/java/org/astraea/common/cost/PartitionMigrateTimeCost.java
+++ b/common/src/main/java/org/astraea/common/cost/PartitionMigrateTimeCost.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.cost;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.astraea.common.Configuration;
+import org.astraea.common.admin.ClusterBean;
+import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.metrics.BeanObject;
+import org.astraea.common.metrics.HasBeanObject;
+import org.astraea.common.metrics.Sensor;
+import org.astraea.common.metrics.broker.HasMeter;
+import org.astraea.common.metrics.broker.HasRate;
+import org.astraea.common.metrics.broker.ServerMetrics;
+import org.astraea.common.metrics.collector.MetricSensor;
+import org.astraea.common.metrics.stats.Max;
+
+/** MoveCost: more max write rate change -> higher migrate cost. */
+public class PartitionMigrateTimeCost implements HasMoveCost {
+  private static final String REPLICATION_IN_RATE = "replication_in_rate";
+  private static final String REPLICATION_OUT_RATE = "replication_out_rate";
+  public static final String MAX_MIGRATE_TIME_KEY = "max.migrated.time.limit";
+  static final Map<Integer, Sensor<Double>> maxBrokerReplicationInRate = new HashMap<>();
+  static final Map<Integer, Sensor<Double>> maxBrokerReplicationOutRate = new HashMap<>();
+  // metrics windows size
+  private final long maxMigrateTime;
+
+  public PartitionMigrateTimeCost(Configuration config) {
+    this.maxMigrateTime =
+        config.string(MAX_MIGRATE_TIME_KEY).map(Long::parseLong).orElse(Long.MAX_VALUE);
+  }
+
+  @Override
+  public Optional<MetricSensor> metricSensor() {
+    return Optional.of(
+        (identity, client, clusterBean) -> {
+          var metrics =
+              clusterBean.all().values().stream()
+                  .flatMap(Collection::stream)
+                  .distinct()
+                  .collect(Collectors.toCollection(ArrayList::new));
+          var newInMetrics = ServerMetrics.BrokerTopic.REPLICATION_BYTES_IN_PER_SEC.fetch(client);
+          var newOutMetrics = ServerMetrics.BrokerTopic.REPLICATION_BYTES_OUT_PER_SEC.fetch(client);
+          var current = Duration.ofMillis(System.currentTimeMillis());
+          var maxInRateSensor =
+              maxBrokerReplicationInRate.computeIfAbsent(
+                  identity,
+                  ignore ->
+                      Sensor.builder().addStat(REPLICATION_IN_RATE, Max.<Double>of()).build());
+          var maxOutRateSensor =
+              maxBrokerReplicationOutRate.computeIfAbsent(
+                  identity,
+                  ignore ->
+                      Sensor.builder().addStat(REPLICATION_OUT_RATE, Max.<Double>of()).build());
+          maxInRateSensor.record(newInMetrics.oneMinuteRate());
+          maxOutRateSensor.record(newOutMetrics.oneMinuteRate());
+          var inRate = maxInRateSensor.measure(REPLICATION_IN_RATE);
+          var outRate = maxOutRateSensor.measure(REPLICATION_OUT_RATE);
+          metrics.add(
+              (MaxReplicationInRateBean)
+                  () ->
+                      new BeanObject(
+                          newInMetrics.beanObject().domainName(),
+                          newInMetrics.beanObject().properties(),
+                          Map.of(HasRate.ONE_MIN_RATE_KEY, inRate),
+                          current.toMillis()));
+          metrics.add(
+              (MaxReplicationOutRateBean)
+                  () ->
+                      new BeanObject(
+                          newOutMetrics.beanObject().domainName(),
+                          newOutMetrics.beanObject().properties(),
+                          Map.of(HasRate.ONE_MIN_RATE_KEY, outRate),
+                          current.toMillis()));
+          return metrics;
+        });
+  }
+
+  public static Map<Integer, OptionalDouble> brokerMaxRate(
+      ClusterInfo clusterInfo,
+      ClusterBean clusterBean,
+      Class<? extends HasBeanObject> statisticMetrics) {
+    return clusterInfo.brokers().stream()
+        .map(
+            broker ->
+                Map.entry(
+                    broker.id(),
+                    clusterBean.all().getOrDefault(broker.id(), List.of()).stream()
+                        .filter(x -> statisticMetrics.isAssignableFrom(x.getClass()))
+                        .mapToDouble(x -> ((HasMeter) x).oneMinuteRate())
+                        .max()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  public Map<Integer, Double> brokerMigratedTime(
+      Map<Integer, Long> needToMigrated, Map<Integer, OptionalDouble> brokerRate) {
+    return needToMigrated.entrySet().stream()
+        .map(
+            brokerSize ->
+                Map.entry(
+                    brokerSize.getKey(),
+                    brokerSize.getValue()
+                        / brokerRate
+                            .get(brokerSize.getKey())
+                            .orElseThrow(
+                                () ->
+                                    new NoSufficientMetricsException(
+                                        this,
+                                        Duration.ofSeconds(1),
+                                        "No metric for broker" + brokerSize.getKey()))))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Override
+  public MoveCost moveCost(ClusterInfo before, ClusterInfo after, ClusterBean clusterBean) {
+    var brokerInRate = brokerMaxRate(before, clusterBean, MaxReplicationInRateBean.class);
+    var brokerOutRate = brokerMaxRate(before, clusterBean, MaxReplicationOutRateBean.class);
+    var needToMigrateIn = MigrationCost.recordSizeToFetch(before, after);
+    var needToMigrateOut = MigrationCost.recordSizeToSync(before, after);
+
+    var brokerMigrateInTime = brokerMigratedTime(needToMigrateIn, brokerInRate);
+    var brokerMigrateOutTime = brokerMigratedTime(needToMigrateOut, brokerOutRate);
+    var maxMigrateTime =
+        Stream.concat(before.nodes().stream(), after.nodes().stream())
+            .distinct()
+            .map(
+                nodeInfo ->
+                    Math.max(
+                        brokerMigrateInTime.get(nodeInfo.id()),
+                        brokerMigrateOutTime.get(nodeInfo.id())))
+            .max(Comparator.comparing(Function.identity()))
+            .orElse(0.0);
+    return () -> maxMigrateTime > this.maxMigrateTime;
+  }
+
+  public interface MaxReplicationInRateBean extends HasMeter {}
+
+  public interface MaxReplicationOutRateBean extends HasMeter {}
+}

--- a/common/src/main/java/org/astraea/common/cost/ReplicaLeaderCost.java
+++ b/common/src/main/java/org/astraea/common/cost/ReplicaLeaderCost.java
@@ -71,7 +71,8 @@ public class ReplicaLeaderCost implements HasBrokerCost, HasClusterCost, HasMove
   @Override
   public Optional<MetricSensor> metricSensor() {
     return Optional.of(
-        (client, ignored) -> List.of(ServerMetrics.ReplicaManager.LEADER_COUNT.fetch(client)));
+        (ignore, client, ignored) ->
+            List.of(ServerMetrics.ReplicaManager.LEADER_COUNT.fetch(client)));
   }
 
   public Configuration config() {

--- a/common/src/main/java/org/astraea/common/cost/utils/ClusterInfoSensor.java
+++ b/common/src/main/java/org/astraea/common/cost/utils/ClusterInfoSensor.java
@@ -38,7 +38,7 @@ import org.astraea.common.metrics.collector.MetricSensor;
 public class ClusterInfoSensor implements MetricSensor {
 
   @Override
-  public List<? extends HasBeanObject> fetch(MBeanClient client, ClusterBean bean) {
+  public List<? extends HasBeanObject> fetch(int identity, MBeanClient client, ClusterBean bean) {
     return Stream.of(
             List.of(ServerMetrics.KafkaServer.CLUSTER_ID.fetch(client)),
             LogMetrics.Log.SIZE.fetch(client),

--- a/common/src/main/java/org/astraea/common/metrics/broker/HasRate.java
+++ b/common/src/main/java/org/astraea/common/metrics/broker/HasRate.java
@@ -20,6 +20,10 @@ import java.util.concurrent.TimeUnit;
 import org.astraea.common.metrics.HasBeanObject;
 
 public interface HasRate extends HasBeanObject {
+  String ONE_MIN_RATE_KEY = "OneMinuteRate";
+  String FIVE_MINUTE_RATE = "FiveMinuteRate";
+  String FIFTEEN_MINUTE_RATE = "FifteenMinuteRate";
+
   default double meanRate() {
     return (double) beanObject().attributes().get("MeanRate");
   }

--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricSensor.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricSensor.java
@@ -48,12 +48,12 @@ public interface MetricSensor {
       Collection<MetricSensor> metricSensors, Consumer<Exception> exceptionHandler) {
     if (metricSensors.isEmpty()) return Optional.empty();
     return Optional.of(
-        (client, clusterBean) ->
+        (identity, client, clusterBean) ->
             metricSensors.stream()
                 .flatMap(
                     ms -> {
                       try {
-                        return ms.fetch(client, clusterBean).stream();
+                        return ms.fetch(identity, client, clusterBean).stream();
                       } catch (Exception ex) {
                         exceptionHandler.accept(ex);
                         return Stream.empty();
@@ -66,9 +66,10 @@ public interface MetricSensor {
    * fetch metrics from remote/local mbean server. Or the implementation can generate custom metrics
    * according to existent cluster bean
    *
+   * @param identity
    * @param client mbean client (don't close it!)
    * @param bean current cluster bean
    * @return java metrics
    */
-  Collection<? extends HasBeanObject> fetch(MBeanClient client, ClusterBean bean);
+  Collection<? extends HasBeanObject> fetch(int identity, MBeanClient client, ClusterBean bean);
 }

--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
@@ -117,7 +117,7 @@ public interface MetricStore extends AutoCloseable {
         () ->
             Map.of(
                 (MetricSensor)
-                    (client, bean) ->
+                    (identity, client, bean) ->
                         client.beans(BeanQuery.all()).stream()
                             .map(bs -> (HasBeanObject) () -> bs)
                             .collect(Collectors.toUnmodifiableList()),
@@ -236,7 +236,7 @@ public interface MetricStore extends AutoCloseable {
                             try {
                               beans
                                   .computeIfAbsent(id, ignored -> new ConcurrentLinkedQueue<>())
-                                  .addAll(sensor.fetch(client, clusterBean));
+                                  .addAll(sensor.fetch(id, client, clusterBean));
                             } catch (Exception e) {
                               errorHandler.accept(id, e);
                             }

--- a/common/src/test/java/org/astraea/common/cost/ClusterCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/ClusterCostTest.java
@@ -63,7 +63,7 @@ class ClusterCostTest {
     var mergeCost = HasClusterCost.of(Map.of(cost1, 1.0, cost2, 1.0));
     var metrics =
         mergeCost.metricSensor().stream()
-            .map(x -> x.fetch(MBeanClient.of(SERVICE.jmxServiceURL()), ClusterBean.EMPTY))
+            .map(x -> x.fetch(-1, MBeanClient.of(SERVICE.jmxServiceURL()), ClusterBean.EMPTY))
             .collect(Collectors.toSet());
     Assertions.assertTrue(
         metrics.iterator().next().stream()

--- a/common/src/test/java/org/astraea/common/cost/MoveCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/MoveCostTest.java
@@ -49,7 +49,7 @@ public class MoveCostTest {
     var mergeCost = HasMoveCost.of(List.of(cost1, cost2));
     var metrics =
         mergeCost.metricSensor().stream()
-            .map(x -> x.fetch(MBeanClient.of(SERVICE.jmxServiceURL()), ClusterBean.EMPTY))
+            .map(x -> x.fetch(-1, MBeanClient.of(SERVICE.jmxServiceURL()), ClusterBean.EMPTY))
             .collect(Collectors.toSet());
     Assertions.assertEquals(3, metrics.iterator().next().size());
     Assertions.assertTrue(
@@ -84,9 +84,10 @@ public class MoveCostTest {
     public Optional<MetricSensor> metricSensor() {
       return MetricSensor.of(
           List.of(
-              (c, ignored) ->
+              (ignore, c, ignored) ->
                   List.of(ServerMetrics.BrokerTopic.REPLICATION_BYTES_IN_PER_SEC.fetch(c)),
-              (c, ignored) -> List.of(ServerMetrics.BrokerTopic.BYTES_IN_PER_SEC.fetch(c))));
+              (ignore, c, ignored) ->
+                  List.of(ServerMetrics.BrokerTopic.BYTES_IN_PER_SEC.fetch(c))));
     }
 
     @Override

--- a/common/src/test/java/org/astraea/common/cost/NodeLatencyCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NodeLatencyCostTest.java
@@ -109,7 +109,7 @@ public class NodeLatencyCostTest {
                 new BeanObject("a", Map.of("node-id", "node-10"), Map.of()),
                 new BeanObject("a", Map.of("node-id", "node-10"), Map.of()),
                 new BeanObject("a", Map.of("node-id", "node-11"), Map.of())));
-    var result = function.metricSensor().get().fetch(client, ClusterBean.EMPTY);
+    var result = function.metricSensor().get().fetch(-1, client, ClusterBean.EMPTY);
     Assertions.assertEquals(3, result.size());
   }
 }

--- a/common/src/test/java/org/astraea/common/cost/NodeThroughputCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NodeThroughputCostTest.java
@@ -78,7 +78,7 @@ public class NodeThroughputCostTest {
     var bean = new BeanObject("aaa", Map.of("node-id", "node-1"), Map.of());
     var client = Mockito.mock(MBeanClient.class);
     Mockito.when(client.beans(Mockito.any())).thenReturn(List.of(bean));
-    var result = sensor.fetch(client, ClusterBean.EMPTY);
+    var result = sensor.fetch(-1, client, ClusterBean.EMPTY);
     Assertions.assertEquals(1, result.size());
     Assertions.assertEquals(bean, result.iterator().next().beanObject());
   }

--- a/common/src/test/java/org/astraea/common/cost/PartitionMigrateTimeCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/PartitionMigrateTimeCostTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.cost;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.Node;
+import org.astraea.common.Configuration;
+import org.astraea.common.admin.Broker;
+import org.astraea.common.admin.ClusterBean;
+import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.admin.NodeInfo;
+import org.astraea.common.admin.Replica;
+import org.astraea.common.metrics.BeanObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class PartitionMigrateTimeCostTest {
+
+  private static final BeanObject inBean0 =
+      new BeanObject("domain", Map.of(), Map.of("OneMinuteRate", 1000.0));
+  private static final BeanObject outBean0 =
+      new BeanObject("domain", Map.of(), Map.of("OneMinuteRate", 1500.0));
+  private static final BeanObject inBean1 =
+      new BeanObject("domain", Map.of(), Map.of("OneMinuteRate", 2000.0));
+  private static final BeanObject outBean1 =
+      new BeanObject("domain", Map.of(), Map.of("OneMinuteRate", 2500.0));
+  private static final BeanObject inBean2 =
+      new BeanObject("domain", Map.of(), Map.of("OneMinuteRate", 3000.0));
+  private static final BeanObject outBean2 =
+      new BeanObject("domain", Map.of(), Map.of("OneMinuteRate", 3500.0));
+
+  @Test
+  void testMigratedCost() {
+    // before(partition-broker): p10-1, p11-2, p12-0, p12-0
+    // after(partition-broker):  p10-0, p11-1, p12-2, p12-0
+    // p10:777, p11:700, p12:500
+    List<NodeInfo> brokers =
+        before().stream()
+            .map(Replica::nodeInfo)
+            .distinct()
+            .map(
+                nodeInfo ->
+                    Broker.of(
+                        false,
+                        new Node(nodeInfo.id(), "", nodeInfo.port()),
+                        Map.of(),
+                        Map.of(),
+                        List.of()))
+            .collect(Collectors.toList());
+    var before = of(before(), brokers);
+    var after = of(after(), brokers);
+    var migrationCost = MigrationCost.brokerMigrationTime(before, after, clusterBean());
+    Assertions.assertEquals(Math.max(10000000 / 1000, 30000000 / 1500), migrationCost.get(0));
+    Assertions.assertEquals(Math.max(20000000 / 2000, 10000000 / 2500), migrationCost.get(1));
+    Assertions.assertEquals(Math.max(30000000 / 3000, 20000000 / 3500), migrationCost.get(2));
+  }
+
+  @Test
+  void testMostCost() {
+    List<NodeInfo> brokers =
+        before().stream()
+            .map(Replica::nodeInfo)
+            .distinct()
+            .map(
+                nodeInfo ->
+                    Broker.of(
+                        false,
+                        new Node(nodeInfo.id(), "", nodeInfo.port()),
+                        Map.of(),
+                        Map.of(),
+                        List.of()))
+            .collect(Collectors.toList());
+    var before = of(before(), brokers);
+    var after = of(after(), brokers);
+    var timeLimit =
+        Configuration.of(Map.of(PartitionMigrateTimeCost.MAX_MIGRATE_TIME_KEY, "20000"));
+    var overFlowTimeLimit =
+        Configuration.of(Map.of(PartitionMigrateTimeCost.MAX_MIGRATE_TIME_KEY, "19999"));
+    var cf = new PartitionMigrateTimeCost(timeLimit);
+    var overFlowCf = new PartitionMigrateTimeCost(overFlowTimeLimit);
+    var moveCost = cf.moveCost(before, after, clusterBean());
+    var overflowCost = overFlowCf.moveCost(before, after, clusterBean());
+    Assertions.assertFalse(moveCost.overflow());
+    Assertions.assertTrue(overflowCost.overflow());
+  }
+
+  public static ClusterInfo of(List<Replica> replicas, List<NodeInfo> nodeInfos) {
+    return ClusterInfo.of("fake", nodeInfos, Map.of(), replicas);
+  }
+
+  private List<Replica> after() {
+    return List.of(
+        Replica.builder()
+            .topic("t")
+            .partition(10)
+            .isLeader(true)
+            .size(10000000)
+            .nodeInfo(NodeInfo.of(1, "", -1))
+            .build(),
+        Replica.builder()
+            .topic("t")
+            .partition(11)
+            .isLeader(true)
+            .size(20000000)
+            .nodeInfo(NodeInfo.of(2, "", -1))
+            .build(),
+        Replica.builder()
+            .topic("t")
+            .partition(12)
+            .isLeader(true)
+            .size(30000000)
+            .nodeInfo(NodeInfo.of(0, "", -1))
+            .build(),
+        Replica.builder()
+            .topic("t")
+            .partition(12)
+            .isLeader(false)
+            .size(30000000)
+            .nodeInfo(NodeInfo.of(0, "", -1))
+            .build());
+  }
+
+  private List<Replica> before() {
+    return List.of(
+        Replica.builder()
+            .topic("t")
+            .partition(10)
+            .isLeader(true)
+            .size(10000000)
+            .nodeInfo(NodeInfo.of(0, "", -1))
+            .build(),
+        Replica.builder()
+            .topic("t")
+            .partition(11)
+            .isLeader(true)
+            .size(20000000)
+            .nodeInfo(NodeInfo.of(1, "", -1))
+            .build(),
+        Replica.builder()
+            .topic("t")
+            .partition(12)
+            .isLeader(true)
+            .size(30000000)
+            .nodeInfo(NodeInfo.of(2, "", -1))
+            .build(),
+        Replica.builder()
+            .topic("t")
+            .partition(12)
+            .isLeader(false)
+            .size(30000000)
+            .nodeInfo(NodeInfo.of(0, "", -1))
+            .build());
+  }
+
+  private static ClusterBean clusterBean() {
+    return ClusterBean.of(
+        Map.of(
+            0,
+            List.of(
+                (PartitionMigrateTimeCost.MaxReplicationInRateBean) () -> inBean0,
+                (PartitionMigrateTimeCost.MaxReplicationOutRateBean) () -> outBean0),
+            1,
+            List.of(
+                (PartitionMigrateTimeCost.MaxReplicationInRateBean) () -> inBean1,
+                (PartitionMigrateTimeCost.MaxReplicationOutRateBean) () -> outBean1),
+            2,
+            List.of(
+                (PartitionMigrateTimeCost.MaxReplicationInRateBean) () -> inBean2,
+                (PartitionMigrateTimeCost.MaxReplicationOutRateBean) () -> outBean2)));
+  }
+}

--- a/common/src/test/java/org/astraea/common/metrics/collector/MetricSensorTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/collector/MetricSensorTest.java
@@ -31,13 +31,13 @@ public class MetricSensorTest {
   @Test
   void testMultipleSensors() {
     var mbean0 = Mockito.mock(HasBeanObject.class);
-    MetricSensor metricSensor0 = (client, ignored) -> List.of(mbean0);
+    MetricSensor metricSensor0 = (ignore, client, ignored) -> List.of(mbean0);
     var mbean1 = Mockito.mock(HasBeanObject.class);
-    MetricSensor metricSensor1 = (client, ignored) -> List.of(mbean1);
+    MetricSensor metricSensor1 = (ignore, client, ignored) -> List.of(mbean1);
 
     var sensor = MetricSensor.of(List.of(metricSensor0, metricSensor1)).get();
 
-    var result = sensor.fetch(Mockito.mock(MBeanClient.class), ClusterBean.EMPTY);
+    var result = sensor.fetch(-1, Mockito.mock(MBeanClient.class), ClusterBean.EMPTY);
 
     Assertions.assertEquals(2, result.size());
     Assertions.assertTrue(result.contains(mbean0));
@@ -52,9 +52,9 @@ public class MetricSensorTest {
   @Test
   void testNoSwallowException() {
     var result = List.of(Mockito.mock(HasBeanObject.class));
-    MetricSensor goodMetricSensor = (client, ignored) -> result;
+    MetricSensor goodMetricSensor = (ignore, client, ignored) -> result;
     MetricSensor badMetricSensor =
-        (client, ignored) -> {
+        (ignore, client, ignored) -> {
           throw new RuntimeException("xxx");
         };
     var sensor =
@@ -68,33 +68,33 @@ public class MetricSensorTest {
             .get();
     Assertions.assertThrows(
         RuntimeException.class,
-        () -> sensor.fetch(Mockito.mock(MBeanClient.class), ClusterBean.EMPTY));
+        () -> sensor.fetch(-1, Mockito.mock(MBeanClient.class), ClusterBean.EMPTY));
   }
 
   @Test
   void testSensorsWithExceptionHandler() {
     var mbean0 = Mockito.mock(HasBeanObject.class);
-    MetricSensor metricSensor0 = (client, ignored) -> List.of(mbean0);
+    MetricSensor metricSensor0 = (ignore, client, ignored) -> List.of(mbean0);
     MetricSensor metricSensor1 =
-        (client, ignored) -> {
+        (ignore, client, ignored) -> {
           throw new NoSuchElementException();
         };
     MetricSensor metricSensor2 =
-        (client, ignored) -> {
+        (ignore, client, ignored) -> {
           throw new RuntimeException();
         };
 
     var sensor = MetricSensor.of(List.of(metricSensor0, metricSensor1)).get();
     Assertions.assertDoesNotThrow(
-        () -> sensor.fetch(Mockito.mock(MBeanClient.class), ClusterBean.EMPTY));
+        () -> sensor.fetch(-1, Mockito.mock(MBeanClient.class), ClusterBean.EMPTY));
     Assertions.assertEquals(
-        1, sensor.fetch(Mockito.mock(MBeanClient.class), ClusterBean.EMPTY).size());
+        1, sensor.fetch(-1, Mockito.mock(MBeanClient.class), ClusterBean.EMPTY).size());
 
     Assertions.assertDoesNotThrow(
         () ->
             MetricSensor.of(List.of(metricSensor0, metricSensor2))
                 .get()
-                .fetch(Mockito.mock(MBeanClient.class), ClusterBean.EMPTY));
+                .fetch(-1, Mockito.mock(MBeanClient.class), ClusterBean.EMPTY));
     Assertions.assertThrows(
         NoSuchElementException.class,
         () ->
@@ -104,6 +104,6 @@ public class MetricSensorTest {
                       if (e instanceof NoSuchElementException) throw new NoSuchElementException();
                     })
                 .get()
-                .fetch(Mockito.mock(MBeanClient.class), ClusterBean.EMPTY));
+                .fetch(-1, Mockito.mock(MBeanClient.class), ClusterBean.EMPTY));
   }
 }


### PR DESCRIPTION
此PR做了兩個變動:
1. 新增`PartitionMigrateTimeCost`，用來估計一個搬移計畫的搬移時間，以及用來限制產生的搬移計畫
2. 修改 `MetricSensor#fetch`，在fetch方法的參數加了identity，主要原因是因為要統計broker的流量，需要辨識是哪一個broker的metrics，並在`CostFunction`中做統計

下面還有一些要討論的地方，麻煩看一下