### PR TITLE
[BALANCER] Remove constraint predicates from `AlgorithmConfig`

### DIFF
--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -259,7 +259,6 @@ public class BalancerHandlerTest {
                       .clusterBean(ClusterBean.EMPTY)
                       .timeout(Duration.ofSeconds(3))
                       .clusterCost(clusterCostFunction)
-                      .clusterConstraint((before, after) -> after.value() <= before.value())
                       .moveCost(moveCostFunction)
                       .build());
       Assertions.assertNotEquals(Optional.empty(), Best);
@@ -275,7 +274,6 @@ public class BalancerHandlerTest {
                           .clusterBean(ClusterBean.EMPTY)
                           .timeout(Duration.ofSeconds(3))
                           .clusterCost(clusterCostFunction)
-                          .clusterConstraint((before, after) -> true)
                           .config("iteration", "0")
                           .moveCost(moveCostFunction)
                           .build()));
@@ -294,7 +292,6 @@ public class BalancerHandlerTest {
                       .clusterBean(ClusterBean.EMPTY)
                       .timeout(Duration.ofSeconds(3))
                       .clusterCost(clusterCostFunction)
-                      .clusterConstraint((before, after) -> false)
                       .moveCost(moveCostFunction)
                       .build()));
 
@@ -308,7 +305,6 @@ public class BalancerHandlerTest {
                       .clusterBean(ClusterBean.EMPTY)
                       .timeout(Duration.ofSeconds(3))
                       .clusterCost(clusterCostFunction)
-                      .clusterConstraint((before, after) -> true)
                       .moveCost(failMoveCostFunction)
                       .build()));
     }

--- a/common/src/main/java/org/astraea/common/balancer/algorithms/GreedyBalancer.java
+++ b/common/src/main/java/org/astraea/common/balancer/algorithms/GreedyBalancer.java
@@ -173,11 +173,9 @@ public class GreedyBalancer implements Balancer {
                 .takeWhile(ignored -> moreRoom.get())
                 .filter(
                     newAllocation ->
-                        config
-                            .movementConstraint()
-                            .test(
-                                moveCostFunction.moveCost(
-                                    currentClusterInfo, newAllocation, clusterBean)))
+                        !moveCostFunction
+                            .moveCost(currentClusterInfo, newAllocation, clusterBean)
+                            .overflow())
                 .map(
                     newAllocation ->
                         new Plan(
@@ -185,9 +183,7 @@ public class GreedyBalancer implements Balancer {
                             initialCost,
                             newAllocation,
                             clusterCostFunction.clusterCost(newAllocation, clusterBean)))
-                .filter(
-                    plan ->
-                        config.clusterConstraint().test(currentCost, plan.proposalClusterCost()))
+                .filter(plan -> plan.proposalClusterCost().value() < currentCost.value())
                 .findFirst();
     var currentCost = initialCost;
     var currentAllocation = currentClusterInfo;

--- a/common/src/test/java/org/astraea/common/balancer/algorithms/AlgorithmConfigTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/algorithms/AlgorithmConfigTest.java
@@ -39,7 +39,6 @@ public class AlgorithmConfigTest {
     Assertions.assertSame(config0.executionId(), config1.executionId());
     Assertions.assertSame(config0.clusterCostFunction(), config1.clusterCostFunction());
     Assertions.assertSame(config0.moveCostFunction(), config1.moveCostFunction());
-    Assertions.assertSame(config0.clusterConstraint(), config1.clusterConstraint());
     Assertions.assertEquals(config0.balancerConfig().raw(), config1.balancerConfig().raw());
     Assertions.assertSame(config0.clusterInfo(), config1.clusterInfo());
     Assertions.assertSame(config0.clusterBean(), config1.clusterBean());


### PR DESCRIPTION
這個 PR 移除 `AlgorithmConfig#clusterConstraint` 和 `AlgorithmConfig#movementConstraint`。

這兩個函數原本是要用來描述對得到的解的期望，但 Balancer 經過長期的發展後，這兩個欄位的目的依舊是很直覺單純的

* ClusterCost 要更好。
* MoveCost 不要違反。

實際上對於解的期望的部分，現在的做法是

* ClsuterCost 怎樣算好依內部的實作細節而定，至於多個 Cost 的處置是根據 weight 壓成一個數字做比較。
* MoveCost 如何被視為違反，這些規則現在是從建構子得到的 Configuration 去衡量。

原先的目標(解的期望)已經被其他機制所取代，所以現在繼續保留這兩個很基本的規則，於一個可以變動但實際上我們不會去變動的 Predicate 不太合理，因此這個 PR 把他們兩個移除。