### PR TITLE
[ASSIGNOR] Remove redundant code

### DIFF
--- a/common/src/main/java/org/astraea/common/assignor/Assignor.java
+++ b/common/src/main/java/org/astraea/common/assignor/Assignor.java
@@ -33,7 +33,6 @@ import org.astraea.common.Configuration;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.admin.ClusterInfo;
-import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.consumer.ConsumerConfigs;
 import org.astraea.common.cost.HasPartitionCost;
@@ -80,18 +79,6 @@ public abstract class Assignor implements ConsumerPartitionAssignor, Configurabl
   protected void configure(Configuration config) {}
 
   // -----------------------[helper]-----------------------//
-
-  /**
-   * check the nodes which wasn't register yet.
-   *
-   * @param nodes List of node information
-   * @return Map from each broker id to broker host
-   */
-  protected Map<Integer, String> checkUnregister(List<NodeInfo> nodes) {
-    return nodes.stream()
-        .filter(i -> (metricStore == null || !metricStore.identities().contains(i.id())))
-        .collect(Collectors.toMap(NodeInfo::id, NodeInfo::host));
-  }
 
   /**
    * update cluster information

--- a/common/src/test/java/org/astraea/common/assignor/AssignorTest.java
+++ b/common/src/test/java/org/astraea/common/assignor/AssignorTest.java
@@ -18,16 +18,12 @@ package org.astraea.common.assignor;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
 import org.apache.kafka.common.TopicPartition;
-import org.astraea.common.Utils;
-import org.astraea.common.admin.NodeInfo;
 import org.astraea.common.consumer.ConsumerConfigs;
 import org.astraea.it.Service;
 import org.junit.jupiter.api.Assertions;
@@ -123,58 +119,5 @@ public class AssignorTest {
 
   private static ByteBuffer convert(String value) {
     return ByteBuffer.wrap(value.getBytes(StandardCharsets.UTF_8));
-  }
-
-  @Test
-  void testUnregisterId() {
-    var assignor = new RandomAssignor();
-    assignor.configure(
-        Map.of(
-            "broker.1000.jmx.port",
-            "8000",
-            "broker.1001.jmx.port",
-            "8100",
-            "jmx.port",
-            SERVICE.jmxServiceURL().getPort(),
-            ConsumerConfigs.BOOTSTRAP_SERVERS_CONFIG,
-            SERVICE.bootstrapServers()));
-    var nodes =
-        List.of(
-            NodeInfo.of(1000, "192.168.103.1", 8000),
-            NodeInfo.of(1001, "192.168.103.2", 8100),
-            NodeInfo.of(-1, "local jmx", 0));
-    Utils.sleep(Duration.ofSeconds(3));
-    var unregister = assignor.checkUnregister(nodes);
-    Assertions.assertEquals(2, unregister.size());
-    Assertions.assertEquals("192.168.103.1", unregister.get(1000));
-    Assertions.assertEquals("192.168.103.2", unregister.get(1001));
-  }
-
-  @Test
-  void testAddNode() {
-    var assignor = new RandomAssignor();
-    // Get broker id
-    var brokerId = SERVICE.dataFolders().keySet().stream().findAny().get();
-    var jmxAddr = SERVICE.jmxServiceURL().getHost();
-    var jmxPort = SERVICE.jmxServiceURL().getPort();
-    assignor.configure(
-        Map.of(
-            "broker." + brokerId + ".jmx.port",
-            jmxPort,
-            ConsumerConfigs.BOOTSTRAP_SERVERS_CONFIG,
-            SERVICE.bootstrapServers()));
-
-    var nodes = new ArrayList<NodeInfo>();
-    nodes.add(NodeInfo.of(brokerId, jmxAddr, jmxPort));
-    Utils.sleep(Duration.ofSeconds(3));
-    var unregisterNode = assignor.checkUnregister(nodes);
-    Assertions.assertEquals(0, unregisterNode.size());
-
-    // after add a new node, assignor check unregister node
-
-    nodes.add(NodeInfo.of(1001, "192.168.103.2", 8000));
-    unregisterNode = assignor.checkUnregister(nodes);
-    Assertions.assertEquals(1, unregisterNode.size());
-    Assertions.assertEquals("192.168.103.2", unregisterNode.get(1001));
   }
 }


### PR DESCRIPTION
在執行 https://github.com/skiptests/astraea/pull/1705#issue-1699051646 時，發現有未被使用的方法 `checkUnregister`

因為使用 `MetricStore`、`分配完釋放資源` 後，就不需要去檢查未註冊的節點了。現在 assignor 分配前會用 admin 取得、註冊當下叢集所有的節點，所以 `checkUnregister` 已經用不到了，故移除