### PR TITLE
[TEST] Fix flaky BalancerHandlerTest#testMoveCost

### DIFF
--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -104,6 +104,7 @@ public class BalancerHandlerTest {
   @AfterAll
   static void closeService() {
     SERVICE.close();
+    SERVICE2.close();
   }
 
   static final String TIMEOUT_KEY = "timeout";


### PR DESCRIPTION
修正`BalancerHandlerTest#testMoveCost` 的flaky test，主要問題為SERVICE並行執行，moveCost在計算leader數量時會受影響，因此將其測試改為獨立使用一個SERVICE