### PR TITLE
[METRICS] Fix flacky testBeanExpiration

### DIFF
--- a/common/src/test/java/org/astraea/common/metrics/collector/MetricStoreTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/collector/MetricStoreTest.java
@@ -83,7 +83,7 @@ public class MetricStoreTest {
             .beanExpiration(Duration.ofSeconds(5))
             .build()) {
       Utils.waitFor(() -> store.clusterBean().all().size() == 3);
-      Utils.sleep(Duration.ofSeconds(5));
+      Utils.sleep(Duration.ofSeconds(10));
       Assertions.assertNotEquals(0, count.get());
       Assertions.assertEquals(0, store.clusterBean().all().size());
     }


### PR DESCRIPTION
`MetricStore` 的清理 thread 是每 n 秒檢查一次，若 bean 已存在超過 n 秒，就會移除。但是這並不代表 n 秒前收集到的 bean 會馬上被移除。因為我們檢查的時候，可能已經離上次移除有段時間了。但我們可以確定的是 2*n 秒前收集的 bean 一定會被移除，所以這裡把等待時間改成 5*2 = 10 秒。

![File](https://github.com/skiptests/astraea/assets/26920893/096cff08-f5e2-457d-9a58-f8c7bd35c170)
