### PR TITLE
[COMMON] separate JndiClient from MBeanClient

### DIFF
--- a/app/src/main/java/org/astraea/app/performance/Report.java
+++ b/app/src/main/java/org/astraea/app/performance/Report.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.astraea.common.metrics.BeanQuery;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.client.consumer.ConsumerMetrics;
 import org.astraea.common.metrics.client.consumer.HasConsumerFetchMetrics;
 import org.astraea.common.metrics.client.producer.ProducerMetrics;
@@ -28,7 +28,7 @@ import org.astraea.common.metrics.client.producer.ProducerMetrics;
 public interface Report {
 
   static long recordsConsumedTotal() {
-    var client = MBeanClient.local();
+    var client = JndiClient.local();
     return (long)
         ConsumerMetrics.fetch(client).stream()
             .mapToDouble(HasConsumerFetchMetrics::recordsConsumedTotal)
@@ -37,7 +37,7 @@ public interface Report {
 
   static List<Report> consumers() {
 
-    return ConsumerMetrics.fetch(MBeanClient.local()).stream()
+    return ConsumerMetrics.fetch(JndiClient.local()).stream()
         .map(
             m ->
                 new Report() {
@@ -74,7 +74,7 @@ public interface Report {
                   @Override
                   public Optional<Double> e2eLatency() {
                     return Optional.ofNullable(
-                            MBeanClient.local()
+                            JndiClient.local()
                                 .bean(
                                     BeanQuery.builder()
                                         .domainName(ConsumerThread.DOMAIN_NAME)
@@ -91,7 +91,7 @@ public interface Report {
   }
 
   static List<Report> producers() {
-    return ProducerMetrics.producer(MBeanClient.local()).stream()
+    return ProducerMetrics.producer(JndiClient.local()).stream()
         .map(
             m ->
                 new Report() {
@@ -113,7 +113,7 @@ public interface Report {
                   @Override
                   public Optional<Double> e2eLatency() {
                     return Optional.ofNullable(
-                            MBeanClient.local()
+                            JndiClient.local()
                                 .bean(
                                     BeanQuery.builder()
                                         .domainName(ProducerThread.DOMAIN_NAME)

--- a/app/src/main/java/org/astraea/app/performance/TrackerThread.java
+++ b/app/src/main/java/org/astraea/app/performance/TrackerThread.java
@@ -27,7 +27,7 @@ import java.util.function.ToDoubleFunction;
 import org.astraea.common.DataSize;
 import org.astraea.common.Utils;
 import org.astraea.common.metrics.HasBeanObject;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.client.consumer.ConsumerMetrics;
 import org.astraea.common.metrics.client.consumer.HasConsumerCoordinatorMetrics;
 import org.astraea.common.metrics.client.producer.HasProducerTopicMetrics;
@@ -37,7 +37,7 @@ import org.astraea.common.metrics.client.producer.ProducerMetrics;
 public interface TrackerThread extends AbstractThread {
 
   class ProducerPrinter {
-    private final MBeanClient mBeanClient = MBeanClient.local();
+    private final JndiClient mBeanClient = JndiClient.local();
     private final Supplier<List<Report>> reportSupplier;
     private long lastRecords = 0;
 
@@ -97,7 +97,7 @@ public interface TrackerThread extends AbstractThread {
   }
 
   class ConsumerPrinter {
-    private final MBeanClient mBeanClient = MBeanClient.local();
+    private final JndiClient mBeanClient = JndiClient.local();
     private final Supplier<List<Report>> reportSupplier;
     private long lastRecords = 0;
 

--- a/app/src/main/java/org/astraea/app/publisher/MetricPublisher.java
+++ b/app/src/main/java/org/astraea/app/publisher/MetricPublisher.java
@@ -26,7 +26,7 @@ import org.astraea.app.argument.StringMapField;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.admin.NodeInfo;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.collector.MetricFetcher;
 
 /** Keep fetching all kinds of metrics and publish to inner topics. */
@@ -58,7 +58,7 @@ public class MetricPublisher {
                                         Collectors.toUnmodifiableMap(
                                             NodeInfo::id,
                                             node ->
-                                                MBeanClient.jndi(
+                                                JndiClient.of(
                                                     node.host(),
                                                     arguments.idToJmxPort().apply(node.id()))))))
             .fetchBeanDelay(arguments.period)

--- a/app/src/main/java/org/astraea/app/web/BeanHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BeanHandler.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.metrics.BeanObject;
 import org.astraea.common.metrics.BeanQuery;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 
 public class BeanHandler implements Handler {
   private final Admin admin;
@@ -45,8 +45,7 @@ public class BeanHandler implements Handler {
                     brokers.stream()
                         .map(
                             b -> {
-                              try (var client =
-                                  MBeanClient.jndi(b.host(), jmxPorts.apply(b.id()))) {
+                              try (var client = JndiClient.of(b.host(), jmxPorts.apply(b.id()))) {
                                 return new NodeBean(
                                     b.host(),
                                     client.beans(builder.build()).stream()

--- a/app/src/main/java/org/astraea/app/web/WebService.java
+++ b/app/src/main/java/org/astraea/app/web/WebService.java
@@ -35,6 +35,7 @@ import org.astraea.app.argument.NonNegativeIntegerField;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.admin.NodeInfo;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.MBeanClient;
 import org.astraea.common.metrics.collector.MetricSensor;
 import org.astraea.common.metrics.collector.MetricStore;
@@ -62,8 +63,7 @@ public class WebService implements AutoCloseable {
                                 Collectors.toUnmodifiableMap(
                                     NodeInfo::id,
                                     b ->
-                                        MBeanClient.jndi(
-                                            b.host(), brokerIdToJmxPort.apply(b.id())))));
+                                        JndiClient.of(b.host(), brokerIdToJmxPort.apply(b.id())))));
     var metricStore =
         MetricStore.builder()
             .beanExpiration(beanExpiration)

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -76,6 +76,7 @@ import org.astraea.common.cost.ReplicaLeaderCost;
 import org.astraea.common.json.JsonConverter;
 import org.astraea.common.json.TypeRef;
 import org.astraea.common.metrics.ClusterBean;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.MBeanClient;
 import org.astraea.common.metrics.collector.MetricSensor;
 import org.astraea.common.metrics.collector.MetricStore;
@@ -1355,8 +1356,7 @@ public class BalancerHandlerTest {
                                 Collectors.toUnmodifiableMap(
                                     NodeInfo::id,
                                     b ->
-                                        MBeanClient.jndi(
-                                            b.host(), brokerIdToJmxPort.apply(b.id())))));
+                                        JndiClient.of(b.host(), brokerIdToJmxPort.apply(b.id())))));
     var cw = costWeights.stream().map(x -> x.cost).collect(Collectors.toSet());
     var cf = Utils.costFunctions(cw, HasClusterCost.class, Configuration.EMPTY);
     var metricSensors = cf.stream().map(c -> c.metricSensor().get()).collect(Collectors.toList());

--- a/common/src/main/java/org/astraea/common/assignor/Assignor.java
+++ b/common/src/main/java/org/astraea/common/assignor/Assignor.java
@@ -39,6 +39,7 @@ import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.consumer.ConsumerConfigs;
 import org.astraea.common.cost.HasPartitionCost;
 import org.astraea.common.cost.ReplicaLeaderSizeCost;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.MBeanClient;
 import org.astraea.common.metrics.collector.MetricStore;
 import org.astraea.common.partitioner.PartitionerUtils;
@@ -159,13 +160,13 @@ public abstract class Assignor implements ConsumerPartitionAssignor, Configurabl
                 .brokers()
                 .thenApply(
                     brokers -> {
-                      var map = new HashMap<Integer, MBeanClient>();
+                      var map = new HashMap<Integer, JndiClient>();
                       brokers.forEach(
                           b ->
                               map.put(
-                                  b.id(), MBeanClient.jndi(b.host(), jmxPortGetter.apply(b.id()))));
+                                  b.id(), JndiClient.of(b.host(), jmxPortGetter.apply(b.id()))));
                       // add local client to fetch consumer metrics
-                      map.put(-1, MBeanClient.local());
+                      map.put(-1, JndiClient.local());
                       return Collections.unmodifiableMap(map);
                     });
     metricStore =

--- a/common/src/main/java/org/astraea/common/metrics/JndiClient.java
+++ b/common/src/main/java/org/astraea/common/metrics/JndiClient.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.metrics;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.net.MalformedURLException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MBeanFeatureInfo;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectInstance;
+import javax.management.ReflectionException;
+import javax.management.RuntimeMBeanException;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import org.astraea.common.Utils;
+
+/** A MBeanClient used to retrieve mbean value from remote Jmx server. */
+public interface JndiClient extends MBeanClient, AutoCloseable {
+
+  /**
+   * @param host the address of jmx server
+   * @param port the port of jmx server
+   * @return a mbean client using JNDI to lookup metrics.
+   */
+  static JndiClient of(String host, int port) {
+    try {
+      return of(
+          new JMXServiceURL(
+              String.format(
+                  "service:jmx:rmi://%s:%s/jndi/rmi://%s:%s/jmxrmi", host, port, host, port)));
+    } catch (MalformedURLException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  static JndiClient of(JMXServiceURL jmxServiceURL) {
+    return Utils.packException(
+        () -> {
+          var jmxConnector = JMXConnectorFactory.connect(jmxServiceURL);
+          return new BasicMBeanClient(
+              jmxConnector.getMBeanServerConnection(),
+              jmxServiceURL.getHost(),
+              jmxServiceURL.getPort()) {
+            @Override
+            public void close() {
+              Utils.close(jmxConnector);
+            }
+          };
+        });
+  }
+
+  static JndiClient local() {
+    return new BasicMBeanClient(ManagementFactory.getPlatformMBeanServer(), Utils.hostname(), -1);
+  }
+
+  @Override
+  default void close() {}
+
+  class BasicMBeanClient implements JndiClient {
+
+    private final MBeanServerConnection connection;
+    final String host;
+
+    final int port;
+
+    BasicMBeanClient(MBeanServerConnection connection, String host, int port) {
+      this.connection = connection;
+      this.host = host;
+      this.port = port;
+    }
+
+    @Override
+    public BeanObject bean(BeanQuery beanQuery) {
+      return Utils.packException(
+          () -> {
+            // ask for MBeanInfo
+            var mBeanInfo = connection.getMBeanInfo(beanQuery.objectName());
+
+            // create a list builder all available attributes name
+            var attributeName =
+                Arrays.stream(mBeanInfo.getAttributes())
+                    .map(MBeanFeatureInfo::getName)
+                    .collect(Collectors.toList());
+
+            // query the result
+            return queryBean(beanQuery, attributeName);
+          });
+    }
+
+    BeanObject queryBean(BeanQuery beanQuery, Collection<String> attributeNameCollection)
+        throws ReflectionException,
+            InstanceNotFoundException,
+            IOException,
+            AttributeNotFoundException,
+            MBeanException {
+      // fetch attribute value from mbean server
+      var attributeNameArray = attributeNameCollection.toArray(new String[0]);
+      var attributeList =
+          connection.getAttributes(beanQuery.objectName(), attributeNameArray).asList();
+
+      // collect attribute name & value into a map
+      var attributes = new HashMap<String, Object>();
+      attributeList.forEach(attribute -> attributes.put(attribute.getName(), attribute.getValue()));
+
+      // according to the javadoc of MBeanServerConnection#getAttributes, the API will
+      // ignore any error occurring during the fetch process (for example, attribute not
+      // exists). Below code check for such condition and try to figure out what exactly
+      // the error is. put it into attributes return result.
+      for (var str : attributeNameArray) {
+        if (attributes.containsKey(str)) continue;
+        try {
+          attributes.put(str, connection.getAttribute(beanQuery.objectName(), str));
+        } catch (RuntimeMBeanException e) {
+          if (!(e.getCause() instanceof UnsupportedOperationException))
+            throw new IllegalStateException(e);
+          // the UnsupportedOperationException is thrown when we query unacceptable
+          // attribute. we just skip it as it is normal case to
+          // return "acceptable" attribute only
+        }
+      }
+
+      // collect result, and build a new BeanObject as return result
+      return new BeanObject(beanQuery.domainName(), beanQuery.properties(), attributes);
+    }
+
+    @Override
+    public Collection<BeanObject> beans(
+        BeanQuery beanQuery, Consumer<RuntimeException> errorHandle) {
+      return Utils.packException(
+          () ->
+              connection.queryMBeans(beanQuery.objectName(), null).stream()
+                  // Parallelize the sampling of bean objects. The underlying RMI is thread-safe.
+                  // https://github.com/skiptests/astraea/issues/1553#issuecomment-1461143723
+                  .parallel()
+                  .map(ObjectInstance::getObjectName)
+                  .map(BeanQuery::fromObjectName)
+                  .flatMap(
+                      query -> {
+                        try {
+                          return Stream.of(bean(query));
+                        } catch (RuntimeException e) {
+                          errorHandle.accept(e);
+                          return Stream.empty();
+                        }
+                      })
+                  .collect(Collectors.toUnmodifiableList()));
+    }
+
+    /**
+     * Returns the list of domains in which any MBean is currently registered.
+     *
+     * <p>The order of strings within the returned array is not defined.
+     *
+     * @return a {@link List} of domain name {@link String}
+     */
+    List<String> domains() {
+      return Utils.packException(() -> Arrays.asList(connection.getDomains()));
+    }
+  }
+}

--- a/common/src/main/java/org/astraea/common/metrics/MBeanClient.java
+++ b/common/src/main/java/org/astraea/common/metrics/MBeanClient.java
@@ -16,46 +16,16 @@
  */
 package org.astraea.common.metrics;
 
-import java.io.IOException;
-import java.lang.management.ManagementFactory;
-import java.net.MalformedURLException;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import javax.management.AttributeNotFoundException;
-import javax.management.InstanceNotFoundException;
-import javax.management.MBeanException;
-import javax.management.MBeanFeatureInfo;
-import javax.management.MBeanServerConnection;
-import javax.management.ObjectInstance;
 import javax.management.ObjectName;
-import javax.management.ReflectionException;
-import javax.management.RuntimeMBeanException;
-import javax.management.remote.JMXConnectorFactory;
-import javax.management.remote.JMXServiceURL;
-import org.astraea.common.Utils;
 
-/**
- * A MBeanClient used to retrieve mbean value from remote Jmx server.
- *
- * <pre>{@code
- * try(var client = new MBeanClient(jmxConnectorServer.getAddress())) {
- *   var bean = client.bean(BeanQuery.builder("java.lang")
- *            .property("type", "MemoryManager")
- *            .property("name", "CodeCacheManager")
- *            .build());
- *   System.out.println(bean.getAttributes());
- * }</pre>
- */
-public interface MBeanClient extends AutoCloseable {
+public interface MBeanClient {
   static MBeanClient of(Collection<BeanObject> objs) {
     return new MBeanClient() {
 
@@ -99,42 +69,6 @@ public interface MBeanClient extends AutoCloseable {
   }
 
   /**
-   * @param host the address of jmx server
-   * @param port the port of jmx server
-   * @return a mbean client using JNDI to lookup metrics.
-   */
-  static MBeanClient jndi(String host, int port) {
-    try {
-      return of(
-          new JMXServiceURL(
-              String.format(
-                  "service:jmx:rmi://%s:%s/jndi/rmi://%s:%s/jmxrmi", host, port, host, port)));
-    } catch (MalformedURLException e) {
-      throw new IllegalArgumentException(e);
-    }
-  }
-
-  static MBeanClient of(JMXServiceURL jmxServiceURL) {
-    return Utils.packException(
-        () -> {
-          var jmxConnector = JMXConnectorFactory.connect(jmxServiceURL);
-          return new BasicMBeanClient(
-              jmxConnector.getMBeanServerConnection(),
-              jmxServiceURL.getHost(),
-              jmxServiceURL.getPort()) {
-            @Override
-            public void close() {
-              Utils.close(jmxConnector);
-            }
-          };
-        });
-  }
-
-  static MBeanClient local() {
-    return new BasicMBeanClient(ManagementFactory.getPlatformMBeanServer(), Utils.hostname(), -1);
-  }
-
-  /**
    * Fetch all attributes of target mbean.
    *
    * <p>Note that when exception is raised during the attribute fetching process, the exact
@@ -167,109 +101,4 @@ public interface MBeanClient extends AutoCloseable {
    * @return A {@link Set} of {@link BeanObject}, all BeanObject has its own attributes resolved.
    */
   Collection<BeanObject> beans(BeanQuery beanQuery, Consumer<RuntimeException> errorHandle);
-
-  @Override
-  default void close() {}
-
-  class BasicMBeanClient implements MBeanClient {
-
-    private final MBeanServerConnection connection;
-    final String host;
-
-    final int port;
-
-    BasicMBeanClient(MBeanServerConnection connection, String host, int port) {
-      this.connection = connection;
-      this.host = host;
-      this.port = port;
-    }
-
-    @Override
-    public BeanObject bean(BeanQuery beanQuery) {
-      return Utils.packException(
-          () -> {
-            // ask for MBeanInfo
-            var mBeanInfo = connection.getMBeanInfo(beanQuery.objectName());
-
-            // create a list builder all available attributes name
-            var attributeName =
-                Arrays.stream(mBeanInfo.getAttributes())
-                    .map(MBeanFeatureInfo::getName)
-                    .collect(Collectors.toList());
-
-            // query the result
-            return queryBean(beanQuery, attributeName);
-          });
-    }
-
-    BeanObject queryBean(BeanQuery beanQuery, Collection<String> attributeNameCollection)
-        throws ReflectionException,
-            InstanceNotFoundException,
-            IOException,
-            AttributeNotFoundException,
-            MBeanException {
-      // fetch attribute value from mbean server
-      var attributeNameArray = attributeNameCollection.toArray(new String[0]);
-      var attributeList =
-          connection.getAttributes(beanQuery.objectName(), attributeNameArray).asList();
-
-      // collect attribute name & value into a map
-      var attributes = new HashMap<String, Object>();
-      attributeList.forEach(attribute -> attributes.put(attribute.getName(), attribute.getValue()));
-
-      // according to the javadoc of MBeanServerConnection#getAttributes, the API will
-      // ignore any error occurring during the fetch process (for example, attribute not
-      // exists). Below code check for such condition and try to figure out what exactly
-      // the error is. put it into attributes return result.
-      for (var str : attributeNameArray) {
-        if (attributes.containsKey(str)) continue;
-        try {
-          attributes.put(str, connection.getAttribute(beanQuery.objectName(), str));
-        } catch (RuntimeMBeanException e) {
-          if (!(e.getCause() instanceof UnsupportedOperationException))
-            throw new IllegalStateException(e);
-          // the UnsupportedOperationException is thrown when we query unacceptable
-          // attribute. we just skip it as it is normal case to
-          // return "acceptable" attribute only
-        }
-      }
-
-      // collect result, and build a new BeanObject as return result
-      return new BeanObject(beanQuery.domainName(), beanQuery.properties(), attributes);
-    }
-
-    @Override
-    public Collection<BeanObject> beans(
-        BeanQuery beanQuery, Consumer<RuntimeException> errorHandle) {
-      return Utils.packException(
-          () ->
-              connection.queryMBeans(beanQuery.objectName(), null).stream()
-                  // Parallelize the sampling of bean objects. The underlying RMI is thread-safe.
-                  // https://github.com/skiptests/astraea/issues/1553#issuecomment-1461143723
-                  .parallel()
-                  .map(ObjectInstance::getObjectName)
-                  .map(BeanQuery::fromObjectName)
-                  .flatMap(
-                      query -> {
-                        try {
-                          return Stream.of(bean(query));
-                        } catch (RuntimeException e) {
-                          errorHandle.accept(e);
-                          return Stream.empty();
-                        }
-                      })
-                  .collect(Collectors.toUnmodifiableList()));
-    }
-
-    /**
-     * Returns the list of domains in which any MBean is currently registered.
-     *
-     * <p>The order of strings within the returned array is not defined.
-     *
-     * @return a {@link List} of domain name {@link String}
-     */
-    List<String> domains() {
-      return Utils.packException(() -> Arrays.asList(connection.getDomains()));
-    }
-  }
 }

--- a/common/src/main/java/org/astraea/common/partitioner/SmoothWeightRoundRobinPartitioner.java
+++ b/common/src/main/java/org/astraea/common/partitioner/SmoothWeightRoundRobinPartitioner.java
@@ -33,6 +33,7 @@ import org.astraea.common.Utils;
 import org.astraea.common.admin.BrokerTopic;
 import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.cost.NeutralIntegratedCost;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.MBeanClient;
 import org.astraea.common.metrics.collector.MetricStore;
 
@@ -124,13 +125,13 @@ public class SmoothWeightRoundRobinPartitioner extends Partitioner {
                 .brokers()
                 .thenApply(
                     brokers -> {
-                      var map = new HashMap<Integer, MBeanClient>();
+                      var map = new HashMap<Integer, JndiClient>();
                       brokers.forEach(
                           b ->
                               map.put(
-                                  b.id(), MBeanClient.jndi(b.host(), jmxPortGetter.apply(b.id()))));
+                                  b.id(), JndiClient.of(b.host(), jmxPortGetter.apply(b.id()))));
                       // add local client to fetch consumer metrics
-                      map.put(-1, MBeanClient.local());
+                      map.put(-1, JndiClient.local());
                       return Collections.unmodifiableMap(map);
                     });
 

--- a/common/src/main/java/org/astraea/common/partitioner/StrictCostPartitioner.java
+++ b/common/src/main/java/org/astraea/common/partitioner/StrictCostPartitioner.java
@@ -35,6 +35,7 @@ import org.astraea.common.cost.BrokerCost;
 import org.astraea.common.cost.HasBrokerCost;
 import org.astraea.common.cost.NoSufficientMetricsException;
 import org.astraea.common.cost.NodeLatencyCost;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.MBeanClient;
 import org.astraea.common.metrics.collector.MetricStore;
 
@@ -145,13 +146,13 @@ public class StrictCostPartitioner extends Partitioner {
                 .brokers()
                 .thenApply(
                     brokers -> {
-                      var map = new HashMap<Integer, MBeanClient>();
+                      var map = new HashMap<Integer, JndiClient>();
                       brokers.forEach(
                           b ->
                               map.put(
-                                  b.id(), MBeanClient.jndi(b.host(), jmxPortGetter.apply(b.id()))));
+                                  b.id(), JndiClient.of(b.host(), jmxPortGetter.apply(b.id()))));
                       // add local client to fetch consumer metrics
-                      map.put(-1, MBeanClient.local());
+                      map.put(-1, JndiClient.local());
                       return Collections.unmodifiableMap(map);
                     });
 

--- a/common/src/test/java/org/astraea/common/balancer/algorithms/GreedyBalancerTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/algorithms/GreedyBalancerTest.java
@@ -28,7 +28,7 @@ import org.astraea.common.balancer.FakeClusterInfo;
 import org.astraea.common.cost.DecreasingCost;
 import org.astraea.common.metrics.BeanQuery;
 import org.astraea.common.metrics.ClusterBean;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -65,7 +65,7 @@ class GreedyBalancerTest extends BalancerConfigTestSuite {
         Utils.construct(
             GreedyBalancer.class, Configuration.of(Map.of(GreedyBalancer.ITERATION_CONFIG, "100")));
 
-    try (MBeanClient client = MBeanClient.local()) {
+    try (JndiClient client = JndiClient.local()) {
       IntStream.range(0, 10)
           .forEach(
               run -> {

--- a/common/src/test/java/org/astraea/common/cost/BrokerInputCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/BrokerInputCostTest.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.metrics.BeanObject;
 import org.astraea.common.metrics.ClusterBean;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.MetricsTestUtils;
 import org.astraea.common.metrics.broker.ServerMetrics;
 import org.astraea.common.producer.Producer;
@@ -66,7 +66,7 @@ public class BrokerInputCostTest {
     var f = new BrokerInputCost();
     var clusterBean =
         MetricsTestUtils.clusterBean(
-            Map.of(0, MBeanClient.of(SERVICE.jmxServiceURL())), f.metricSensor().get());
+            Map.of(0, JndiClient.of(SERVICE.jmxServiceURL())), f.metricSensor().get());
 
     Assertions.assertNotEquals(
         0, clusterBean.brokerMetrics(0, ServerMetrics.BrokerTopic.Meter.class).count());

--- a/common/src/test/java/org/astraea/common/cost/BrokerOutputCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/BrokerOutputCostTest.java
@@ -26,7 +26,7 @@ import org.astraea.common.consumer.Consumer;
 import org.astraea.common.consumer.ConsumerConfigs;
 import org.astraea.common.metrics.BeanObject;
 import org.astraea.common.metrics.ClusterBean;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.MetricsTestUtils;
 import org.astraea.common.metrics.broker.ServerMetrics;
 import org.astraea.common.producer.Producer;
@@ -81,7 +81,7 @@ public class BrokerOutputCostTest {
 
     var f = new BrokerOutputCost();
     var clusterBean =
-        MetricsTestUtils.clusterBean(Map.of(0, MBeanClient.local()), f.metricSensor().get());
+        MetricsTestUtils.clusterBean(Map.of(0, JndiClient.local()), f.metricSensor().get());
 
     Assertions.assertNotEquals(
         0, clusterBean.brokerMetrics(0, ServerMetrics.BrokerTopic.Meter.class).count());

--- a/common/src/test/java/org/astraea/common/cost/ClusterCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/ClusterCostTest.java
@@ -22,7 +22,7 @@ import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.metrics.ClusterBean;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.broker.ServerMetrics;
 import org.astraea.it.Service;
 import org.junit.jupiter.api.AfterAll;
@@ -63,7 +63,7 @@ class ClusterCostTest {
     var mergeCost = HasClusterCost.of(Map.of(cost1, 1.0, cost2, 1.0));
     var metrics =
         mergeCost.metricSensor().stream()
-            .map(x -> x.fetch(MBeanClient.of(SERVICE.jmxServiceURL()), ClusterBean.EMPTY))
+            .map(x -> x.fetch(JndiClient.of(SERVICE.jmxServiceURL()), ClusterBean.EMPTY))
             .collect(Collectors.toSet());
     Assertions.assertTrue(
         metrics.iterator().next().stream()

--- a/common/src/test/java/org/astraea/common/cost/CpuCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/CpuCostTest.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.metrics.ClusterBean;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.MetricsTestUtils;
 import org.astraea.common.metrics.platform.OperatingSystemInfo;
 import org.junit.jupiter.api.Assertions;
@@ -55,7 +55,7 @@ public class CpuCostTest {
   void testSensor() {
     var f = new CpuCost();
     var clusterBean =
-        MetricsTestUtils.clusterBean(Map.of(0, MBeanClient.local()), f.metricSensor().get());
+        MetricsTestUtils.clusterBean(Map.of(0, JndiClient.local()), f.metricSensor().get());
     Assertions.assertFalse(
         clusterBean.brokerMetrics(0, OperatingSystemInfo.class).findAny().isEmpty());
     Assertions.assertTrue(

--- a/common/src/test/java/org/astraea/common/cost/MemoryCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/MemoryCostTest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.metrics.ClusterBean;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.MetricsTestUtils;
 import org.astraea.common.metrics.platform.HasJvmMemory;
 import org.astraea.common.metrics.platform.JvmMemory;
@@ -54,7 +54,7 @@ public class MemoryCostTest {
   void testSensor() {
     var f = new MemoryCost();
     var clusterBean =
-        MetricsTestUtils.clusterBean(Map.of(0, MBeanClient.local()), f.metricSensor().get());
+        MetricsTestUtils.clusterBean(Map.of(0, JndiClient.local()), f.metricSensor().get());
     Assertions.assertTrue(clusterBean.brokerMetrics(0, JvmMemory.class).allMatch(Objects::nonNull));
 
     // Test if we can get "used memory" and "max memory".

--- a/common/src/test/java/org/astraea/common/cost/MoveCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/MoveCostTest.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.metrics.ClusterBean;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.broker.ServerMetrics;
 import org.astraea.common.metrics.collector.MetricSensor;
 import org.astraea.it.Service;
@@ -49,7 +49,7 @@ public class MoveCostTest {
     var mergeCost = HasMoveCost.of(List.of(cost1, cost2));
     var metrics =
         mergeCost.metricSensor().stream()
-            .map(x -> x.fetch(MBeanClient.of(SERVICE.jmxServiceURL()), ClusterBean.EMPTY))
+            .map(x -> x.fetch(JndiClient.of(SERVICE.jmxServiceURL()), ClusterBean.EMPTY))
             .collect(Collectors.toSet());
     Assertions.assertEquals(3, metrics.iterator().next().size());
     Assertions.assertTrue(

--- a/common/src/test/java/org/astraea/common/cost/NodeLatencyCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NodeLatencyCostTest.java
@@ -26,7 +26,7 @@ import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.metrics.BeanObject;
 import org.astraea.common.metrics.ClusterBean;
 import org.astraea.common.metrics.HasBeanObject;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.client.HasNodeMetrics;
 import org.astraea.common.metrics.client.producer.ProducerMetrics;
 import org.astraea.common.producer.Producer;
@@ -90,7 +90,7 @@ public class NodeLatencyCostTest {
                           ClusterBean.of(
                               Map.of(
                                   -1,
-                                  ProducerMetrics.node(MBeanClient.local()).stream()
+                                  ProducerMetrics.node(JndiClient.local()).stream()
                                       .map(b -> (HasBeanObject) b)
                                       .collect(Collectors.toUnmodifiableList()))))
                       .value()
@@ -102,7 +102,7 @@ public class NodeLatencyCostTest {
   @Test
   void testSensor() {
     var function = new NodeLatencyCost();
-    var client = Mockito.mock(MBeanClient.class);
+    var client = Mockito.mock(JndiClient.class);
     Mockito.when(client.beans(Mockito.any()))
         .thenReturn(
             List.of(

--- a/common/src/test/java/org/astraea/common/cost/NodeMetricsCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NodeMetricsCostTest.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.metrics.ClusterBean;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.client.HasNodeMetrics;
 import org.astraea.common.metrics.client.producer.ProducerMetrics;
 import org.astraea.common.producer.Producer;
@@ -64,7 +64,7 @@ public class NodeMetricsCostTest {
                   .toCompletableFuture()
                   .join(),
               ClusterBean.of(
-                  ProducerMetrics.node(MBeanClient.local()).stream()
+                  ProducerMetrics.node(JndiClient.local()).stream()
                       .collect(Collectors.groupingBy(HasNodeMetrics::brokerId))));
       Assertions.assertEquals(3, cost.value().size());
       // only 1 node has latency metrics, so all costs are equal
@@ -86,7 +86,7 @@ public class NodeMetricsCostTest {
                   .toCompletableFuture()
                   .join(),
               ClusterBean.of(
-                  ProducerMetrics.node(MBeanClient.local()).stream()
+                  ProducerMetrics.node(JndiClient.local()).stream()
                       .collect(Collectors.groupingBy(HasNodeMetrics::brokerId))));
       Assertions.assertEquals(3, cost2.value().size());
       // only 2 node has latency metrics. The other cost is equal to "max cost"

--- a/common/src/test/java/org/astraea/common/cost/NodeThroughputCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NodeThroughputCostTest.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.metrics.BeanObject;
 import org.astraea.common.metrics.ClusterBean;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.client.HasNodeMetrics;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -76,7 +76,7 @@ public class NodeThroughputCostTest {
     var throughputCost = new NodeThroughputCost();
     var sensor = throughputCost.metricSensor().get();
     var bean = new BeanObject("aaa", Map.of("node-id", "node-1"), Map.of());
-    var client = Mockito.mock(MBeanClient.class);
+    var client = Mockito.mock(JndiClient.class);
     Mockito.when(client.beans(Mockito.any())).thenReturn(List.of(bean));
     var result = sensor.fetch(client, ClusterBean.EMPTY);
     Assertions.assertEquals(1, result.size());

--- a/common/src/test/java/org/astraea/common/cost/utils/ClusterInfoSensorTest.java
+++ b/common/src/test/java/org/astraea/common/cost/utils/ClusterInfoSensorTest.java
@@ -29,7 +29,7 @@ import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.metrics.BeanObject;
 import org.astraea.common.metrics.ClusterBean;
 import org.astraea.common.metrics.HasBeanObject;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.MetricFactory;
 import org.astraea.common.metrics.MetricsTestUtils;
 import org.astraea.common.metrics.broker.ClusterMetrics;
@@ -74,7 +74,7 @@ class ClusterInfoSensorTest {
             .forEach(i -> i.toCompletableFuture().join());
       }
 
-      var cb = MetricsTestUtils.clusterBean(Map.of(aBroker.id(), MBeanClient.local()), sensor);
+      var cb = MetricsTestUtils.clusterBean(Map.of(aBroker.id(), JndiClient.local()), sensor);
 
       // assert contains that metrics
       cb.all()

--- a/common/src/test/java/org/astraea/common/metrics/BeanQueryIntegratedTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/BeanQueryIntegratedTest.java
@@ -35,7 +35,7 @@ class BeanQueryIntegratedTest {
 
   @Test
   void testAllBuiltInQueries() {
-    try (var client = MBeanClient.of(SERVICE.jmxServiceURL())) {
+    try (var client = JndiClient.of(SERVICE.jmxServiceURL())) {
       var exist = new HashSet<Map<String, String>>();
       MetricFetcher.QUERIES.forEach(
           q ->

--- a/common/src/test/java/org/astraea/common/metrics/MBeanClientTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/MBeanClientTest.java
@@ -109,7 +109,7 @@ class MBeanClientTest {
   @Test
   void testFetchAttributes() {
     // arrange
-    try (var client = MBeanClient.of(jmxServer.getAddress())) {
+    try (var client = JndiClient.of(jmxServer.getAddress())) {
       BeanQuery beanQuery =
           BeanQuery.builder().domainName("java.lang").property("type", "Memory").build();
 
@@ -126,7 +126,7 @@ class MBeanClientTest {
   @Test
   void testFetchMbeanWithMultipleProperties() {
     // arrange
-    try (var client = MBeanClient.of(jmxServer.getAddress())) {
+    try (var client = JndiClient.of(jmxServer.getAddress())) {
       BeanQuery query1 =
           BeanQuery.builder()
               .domainName("java.lang")
@@ -168,7 +168,7 @@ class MBeanClientTest {
           AttributeNotFoundException,
           MBeanException {
     // arrange
-    try (var client = (MBeanClient.BasicMBeanClient) MBeanClient.of(jmxServer.getAddress())) {
+    try (var client = (JndiClient.BasicMBeanClient) JndiClient.of(jmxServer.getAddress())) {
       BeanQuery beanQuery =
           BeanQuery.builder().domainName("java.lang").property("type", "Memory").build();
       List<String> selectedAttribute = List.of("HeapMemoryUsage");
@@ -186,7 +186,7 @@ class MBeanClientTest {
   @Test
   void testQueryBeans() {
     // arrange 1 query beans
-    try (var client = MBeanClient.of(jmxServer.getAddress())) {
+    try (var client = JndiClient.of(jmxServer.getAddress())) {
       BeanQuery beanQuery =
           BeanQuery.builder().domainName("java.lang").property("type", "C*").build();
 
@@ -224,7 +224,7 @@ class MBeanClientTest {
   @Test
   void testQueryNonExistsBeans() {
     // arrange
-    try (var client = MBeanClient.of(jmxServer.getAddress())) {
+    try (var client = JndiClient.of(jmxServer.getAddress())) {
       BeanQuery beanQuery =
           BeanQuery.builder().domainName("java.lang").property("type", "Something").build();
 
@@ -239,7 +239,7 @@ class MBeanClientTest {
   @Test
   void testFetchNonExistsBeans() {
     // arrange
-    try (var client = (MBeanClient.BasicMBeanClient) MBeanClient.of(jmxServer.getAddress())) {
+    try (var client = (JndiClient.BasicMBeanClient) JndiClient.of(jmxServer.getAddress())) {
       BeanQuery beanQuery =
           BeanQuery.builder().domainName("java.lang").property("type", "Something").build();
 
@@ -254,7 +254,7 @@ class MBeanClientTest {
   @Test
   void testCloseOnceMore() {
     // arrange
-    var client = MBeanClient.of(jmxServer.getAddress());
+    var client = JndiClient.of(jmxServer.getAddress());
 
     // act
     client.close();
@@ -270,7 +270,7 @@ class MBeanClientTest {
   @Test
   void testGetAllMBeans() {
     // arrange
-    try (var client = MBeanClient.of(jmxServer.getAddress())) {
+    try (var client = JndiClient.of(jmxServer.getAddress())) {
 
       // act
       Collection<BeanObject> beanObjects = client.beans(BeanQuery.all());
@@ -284,7 +284,7 @@ class MBeanClientTest {
   @Test
   void testGetAllMBeansUnderSpecificDomainName() {
     // arrange
-    try (var client = MBeanClient.of(jmxServer.getAddress())) {
+    try (var client = JndiClient.of(jmxServer.getAddress())) {
 
       // act
       Collection<BeanObject> beanObjects = client.beans(BeanQuery.all("java.lang"));
@@ -298,7 +298,7 @@ class MBeanClientTest {
   @Test
   void testGetAllMBeansUnderSpecificDomainNamePattern() {
     // arrange
-    try (var client = MBeanClient.of(jmxServer.getAddress())) {
+    try (var client = JndiClient.of(jmxServer.getAddress())) {
 
       // act
       Collection<BeanObject> beanObjects = client.beans(BeanQuery.all("java.*"));
@@ -311,15 +311,15 @@ class MBeanClientTest {
 
   @Test
   void testUsePropertyListPatternForRemote() {
-    testUsePropertyListPattern(MBeanClient.of(jmxServer.getAddress()));
+    testUsePropertyListPattern(JndiClient.of(jmxServer.getAddress()));
   }
 
   @Test
   void testUsePropertyListPatternForLocal() {
-    testUsePropertyListPattern(MBeanClient.local());
+    testUsePropertyListPattern(JndiClient.local());
   }
 
-  private void testUsePropertyListPattern(MBeanClient client) {
+  private void testUsePropertyListPattern(JndiClient client) {
     // arrange
     try (client) {
       BeanQuery patternQuery =
@@ -374,7 +374,7 @@ class MBeanClientTest {
   @Test
   void testListDomains() {
     // arrange
-    try (var client = (MBeanClient.BasicMBeanClient) MBeanClient.of(jmxServer.getAddress())) {
+    try (var client = (JndiClient.BasicMBeanClient) JndiClient.of(jmxServer.getAddress())) {
 
       // act
       List<String> domains = client.domains();
@@ -388,7 +388,7 @@ class MBeanClientTest {
   @Test
   void testHostAndPort() {
     // arrange
-    try (var client = (MBeanClient.BasicMBeanClient) MBeanClient.of(jmxServer.getAddress())) {
+    try (var client = (JndiClient.BasicMBeanClient) JndiClient.of(jmxServer.getAddress())) {
       assertEquals(jmxServer.getAddress().getHost(), client.host);
       assertEquals(jmxServer.getAddress().getPort(), client.port);
     }
@@ -404,7 +404,7 @@ class MBeanClientTest {
 
     register(objectName0, customMBean0);
 
-    try (var client = MBeanClient.of(jmxServer.getAddress())) {
+    try (var client = JndiClient.of(jmxServer.getAddress())) {
 
       // act
       Collection<BeanObject> all =
@@ -431,7 +431,7 @@ class MBeanClientTest {
       register(objectName, mbean);
     }
 
-    try (var client = MBeanClient.of(jmxServer.getAddress())) {
+    try (var client = JndiClient.of(jmxServer.getAddress())) {
 
       // act
       Collection<BeanObject> all =
@@ -469,7 +469,7 @@ class MBeanClientTest {
 
   @Test
   void testLocal() {
-    var client = MBeanClient.local();
+    var client = JndiClient.local();
     Assertions.assertNotEquals(0, client.beans(BeanQuery.all()).size());
   }
 

--- a/common/src/test/java/org/astraea/common/metrics/MBeanRegisterTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/MBeanRegisterTest.java
@@ -35,14 +35,14 @@ class MBeanRegisterTest {
         .attribute("incoming-byte-rate", Double.class, () -> 10D)
         .register();
 
-    var metrics = ProducerMetrics.node(MBeanClient.local());
+    var metrics = ProducerMetrics.node(JndiClient.local());
     Assertions.assertEquals(1, metrics.size());
     Assertions.assertEquals(10D, metrics.iterator().next().incomingByteRate());
   }
 
   @Test
   void testBuilder() {
-    try (MBeanClient client = MBeanClient.local()) {
+    try (JndiClient client = JndiClient.local()) {
       var domainName = MBeanRegisterTest.class.getPackageName();
       var id = UUID.randomUUID().toString();
       Supplier<BeanObject> bean =

--- a/common/src/test/java/org/astraea/common/metrics/MetricsTestUtils.java
+++ b/common/src/test/java/org/astraea/common/metrics/MetricsTestUtils.java
@@ -43,7 +43,7 @@ public final class MetricsTestUtils {
    * @param sensor to generate object
    * @return cluster bean
    */
-  public static ClusterBean clusterBean(Map<Integer, MBeanClient> clients, MetricSensor sensor) {
+  public static ClusterBean clusterBean(Map<Integer, JndiClient> clients, MetricSensor sensor) {
     return ClusterBean.of(
         clients.entrySet().stream()
             .collect(

--- a/common/src/test/java/org/astraea/common/metrics/broker/ControllerMetricsTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/broker/ControllerMetricsTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Locale;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.MetricsTestUtils;
 import org.astraea.it.Service;
 import org.junit.jupiter.api.AfterAll;
@@ -47,7 +47,7 @@ class ControllerMetricsTest {
   @ParameterizedTest
   @EnumSource(ControllerMetrics.Controller.class)
   void testController(ControllerMetrics.Controller controller) {
-    var gauge = controller.fetch(MBeanClient.local());
+    var gauge = controller.fetch(JndiClient.local());
     MetricsTestUtils.validate(gauge);
     Assertions.assertEquals(controller, gauge.type());
   }

--- a/common/src/test/java/org/astraea/common/metrics/broker/LogMetricsTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/broker/LogMetricsTest.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.metrics.HasBeanObject;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.MetricsTestUtils;
 import org.astraea.it.Service;
 import org.junit.jupiter.api.AfterAll;
@@ -56,7 +56,7 @@ public class LogMetricsTest {
     var topicName = Utils.randomString(10);
     try (var admin = Admin.of(SERVICE.bootstrapServers())) {
       var beans =
-          log.fetch(MBeanClient.local()).stream()
+          log.fetch(JndiClient.local()).stream()
               .collect(Collectors.groupingBy(LogMetrics.LogCleanerManager.Gauge::path));
       Assertions.assertEquals(
           SERVICE.dataFolders().values().stream().flatMap(Collection::stream).distinct().count(),
@@ -79,7 +79,7 @@ public class LogMetricsTest {
       admin.creator().topic(topicName).numberOfPartitions(2).run().toCompletableFuture().join();
       Utils.sleep(Duration.ofSeconds(2));
       var beans =
-          log.fetch(MBeanClient.local()).stream()
+          log.fetch(JndiClient.local()).stream()
               .filter(m -> m.topic().equals(topicName))
               .collect(Collectors.toUnmodifiableList());
       Assertions.assertEquals(2, beans.size());
@@ -93,7 +93,7 @@ public class LogMetricsTest {
   @ParameterizedTest
   @EnumSource(LogMetrics.Log.class)
   void testValue(LogMetrics.Log log) {
-    log.fetch(MBeanClient.local())
+    log.fetch(JndiClient.local())
         .forEach(
             m -> {
               MetricsTestUtils.validate(m);
@@ -130,7 +130,7 @@ public class LogMetricsTest {
     // wait for topic creation
     Utils.sleep(Duration.ofSeconds(2));
 
-    var beans = request.fetch(MBeanClient.local());
+    var beans = request.fetch(JndiClient.local());
     assertNotEquals(0, beans.size());
   }
 

--- a/common/src/test/java/org/astraea/common/metrics/broker/NetworkMetricsTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/broker/NetworkMetricsTest.java
@@ -16,7 +16,7 @@
  */
 package org.astraea.common.metrics.broker;
 
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.MetricsTestUtils;
 import org.astraea.it.Service;
 import org.junit.jupiter.api.AfterAll;
@@ -44,7 +44,7 @@ public class NetworkMetricsTest {
   @ParameterizedTest()
   @EnumSource(value = NetworkMetrics.Request.class)
   void testRequestTotalTimeMs(NetworkMetrics.Request request) {
-    var histogram = request.fetch(MBeanClient.local());
+    var histogram = request.fetch(JndiClient.local());
     MetricsTestUtils.validate(histogram);
   }
 

--- a/common/src/test/java/org/astraea/common/metrics/broker/ReplicaManagerMetricsTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/broker/ReplicaManagerMetricsTest.java
@@ -16,7 +16,7 @@
  */
 package org.astraea.common.metrics.broker;
 
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.MetricsTestUtils;
 import org.astraea.it.Service;
 import org.junit.jupiter.api.AfterAll;
@@ -44,7 +44,7 @@ public class ReplicaManagerMetricsTest {
   @ParameterizedTest
   @EnumSource(ServerMetrics.ReplicaManager.class)
   void testBrokerTopic(ServerMetrics.ReplicaManager rm) {
-    var gauge = rm.fetch(MBeanClient.local());
+    var gauge = rm.fetch(JndiClient.local());
     Assertions.assertEquals(0, gauge.value());
     MetricsTestUtils.validate(gauge);
     Assertions.assertEquals(rm, gauge.type());

--- a/common/src/test/java/org/astraea/common/metrics/broker/ServerMetricsTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/broker/ServerMetricsTest.java
@@ -31,7 +31,7 @@ import org.astraea.common.Utils;
 import org.astraea.common.consumer.Consumer;
 import org.astraea.common.consumer.ConsumerConfigs;
 import org.astraea.common.metrics.BeanObject;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.MetricsTestUtils;
 import org.astraea.common.producer.Producer;
 import org.astraea.common.producer.Record;
@@ -60,13 +60,13 @@ public class ServerMetricsTest {
 
   @Test
   void testAppInfo() {
-    ServerMetrics.appInfo(MBeanClient.local()).forEach(MetricsTestUtils::validate);
+    ServerMetrics.appInfo(JndiClient.local()).forEach(MetricsTestUtils::validate);
   }
 
   @ParameterizedTest()
   @EnumSource(value = ServerMetrics.DelayedOperationPurgatory.class)
   void testPurgatorySize(ServerMetrics.DelayedOperationPurgatory request) {
-    var m = request.fetch(MBeanClient.local());
+    var m = request.fetch(JndiClient.local());
     Assertions.assertDoesNotThrow(m::value);
     MetricsTestUtils.validate(m);
   }
@@ -74,17 +74,17 @@ public class ServerMetricsTest {
   @ParameterizedTest()
   @EnumSource(value = ServerMetrics.KafkaServer.class)
   void testKafkaServer(ServerMetrics.KafkaServer request) {
-    MetricsTestUtils.validate(request.fetch(MBeanClient.local()));
+    MetricsTestUtils.validate(request.fetch(JndiClient.local()));
   }
 
   @Test
   void testKafkaServerOtherMetrics() {
-    MetricsTestUtils.validate(ServerMetrics.KafkaServer.CLUSTER_ID.fetch(MBeanClient.local()));
+    MetricsTestUtils.validate(ServerMetrics.KafkaServer.CLUSTER_ID.fetch(JndiClient.local()));
   }
 
   @Test
   void testSocketMetrics() {
-    var socketMetric = ServerMetrics.Socket.socket(MBeanClient.local());
+    var socketMetric = ServerMetrics.Socket.socket(JndiClient.local());
 
     assertDoesNotThrow(socketMetric::brokerConnectionAcceptRate);
     assertDoesNotThrow(socketMetric::memoryPoolAvgDepletedPercent);
@@ -93,7 +93,7 @@ public class ServerMetricsTest {
 
   @Test
   void testSocketListenerMetrics() {
-    var socketListenerMetrics = ServerMetrics.Socket.socketListener(MBeanClient.local());
+    var socketListenerMetrics = ServerMetrics.Socket.socketListener(JndiClient.local());
     assertTrue(socketListenerMetrics.size() > 0);
     socketListenerMetrics.forEach(
         x -> {
@@ -108,7 +108,7 @@ public class ServerMetricsTest {
   @Test
   void testSocketNetworkProcessorMetrics() {
     var socketNetworkProcessorMetrics =
-        ServerMetrics.Socket.socketNetworkProcessor(MBeanClient.local());
+        ServerMetrics.Socket.socketNetworkProcessor(JndiClient.local());
     assertTrue(socketNetworkProcessorMetrics.size() > 0);
     socketNetworkProcessorMetrics.forEach(
         x -> {
@@ -160,7 +160,7 @@ public class ServerMetricsTest {
 
   @Test
   void testSocketClientMetrics() {
-    var clientMetrics = ServerMetrics.Socket.client(MBeanClient.local());
+    var clientMetrics = ServerMetrics.Socket.client(JndiClient.local());
     assertTrue(clientMetrics.size() > 0);
     clientMetrics.forEach(
         x -> {
@@ -228,7 +228,7 @@ public class ServerMetricsTest {
       var records = consumer.poll(Duration.ofSeconds(5));
       Assertions.assertEquals(1, records.size());
     }
-    var meters = topic.fetch(MBeanClient.local());
+    var meters = topic.fetch(JndiClient.local());
     Assertions.assertNotEquals(0, meters.size());
     Assertions.assertNotEquals(0, meters.stream().filter(m -> m.topic().equals(name)).count());
     meters.forEach(

--- a/common/src/test/java/org/astraea/common/metrics/broker/ServerTopicMetricsTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/broker/ServerTopicMetricsTest.java
@@ -16,7 +16,7 @@
  */
 package org.astraea.common.metrics.broker;
 
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.MetricsTestUtils;
 import org.astraea.it.Service;
 import org.junit.jupiter.api.AfterAll;
@@ -43,7 +43,7 @@ public class ServerTopicMetricsTest {
   @ParameterizedTest
   @EnumSource(value = ServerMetrics.BrokerTopic.class)
   void testRequestBrokerTopicMetrics(ServerMetrics.BrokerTopic metric) {
-    var meter = metric.fetch(MBeanClient.local());
+    var meter = metric.fetch(JndiClient.local());
     MetricsTestUtils.validate(meter);
   }
 }

--- a/common/src/test/java/org/astraea/common/metrics/client/admin/AdminMetricsTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/client/admin/AdminMetricsTest.java
@@ -19,7 +19,7 @@ package org.astraea.common.metrics.client.admin;
 import java.time.Duration;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.client.HasNodeMetrics;
 import org.astraea.it.Service;
 import org.junit.jupiter.api.AfterAll;
@@ -41,7 +41,7 @@ public class AdminMetricsTest {
     try (var admin = Admin.of(SERVICE.bootstrapServers())) {
       admin.creator().topic(topic).numberOfPartitions(3).run().toCompletableFuture().join();
       Utils.sleep(Duration.ofSeconds(3));
-      var metrics = AdminMetrics.node(MBeanClient.local());
+      var metrics = AdminMetrics.node(JndiClient.local());
       Assertions.assertNotEquals(1, metrics.size());
       Assertions.assertTrue(
           metrics.stream()
@@ -73,7 +73,7 @@ public class AdminMetricsTest {
       admin.creator().topic(topic).numberOfPartitions(3).run().toCompletableFuture().join();
       Utils.sleep(Duration.ofSeconds(3));
       var metrics =
-          AdminMetrics.admin(MBeanClient.local()).stream()
+          AdminMetrics.admin(JndiClient.local()).stream()
               .filter(m -> m.clientId().equals(admin.clientId()))
               .findFirst()
               .get();

--- a/common/src/test/java/org/astraea/common/metrics/client/consumer/ConsumerMetricsTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/client/consumer/ConsumerMetricsTest.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.consumer.Consumer;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.MetricsTestUtils;
 import org.astraea.common.metrics.client.HasNodeMetrics;
 import org.astraea.it.Service;
@@ -50,7 +50,7 @@ public class ConsumerMetricsTest {
       admin.creator().topic(topic).numberOfPartitions(3).run().toCompletableFuture().join();
       Utils.sleep(Duration.ofSeconds(3));
       consumer.poll(Duration.ofSeconds(5));
-      ConsumerMetrics.appInfo(MBeanClient.local()).forEach(MetricsTestUtils::validate);
+      ConsumerMetrics.appInfo(JndiClient.local()).forEach(MetricsTestUtils::validate);
     }
   }
 
@@ -65,7 +65,7 @@ public class ConsumerMetricsTest {
       admin.creator().topic(topic).numberOfPartitions(3).run().toCompletableFuture().join();
       Utils.sleep(Duration.ofSeconds(3));
       consumer.poll(Duration.ofSeconds(5));
-      var metrics = ConsumerMetrics.node(MBeanClient.local());
+      var metrics = ConsumerMetrics.node(JndiClient.local());
       Assertions.assertNotEquals(1, metrics.size());
       Assertions.assertTrue(
           metrics.stream()

--- a/common/src/test/java/org/astraea/common/metrics/client/consumer/HasConsumerCoordinatorMetricsTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/client/consumer/HasConsumerCoordinatorMetricsTest.java
@@ -23,7 +23,7 @@ import java.util.stream.IntStream;
 import org.astraea.common.Utils;
 import org.astraea.common.consumer.Consumer;
 import org.astraea.common.consumer.ConsumerConfigs;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.producer.Producer;
 import org.astraea.common.producer.Record;
 import org.astraea.it.Service;
@@ -63,7 +63,7 @@ public class HasConsumerCoordinatorMetricsTest {
             .build()) {
       Assertions.assertEquals(10, consumer.poll(Duration.ofSeconds(5)).size());
       consumer.commitOffsets(Duration.ofSeconds(2));
-      var metrics = ConsumerMetrics.coordinator(MBeanClient.local());
+      var metrics = ConsumerMetrics.coordinator(JndiClient.local());
       Assertions.assertEquals(1, metrics.size());
       var m = metrics.iterator().next();
       Assertions.assertNotNull(m.clientId());

--- a/common/src/test/java/org/astraea/common/metrics/client/consumer/HasConsumerFetchMetricsTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/client/consumer/HasConsumerFetchMetricsTest.java
@@ -23,7 +23,7 @@ import java.util.stream.IntStream;
 import org.astraea.common.Utils;
 import org.astraea.common.consumer.Consumer;
 import org.astraea.common.consumer.ConsumerConfigs;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.producer.Producer;
 import org.astraea.common.producer.Record;
 import org.astraea.it.Service;
@@ -63,7 +63,7 @@ public class HasConsumerFetchMetricsTest {
             .build()) {
       Assertions.assertEquals(10, consumer.poll(Duration.ofSeconds(5)).size());
       consumer.commitOffsets(Duration.ofSeconds(2));
-      var metrics = ConsumerMetrics.fetch(MBeanClient.local());
+      var metrics = ConsumerMetrics.fetch(JndiClient.local());
       Assertions.assertEquals(1, metrics.size());
       var m = metrics.iterator().next();
       Assertions.assertNotNull(m.clientId());

--- a/common/src/test/java/org/astraea/common/metrics/client/consumer/HasConsumerMetricsTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/client/consumer/HasConsumerMetricsTest.java
@@ -23,7 +23,7 @@ import java.util.stream.IntStream;
 import org.astraea.common.Utils;
 import org.astraea.common.consumer.Consumer;
 import org.astraea.common.consumer.ConsumerConfigs;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.producer.Producer;
 import org.astraea.common.producer.Record;
 import org.astraea.it.Service;
@@ -63,7 +63,7 @@ public class HasConsumerMetricsTest {
             .build()) {
       Assertions.assertEquals(10, consumer.poll(Duration.ofSeconds(5)).size());
       consumer.commitOffsets(Duration.ofSeconds(2));
-      var metrics = ConsumerMetrics.consumer(MBeanClient.local());
+      var metrics = ConsumerMetrics.consumer(JndiClient.local());
       Assertions.assertEquals(1, metrics.size());
       var m = metrics.iterator().next();
       Assertions.assertNotNull(m.clientId());

--- a/common/src/test/java/org/astraea/common/metrics/client/producer/ProducerMetricsTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/client/producer/ProducerMetricsTest.java
@@ -20,7 +20,7 @@ import java.time.Duration;
 import java.util.stream.Collectors;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.MetricsTestUtils;
 import org.astraea.common.metrics.client.HasNodeMetrics;
 import org.astraea.common.producer.Producer;
@@ -44,7 +44,7 @@ public class ProducerMetricsTest {
     var topic = Utils.randomString(10);
     try (var producer = Producer.of(SERVICE.bootstrapServers())) {
       producer.send(Record.builder().topic(topic).build()).toCompletableFuture().join();
-      ProducerMetrics.appInfo(MBeanClient.local()).forEach(MetricsTestUtils::validate);
+      ProducerMetrics.appInfo(JndiClient.local()).forEach(MetricsTestUtils::validate);
     }
   }
 
@@ -54,7 +54,7 @@ public class ProducerMetricsTest {
     try (var producer = Producer.of(SERVICE.bootstrapServers())) {
       producer.send(Record.builder().topic(topic).build()).toCompletableFuture().join();
       var metrics =
-          ProducerMetrics.producer(MBeanClient.local()).stream()
+          ProducerMetrics.producer(JndiClient.local()).stream()
               .filter(m -> m.clientId().equals(producer.clientId()))
               .findFirst()
               .get();
@@ -135,7 +135,7 @@ public class ProducerMetricsTest {
     var topic = Utils.randomString(10);
     try (var producer = Producer.of(SERVICE.bootstrapServers())) {
       producer.send(Record.builder().topic(topic).build()).toCompletableFuture().join();
-      var metrics = ProducerMetrics.topic(MBeanClient.local());
+      var metrics = ProducerMetrics.topic(JndiClient.local());
       Assertions.assertNotEquals(0, metrics.stream().filter(m -> m.topic().equals(topic)).count());
       var producerTopicMetrics =
           metrics.stream().filter(m -> m.clientId().equals(producer.clientId())).findFirst().get();
@@ -173,7 +173,7 @@ public class ProducerMetricsTest {
           .toCompletableFuture()
           .join();
 
-      var metrics = ProducerMetrics.node(MBeanClient.local());
+      var metrics = ProducerMetrics.node(JndiClient.local());
       Assertions.assertNotEquals(1, metrics.size());
       Assertions.assertTrue(
           metrics.stream()

--- a/common/src/test/java/org/astraea/common/metrics/collector/LocalMetricsTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/collector/LocalMetricsTest.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.astraea.common.Utils;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.it.Service;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -42,7 +42,7 @@ public class LocalMetricsTest {
     try (var store =
         MetricStore.builder()
             .beanExpiration(Duration.ofSeconds(1))
-            .localReceiver(() -> CompletableFuture.completedStage(Map.of(-1, MBeanClient.local())))
+            .localReceiver(() -> CompletableFuture.completedStage(Map.of(-1, JndiClient.local())))
             .build()) {
       Utils.sleep(Duration.ofSeconds(3));
       Assertions.assertNotEquals(0, store.clusterBean().all().size());

--- a/common/src/test/java/org/astraea/common/metrics/collector/MetricFetcherTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/collector/MetricFetcherTest.java
@@ -33,6 +33,7 @@ import org.astraea.common.consumer.Consumer;
 import org.astraea.common.consumer.Deserializer;
 import org.astraea.common.consumer.SeekStrategy;
 import org.astraea.common.metrics.BeanObject;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.MBeanClient;
 import org.astraea.it.Service;
 import org.junit.jupiter.api.AfterAll;
@@ -51,7 +52,7 @@ public class MetricFetcherTest {
   @Test
   void testPublishAndClose() {
     var beans = List.of(new BeanObject(Utils.randomString(), Map.of(), Map.of()));
-    var client = Mockito.mock(MBeanClient.class);
+    var client = Mockito.mock(JndiClient.class);
     Mockito.when(client.beans(Mockito.any(), Mockito.any())).thenReturn(beans);
     var sender = Mockito.mock(MetricFetcher.Sender.class);
     var queue = new ConcurrentHashMap<Integer, Collection<BeanObject>>();
@@ -105,7 +106,7 @@ public class MetricFetcherTest {
 
   @Test
   void testFetchBeanDelay() {
-    var client = Mockito.mock(MBeanClient.class);
+    var client = Mockito.mock(JndiClient.class);
     try (var fetcher =
         MetricFetcher.builder()
             .sender(MetricFetcher.Sender.local())

--- a/common/src/test/java/org/astraea/common/metrics/collector/MetricSensorTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/collector/MetricSensorTest.java
@@ -21,7 +21,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.astraea.common.metrics.ClusterBean;
 import org.astraea.common.metrics.HasBeanObject;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -37,7 +37,7 @@ public class MetricSensorTest {
 
     var sensor = MetricSensor.of(List.of(metricSensor0, metricSensor1)).get();
 
-    var result = sensor.fetch(Mockito.mock(MBeanClient.class), ClusterBean.EMPTY);
+    var result = sensor.fetch(Mockito.mock(JndiClient.class), ClusterBean.EMPTY);
 
     Assertions.assertEquals(2, result.size());
     Assertions.assertTrue(result.contains(mbean0));
@@ -68,7 +68,7 @@ public class MetricSensorTest {
             .get();
     Assertions.assertThrows(
         RuntimeException.class,
-        () -> sensor.fetch(Mockito.mock(MBeanClient.class), ClusterBean.EMPTY));
+        () -> sensor.fetch(Mockito.mock(JndiClient.class), ClusterBean.EMPTY));
   }
 
   @Test
@@ -86,15 +86,15 @@ public class MetricSensorTest {
 
     var sensor = MetricSensor.of(List.of(metricSensor0, metricSensor1)).get();
     Assertions.assertDoesNotThrow(
-        () -> sensor.fetch(Mockito.mock(MBeanClient.class), ClusterBean.EMPTY));
+        () -> sensor.fetch(Mockito.mock(JndiClient.class), ClusterBean.EMPTY));
     Assertions.assertEquals(
-        1, sensor.fetch(Mockito.mock(MBeanClient.class), ClusterBean.EMPTY).size());
+        1, sensor.fetch(Mockito.mock(JndiClient.class), ClusterBean.EMPTY).size());
 
     Assertions.assertDoesNotThrow(
         () ->
             MetricSensor.of(List.of(metricSensor0, metricSensor2))
                 .get()
-                .fetch(Mockito.mock(MBeanClient.class), ClusterBean.EMPTY));
+                .fetch(Mockito.mock(JndiClient.class), ClusterBean.EMPTY));
     Assertions.assertThrows(
         NoSuchElementException.class,
         () ->
@@ -104,6 +104,6 @@ public class MetricSensorTest {
                       if (e instanceof NoSuchElementException) throw new NoSuchElementException();
                     })
                 .get()
-                .fetch(Mockito.mock(MBeanClient.class), ClusterBean.EMPTY));
+                .fetch(Mockito.mock(JndiClient.class), ClusterBean.EMPTY));
   }
 }

--- a/common/src/test/java/org/astraea/common/metrics/connector/ConnectorMetricsTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/connector/ConnectorMetricsTest.java
@@ -17,7 +17,7 @@
 package org.astraea.common.metrics.connector;
 
 import org.astraea.common.connector.ConnectorClient;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.it.Service;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -36,7 +36,7 @@ public class ConnectorMetricsTest {
   void testMetrics() {
     ConnectorClient.builder().url(SERVICE.workerUrl()).build();
 
-    var m0 = ConnectorMetrics.appInfo(MBeanClient.local());
+    var m0 = ConnectorMetrics.appInfo(JndiClient.local());
     Assertions.assertNotEquals(0, m0.size());
     m0.forEach(
         m -> {
@@ -45,7 +45,7 @@ public class ConnectorMetricsTest {
           Assertions.assertDoesNotThrow(m::version);
         });
 
-    var m1 = ConnectorMetrics.coordinatorInfo(MBeanClient.local());
+    var m1 = ConnectorMetrics.coordinatorInfo(JndiClient.local());
     Assertions.assertNotEquals(0, m1.size());
     m1.forEach(
         m -> {
@@ -73,7 +73,7 @@ public class ConnectorMetricsTest {
           Assertions.assertDoesNotThrow(m::assignedTasks);
         });
 
-    var m2 = ConnectorMetrics.connector(MBeanClient.local());
+    var m2 = ConnectorMetrics.connector(JndiClient.local());
     Assertions.assertNotEquals(0, m2.size());
     m2.forEach(
         m -> {
@@ -115,7 +115,7 @@ public class ConnectorMetricsTest {
           Assertions.assertDoesNotThrow(m::successfulReauthenticationTotal);
         });
 
-    var m3 = ConnectorMetrics.nodeInfo(MBeanClient.local());
+    var m3 = ConnectorMetrics.nodeInfo(JndiClient.local());
     Assertions.assertNotEquals(0, m3.size());
     m3.forEach(
         m -> {
@@ -133,7 +133,7 @@ public class ConnectorMetricsTest {
           Assertions.assertDoesNotThrow(m::responseTotal);
         });
 
-    var m4 = ConnectorMetrics.workerInfo(MBeanClient.local());
+    var m4 = ConnectorMetrics.workerInfo(JndiClient.local());
     Assertions.assertNotEquals(0, m4.size());
     m4.forEach(
         m -> {
@@ -151,7 +151,7 @@ public class ConnectorMetricsTest {
           Assertions.assertDoesNotThrow(m::taskStartupSuccessTotal);
         });
 
-    var m5 = ConnectorMetrics.workerRebalanceInfo(MBeanClient.local());
+    var m5 = ConnectorMetrics.workerRebalanceInfo(JndiClient.local());
     Assertions.assertNotEquals(0, m5.size());
     m5.forEach(
         m -> {

--- a/common/src/test/java/org/astraea/common/metrics/platform/HostMetricsTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/platform/HostMetricsTest.java
@@ -19,7 +19,7 @@ package org.astraea.common.metrics.platform;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
@@ -27,7 +27,7 @@ public class HostMetricsTest {
 
   @Test
   void operatingSystem() {
-    var operatingSystemInfo = HostMetrics.operatingSystem(MBeanClient.local());
+    var operatingSystemInfo = HostMetrics.operatingSystem(JndiClient.local());
     assertDoesNotThrow(operatingSystemInfo::arch);
     assertDoesNotThrow(operatingSystemInfo::availableProcessors);
     assertDoesNotThrow(operatingSystemInfo::committedVirtualMemorySize);
@@ -46,20 +46,20 @@ public class HostMetricsTest {
   @Test
   @DisabledOnOs(WINDOWS)
   void maxFileDescriptorCount() {
-    OperatingSystemInfo operatingSystemInfo = HostMetrics.operatingSystem(MBeanClient.local());
+    OperatingSystemInfo operatingSystemInfo = HostMetrics.operatingSystem(JndiClient.local());
     assertDoesNotThrow(operatingSystemInfo::maxFileDescriptorCount);
   }
 
   @Test
   @DisabledOnOs(WINDOWS)
   void openFileDescriptorCount() {
-    OperatingSystemInfo operatingSystemInfo = HostMetrics.operatingSystem(MBeanClient.local());
+    OperatingSystemInfo operatingSystemInfo = HostMetrics.operatingSystem(JndiClient.local());
     assertDoesNotThrow(operatingSystemInfo::openFileDescriptorCount);
   }
 
   @Test
   void testJvmMemory() {
-    JvmMemory jvmMemory = HostMetrics.jvmMemory(MBeanClient.local());
+    JvmMemory jvmMemory = HostMetrics.jvmMemory(JndiClient.local());
     assertDoesNotThrow(() -> jvmMemory.heapMemoryUsage().getCommitted());
     assertDoesNotThrow(() -> jvmMemory.heapMemoryUsage().getMax());
     assertDoesNotThrow(() -> jvmMemory.heapMemoryUsage().getUsed());

--- a/connector/src/test/java/org/astraea/connector/perf/PerfSinkTest.java
+++ b/connector/src/test/java/org/astraea/connector/perf/PerfSinkTest.java
@@ -25,7 +25,7 @@ import org.astraea.common.Utils;
 import org.astraea.common.connector.ConnectorClient;
 import org.astraea.common.connector.ConnectorConfigs;
 import org.astraea.common.consumer.Record;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.connector.ConnectorMetrics;
 import org.astraea.it.Service;
 import org.junit.jupiter.api.AfterAll;
@@ -132,7 +132,7 @@ public class PerfSinkTest {
     Utils.sleep(Duration.ofSeconds(3));
 
     var m0 =
-        ConnectorMetrics.sinkTaskInfo(MBeanClient.local()).stream()
+        ConnectorMetrics.sinkTaskInfo(JndiClient.local()).stream()
             .filter(m -> m.connectorName().equals(name))
             .collect(Collectors.toList());
     Assertions.assertNotEquals(0, m0.size());
@@ -158,7 +158,7 @@ public class PerfSinkTest {
         });
 
     var m1 =
-        ConnectorMetrics.taskError(MBeanClient.local()).stream()
+        ConnectorMetrics.taskError(JndiClient.local()).stream()
             .filter(m -> m.connectorName().equals(name))
             .collect(Collectors.toList());
     Assertions.assertNotEquals(0, m1.size());
@@ -175,7 +175,7 @@ public class PerfSinkTest {
         });
 
     var m2 =
-        ConnectorMetrics.connectorTaskInfo(MBeanClient.local()).stream()
+        ConnectorMetrics.connectorTaskInfo(JndiClient.local()).stream()
             .filter(m -> m.connectorName().equals(name))
             .collect(Collectors.toList());
     Assertions.assertEquals(1, m2.size());
@@ -195,7 +195,7 @@ public class PerfSinkTest {
         });
 
     var m3 =
-        ConnectorMetrics.workerConnectorInfo(MBeanClient.local()).stream()
+        ConnectorMetrics.workerConnectorInfo(JndiClient.local()).stream()
             .filter(m -> m.connectorName().equals(name))
             .collect(Collectors.toList());
     Assertions.assertEquals(1, m3.size());
@@ -211,7 +211,7 @@ public class PerfSinkTest {
         });
 
     var m4 =
-        ConnectorMetrics.connectorInfo(MBeanClient.local()).stream()
+        ConnectorMetrics.connectorInfo(JndiClient.local()).stream()
             .filter(m -> m.connectorName().equals(name))
             .collect(Collectors.toList());
     Assertions.assertEquals(1, m4.size());

--- a/connector/src/test/java/org/astraea/connector/perf/PerfSourceTest.java
+++ b/connector/src/test/java/org/astraea/connector/perf/PerfSourceTest.java
@@ -28,7 +28,7 @@ import org.astraea.common.admin.Replica;
 import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.connector.ConnectorClient;
 import org.astraea.common.connector.ConnectorConfigs;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.connector.ConnectorMetrics;
 import org.astraea.connector.MetadataStorage;
 import org.astraea.connector.SourceConnector;
@@ -241,7 +241,7 @@ public class PerfSourceTest {
     Utils.sleep(Duration.ofSeconds(3));
 
     var m0 =
-        ConnectorMetrics.sourceTaskInfo(MBeanClient.local()).stream()
+        ConnectorMetrics.sourceTaskInfo(JndiClient.local()).stream()
             .filter(m -> m.connectorName().equals(name))
             .collect(Collectors.toList());
     Assertions.assertNotEquals(0, m0.size());
@@ -262,7 +262,7 @@ public class PerfSourceTest {
         });
 
     var m1 =
-        ConnectorMetrics.taskError(MBeanClient.local()).stream()
+        ConnectorMetrics.taskError(JndiClient.local()).stream()
             .filter(m -> m.connectorName().equals(name))
             .collect(Collectors.toList());
     Assertions.assertNotEquals(0, m1.size());
@@ -279,7 +279,7 @@ public class PerfSourceTest {
         });
 
     var m2 =
-        ConnectorMetrics.connectorTaskInfo(MBeanClient.local()).stream()
+        ConnectorMetrics.connectorTaskInfo(JndiClient.local()).stream()
             .filter(m -> m.connectorName().equals(name))
             .collect(Collectors.toList());
     Assertions.assertEquals(1, m2.size());
@@ -299,7 +299,7 @@ public class PerfSourceTest {
         });
 
     var m3 =
-        ConnectorMetrics.workerConnectorInfo(MBeanClient.local()).stream()
+        ConnectorMetrics.workerConnectorInfo(JndiClient.local()).stream()
             .filter(m -> m.connectorName().equals(name))
             .collect(Collectors.toList());
     Assertions.assertEquals(1, m3.size());
@@ -315,7 +315,7 @@ public class PerfSourceTest {
         });
 
     var m4 =
-        ConnectorMetrics.connectorInfo(MBeanClient.local()).stream()
+        ConnectorMetrics.connectorInfo(JndiClient.local()).stream()
             .filter(m -> m.connectorName().equals(name))
             .collect(Collectors.toList());
     Assertions.assertEquals(1, m4.size());

--- a/gui/src/main/java/org/astraea/gui/tab/BrokerNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/BrokerNode.java
@@ -40,7 +40,7 @@ import org.astraea.common.admin.Broker;
 import org.astraea.common.admin.BrokerConfigs;
 import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.TopicPartition;
-import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.broker.ControllerMetrics;
 import org.astraea.common.metrics.broker.HasGauge;
 import org.astraea.common.metrics.broker.HasStatistics;
@@ -196,10 +196,10 @@ public class BrokerNode {
                           }
                         })));
 
-    private final Function<MBeanClient, Map<String, Object>> fetcher;
+    private final Function<JndiClient, Map<String, Object>> fetcher;
     private final String display;
 
-    MetricType(String display, Function<MBeanClient, Map<String, Object>> fetcher) {
+    MetricType(String display, Function<JndiClient, Map<String, Object>> fetcher) {
       this.display = display;
       this.fetcher = fetcher;
     }


### PR DESCRIPTION
metrics 在獨立成另一個服務後，理論上我們的 code base 應該要避免直接使用 jndi，這隻PR先將 jndi 的邏輯從 `MBeanClient`中抽離出來，隨後在適當的時機會將其改成 private (只用於 metrics fetcher)