### PR TITLE
[COMMON] add BeanObjectClient for MetricSensor

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/utils/ClusterInfoSensor.java
+++ b/common/src/main/java/org/astraea/common/cost/utils/ClusterInfoSensor.java
@@ -27,18 +27,18 @@ import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.Replica;
 import org.astraea.common.metrics.ClusterBean;
 import org.astraea.common.metrics.HasBeanObject;
-import org.astraea.common.metrics.MBeanClient;
 import org.astraea.common.metrics.broker.ClusterMetrics;
 import org.astraea.common.metrics.broker.HasGauge;
 import org.astraea.common.metrics.broker.LogMetrics;
 import org.astraea.common.metrics.broker.ServerMetrics;
+import org.astraea.common.metrics.collector.BeanObjectClient;
 import org.astraea.common.metrics.collector.MetricSensor;
 
 /** This MetricSensor attempts to reconstruct a ClusterInfo of the kafka cluster via JMX metrics. */
 public class ClusterInfoSensor implements MetricSensor {
 
   @Override
-  public List<? extends HasBeanObject> fetch(MBeanClient client, ClusterBean bean) {
+  public List<? extends HasBeanObject> fetch(BeanObjectClient client, ClusterBean bean) {
     return Stream.of(
             List.of(ServerMetrics.KafkaServer.CLUSTER_ID.fetch(client)),
             LogMetrics.Log.SIZE.fetch(client),

--- a/common/src/main/java/org/astraea/common/metrics/JndiClient.java
+++ b/common/src/main/java/org/astraea/common/metrics/JndiClient.java
@@ -40,7 +40,6 @@ import org.astraea.common.Utils;
 
 /** A MBeanClient used to retrieve mbean value from remote Jmx server. */
 public interface JndiClient extends MBeanClient, AutoCloseable {
-
   /**
    * @param host the address of jmx server
    * @param port the port of jmx server

--- a/common/src/main/java/org/astraea/common/metrics/MBeanClient.java
+++ b/common/src/main/java/org/astraea/common/metrics/MBeanClient.java
@@ -17,56 +17,11 @@
 package org.astraea.common.metrics;
 
 import java.util.Collection;
-import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import javax.management.ObjectName;
 
 public interface MBeanClient {
-  static MBeanClient of(Collection<BeanObject> objs) {
-    return new MBeanClient() {
-
-      @Override
-      public BeanObject bean(BeanQuery beanQuery) {
-        return beans(beanQuery).stream()
-            .findAny()
-            .orElseThrow(() -> new NoSuchElementException("failed to get metrics from cache"));
-      }
-
-      @Override
-      public Collection<BeanObject> beans(
-          BeanQuery beanQuery, Consumer<RuntimeException> errorHandle) {
-        // The queried domain name (or properties) may contain wildcard. Change wildcard to regular
-        // expression.
-        var wildCardDomain =
-            Pattern.compile(beanQuery.domainName().replaceAll("[*]", ".*").replaceAll("[?]", "."));
-        var wildCardProperties =
-            beanQuery.properties().entrySet().stream()
-                .collect(
-                    Collectors.toUnmodifiableMap(
-                        Map.Entry::getKey,
-                        e ->
-                            Pattern.compile(
-                                e.getValue().replaceAll("[*]", ".*").replaceAll("[?]", "."))));
-        // Filtering out beanObject that match the query
-        return objs.stream()
-            .filter(storedEntry -> wildCardDomain.matcher(storedEntry.domainName()).matches())
-            .filter(
-                storedEntry ->
-                    wildCardProperties.entrySet().stream()
-                        .allMatch(
-                            e ->
-                                storedEntry.properties().containsKey(e.getKey())
-                                    && e.getValue()
-                                        .matcher(storedEntry.properties().get(e.getKey()))
-                                        .matches()))
-            .collect(Collectors.toUnmodifiableList());
-      }
-    };
-  }
 
   /**
    * Fetch all attributes of target mbean.

--- a/common/src/main/java/org/astraea/common/metrics/collector/BeanObjectClient.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/BeanObjectClient.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.metrics.collector;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.astraea.common.metrics.BeanObject;
+import org.astraea.common.metrics.BeanQuery;
+import org.astraea.common.metrics.JndiClient;
+import org.astraea.common.metrics.MBeanClient;
+
+/**
+ * BeanObjectClient is a variety of MBeanClient. It stores all bean objects in memory, so it is able
+ * to offer more useful information to {@link MetricSensor}. Also, this interface is used by {@link
+ * MetricSensor} only, so it is free to enhance this interface without significant breaks.
+ */
+public interface BeanObjectClient extends MBeanClient {
+
+  static BeanObjectClient local(int identity) {
+    try (var client = JndiClient.local()) {
+      return of(identity, client.beans(BeanQuery.all()));
+    }
+  }
+
+  static BeanObjectClient of(int identity, Collection<BeanObject> objs) {
+    return new BeanObjectClient() {
+
+      @Override
+      public int identity() {
+        return identity;
+      }
+
+      @Override
+      public int size() {
+        return objs.size();
+      }
+
+      @Override
+      public BeanObject bean(BeanQuery beanQuery) {
+        return beans(beanQuery).stream()
+            .findAny()
+            .orElseThrow(() -> new NoSuchElementException("failed to get metrics from cache"));
+      }
+
+      @Override
+      public Collection<BeanObject> beans(
+          BeanQuery beanQuery, Consumer<RuntimeException> errorHandle) {
+        // The queried domain name (or properties) may contain wildcard. Change wildcard to regular
+        // expression.
+        var wildCardDomain =
+            Pattern.compile(beanQuery.domainName().replaceAll("[*]", ".*").replaceAll("[?]", "."));
+        var wildCardProperties =
+            beanQuery.properties().entrySet().stream()
+                .collect(
+                    Collectors.toUnmodifiableMap(
+                        Map.Entry::getKey,
+                        e ->
+                            Pattern.compile(
+                                e.getValue().replaceAll("[*]", ".*").replaceAll("[?]", "."))));
+        // Filtering out beanObject that match the query
+        return objs.stream()
+            .filter(storedEntry -> wildCardDomain.matcher(storedEntry.domainName()).matches())
+            .filter(
+                storedEntry ->
+                    wildCardProperties.entrySet().stream()
+                        .allMatch(
+                            e ->
+                                storedEntry.properties().containsKey(e.getKey())
+                                    && e.getValue()
+                                        .matcher(storedEntry.properties().get(e.getKey()))
+                                        .matches()))
+            .collect(Collectors.toUnmodifiableList());
+      }
+    };
+  }
+
+  /**
+   * @return identity of source
+   */
+  int identity();
+
+  /**
+   * @return the number of cached beans
+   */
+  int size();
+}

--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricSensor.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricSensor.java
@@ -23,7 +23,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.astraea.common.metrics.ClusterBean;
 import org.astraea.common.metrics.HasBeanObject;
-import org.astraea.common.metrics.MBeanClient;
 
 @FunctionalInterface
 public interface MetricSensor {
@@ -66,9 +65,9 @@ public interface MetricSensor {
    * fetch metrics from remote/local mbean server. Or the implementation can generate custom metrics
    * according to existent cluster bean
    *
-   * @param client mbean client (don't close it!)
+   * @param client mbean client
    * @param bean current cluster bean
    * @return java metrics
    */
-  Collection<? extends HasBeanObject> fetch(MBeanClient client, ClusterBean bean);
+  Collection<? extends HasBeanObject> fetch(BeanObjectClient client, ClusterBean bean);
 }

--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
@@ -229,7 +229,7 @@ public interface MetricStore extends AutoCloseable {
                 lastSensors = sensorsSupplier.get();
                 allBeans.forEach(
                     (id, bs) -> {
-                      var client = MBeanClient.of(bs);
+                      var client = BeanObjectClient.of(id, bs);
                       var clusterBean = clusterBean();
                       lastSensors.forEach(
                           (sensor, errorHandler) -> {

--- a/common/src/test/java/org/astraea/common/cost/ClusterCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/ClusterCostTest.java
@@ -22,8 +22,8 @@ import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.metrics.ClusterBean;
-import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.broker.ServerMetrics;
+import org.astraea.common.metrics.collector.BeanObjectClient;
 import org.astraea.it.Service;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -63,7 +63,11 @@ class ClusterCostTest {
     var mergeCost = HasClusterCost.of(Map.of(cost1, 1.0, cost2, 1.0));
     var metrics =
         mergeCost.metricSensor().stream()
-            .map(x -> x.fetch(JndiClient.of(SERVICE.jmxServiceURL()), ClusterBean.EMPTY))
+            .map(
+                x ->
+                    x.fetch(
+                        BeanObjectClient.local(SERVICE.dataFolders().keySet().iterator().next()),
+                        ClusterBean.EMPTY))
             .collect(Collectors.toSet());
     Assertions.assertTrue(
         metrics.iterator().next().stream()

--- a/common/src/test/java/org/astraea/common/cost/MoveCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/MoveCostTest.java
@@ -22,8 +22,8 @@ import java.util.stream.Collectors;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.metrics.ClusterBean;
-import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.broker.ServerMetrics;
+import org.astraea.common.metrics.collector.BeanObjectClient;
 import org.astraea.common.metrics.collector.MetricSensor;
 import org.astraea.it.Service;
 import org.junit.jupiter.api.AfterAll;
@@ -49,7 +49,11 @@ public class MoveCostTest {
     var mergeCost = HasMoveCost.of(List.of(cost1, cost2));
     var metrics =
         mergeCost.metricSensor().stream()
-            .map(x -> x.fetch(JndiClient.of(SERVICE.jmxServiceURL()), ClusterBean.EMPTY))
+            .map(
+                x ->
+                    x.fetch(
+                        BeanObjectClient.local(SERVICE.dataFolders().keySet().iterator().next()),
+                        ClusterBean.EMPTY))
             .collect(Collectors.toSet());
     Assertions.assertEquals(3, metrics.iterator().next().size());
     Assertions.assertTrue(

--- a/common/src/test/java/org/astraea/common/cost/NodeLatencyCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NodeLatencyCostTest.java
@@ -29,6 +29,7 @@ import org.astraea.common.metrics.HasBeanObject;
 import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.client.HasNodeMetrics;
 import org.astraea.common.metrics.client.producer.ProducerMetrics;
+import org.astraea.common.metrics.collector.BeanObjectClient;
 import org.astraea.common.producer.Producer;
 import org.astraea.common.producer.Record;
 import org.astraea.it.Service;
@@ -102,7 +103,7 @@ public class NodeLatencyCostTest {
   @Test
   void testSensor() {
     var function = new NodeLatencyCost();
-    var client = Mockito.mock(JndiClient.class);
+    var client = Mockito.mock(BeanObjectClient.class);
     Mockito.when(client.beans(Mockito.any()))
         .thenReturn(
             List.of(

--- a/common/src/test/java/org/astraea/common/cost/NodeThroughputCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/NodeThroughputCostTest.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.metrics.BeanObject;
 import org.astraea.common.metrics.ClusterBean;
-import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.client.HasNodeMetrics;
+import org.astraea.common.metrics.collector.BeanObjectClient;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -76,7 +76,7 @@ public class NodeThroughputCostTest {
     var throughputCost = new NodeThroughputCost();
     var sensor = throughputCost.metricSensor().get();
     var bean = new BeanObject("aaa", Map.of("node-id", "node-1"), Map.of());
-    var client = Mockito.mock(JndiClient.class);
+    var client = Mockito.mock(BeanObjectClient.class);
     Mockito.when(client.beans(Mockito.any())).thenReturn(List.of(bean));
     var result = sensor.fetch(client, ClusterBean.EMPTY);
     Assertions.assertEquals(1, result.size());

--- a/common/src/test/java/org/astraea/common/metrics/MetricsTestUtils.java
+++ b/common/src/test/java/org/astraea/common/metrics/MetricsTestUtils.java
@@ -29,6 +29,7 @@ import org.astraea.common.metrics.broker.HasPercentiles;
 import org.astraea.common.metrics.broker.HasRate;
 import org.astraea.common.metrics.broker.HasStatistics;
 import org.astraea.common.metrics.broker.HasTimer;
+import org.astraea.common.metrics.collector.BeanObjectClient;
 import org.astraea.common.metrics.collector.MetricSensor;
 import org.junit.jupiter.api.Assertions;
 
@@ -51,7 +52,8 @@ public final class MetricsTestUtils {
                     Map.Entry::getKey,
                     entry ->
                         sensor.fetch(
-                            MBeanClient.of(entry.getValue().beans(BeanQuery.all())),
+                            BeanObjectClient.of(
+                                entry.getKey(), entry.getValue().beans(BeanQuery.all())),
                             ClusterBean.EMPTY))));
   }
 

--- a/common/src/test/java/org/astraea/common/metrics/collector/MetricSensorTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/collector/MetricSensorTest.java
@@ -21,7 +21,6 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.astraea.common.metrics.ClusterBean;
 import org.astraea.common.metrics.HasBeanObject;
-import org.astraea.common.metrics.JndiClient;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -37,7 +36,7 @@ public class MetricSensorTest {
 
     var sensor = MetricSensor.of(List.of(metricSensor0, metricSensor1)).get();
 
-    var result = sensor.fetch(Mockito.mock(JndiClient.class), ClusterBean.EMPTY);
+    var result = sensor.fetch(Mockito.mock(BeanObjectClient.class), ClusterBean.EMPTY);
 
     Assertions.assertEquals(2, result.size());
     Assertions.assertTrue(result.contains(mbean0));
@@ -68,7 +67,7 @@ public class MetricSensorTest {
             .get();
     Assertions.assertThrows(
         RuntimeException.class,
-        () -> sensor.fetch(Mockito.mock(JndiClient.class), ClusterBean.EMPTY));
+        () -> sensor.fetch(Mockito.mock(BeanObjectClient.class), ClusterBean.EMPTY));
   }
 
   @Test
@@ -86,15 +85,15 @@ public class MetricSensorTest {
 
     var sensor = MetricSensor.of(List.of(metricSensor0, metricSensor1)).get();
     Assertions.assertDoesNotThrow(
-        () -> sensor.fetch(Mockito.mock(JndiClient.class), ClusterBean.EMPTY));
+        () -> sensor.fetch(Mockito.mock(BeanObjectClient.class), ClusterBean.EMPTY));
     Assertions.assertEquals(
-        1, sensor.fetch(Mockito.mock(JndiClient.class), ClusterBean.EMPTY).size());
+        1, sensor.fetch(Mockito.mock(BeanObjectClient.class), ClusterBean.EMPTY).size());
 
     Assertions.assertDoesNotThrow(
         () ->
             MetricSensor.of(List.of(metricSensor0, metricSensor2))
                 .get()
-                .fetch(Mockito.mock(JndiClient.class), ClusterBean.EMPTY));
+                .fetch(Mockito.mock(BeanObjectClient.class), ClusterBean.EMPTY));
     Assertions.assertThrows(
         NoSuchElementException.class,
         () ->
@@ -104,6 +103,6 @@ public class MetricSensorTest {
                       if (e instanceof NoSuchElementException) throw new NoSuchElementException();
                     })
                 .get()
-                .fetch(Mockito.mock(JndiClient.class), ClusterBean.EMPTY));
+                .fetch(Mockito.mock(BeanObjectClient.class), ClusterBean.EMPTY));
   }
 }


### PR DESCRIPTION
新增一個介面`BeanObjectClient`來將`MetricSensor`使用的介面與通用的`MBeanClient`做出區隔，這樣之後要增加更多方法都不用擔心會破壞通用的`MBeanClient`