### PR TITLE
[METRICS] Add receiver to metricStore

### DIFF
--- a/app/src/main/java/org/astraea/app/web/WebService.java
+++ b/app/src/main/java/org/astraea/app/web/WebService.java
@@ -67,7 +67,7 @@ public class WebService implements AutoCloseable {
     var metricStore =
         MetricStore.builder()
             .beanExpiration(beanExpiration)
-            .localReceiver(clientSupplier)
+            .addLocalReceiver(clientSupplier)
             .sensorsSupplier(
                 () ->
                     sensors.metricSensors().stream()

--- a/app/src/main/java/org/astraea/app/web/WebService.java
+++ b/app/src/main/java/org/astraea/app/web/WebService.java
@@ -22,6 +22,7 @@ import com.sun.net.httpserver.HttpServer;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -67,7 +68,7 @@ public class WebService implements AutoCloseable {
     var metricStore =
         MetricStore.builder()
             .beanExpiration(beanExpiration)
-            .addLocalReceiver(clientSupplier)
+            .receivers(List.of(MetricStore.Receiver.local(clientSupplier)))
             .sensorsSupplier(
                 () ->
                     sensors.metricSensors().stream()

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -1362,7 +1362,7 @@ public class BalancerHandlerTest {
     var metricSensors = cf.stream().map(CostFunction::metricSensor).toList();
     return MetricStore.builder()
         .beanExpiration(Duration.ofMinutes(2))
-        .addLocalReceiver(clientSupplier)
+        .receivers(List.of(MetricStore.Receiver.local(clientSupplier)))
         .sensorsSupplier(
             () ->
                 metricSensors.stream()

--- a/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/BalancerHandlerTest.java
@@ -1362,7 +1362,7 @@ public class BalancerHandlerTest {
     var metricSensors = cf.stream().map(CostFunction::metricSensor).toList();
     return MetricStore.builder()
         .beanExpiration(Duration.ofMinutes(2))
-        .localReceiver(clientSupplier)
+        .addLocalReceiver(clientSupplier)
         .sensorsSupplier(
             () ->
                 metricSensors.stream()

--- a/common/src/main/java/org/astraea/common/Utils.java
+++ b/common/src/main/java/org/astraea/common/Utils.java
@@ -490,5 +490,9 @@ public final class Utils {
     return FixedIterable.of(items.size(), iter);
   }
 
+  public static <V extends Collection<?>> boolean isBlank(V collection) {
+    return collection == null || collection.isEmpty();
+  }
+
   private Utils() {}
 }

--- a/common/src/main/java/org/astraea/common/Utils.java
+++ b/common/src/main/java/org/astraea/common/Utils.java
@@ -490,8 +490,11 @@ public final class Utils {
     return FixedIterable.of(items.size(), iter);
   }
 
-  public static <V extends Collection<?>> boolean isBlank(V collection) {
-    return collection == null || collection.isEmpty();
+  public static <V extends Collection<?>> V requireNonEmpty(V collection, String message) {
+    if (collection == null || collection.isEmpty()) {
+      throw new IllegalArgumentException(message);
+    }
+    return collection;
   }
 
   private Utils() {}

--- a/common/src/main/java/org/astraea/common/Utils.java
+++ b/common/src/main/java/org/astraea/common/Utils.java
@@ -491,9 +491,7 @@ public final class Utils {
   }
 
   public static <V extends Collection<?>> V requireNonEmpty(V collection, String message) {
-    if (collection == null || collection.isEmpty()) {
-      throw new IllegalArgumentException(message);
-    }
+    if (collection == null || collection.isEmpty()) throw new IllegalArgumentException(message);
     return collection;
   }
 

--- a/common/src/main/java/org/astraea/common/assignor/Assignor.java
+++ b/common/src/main/java/org/astraea/common/assignor/Assignor.java
@@ -116,7 +116,7 @@ public abstract class Assignor implements ConsumerPartitionAssignor, Configurabl
                     });
     metricStore =
         MetricStore.builder()
-            .addLocalReceiver(clientSupplier)
+            .receivers(List.of(MetricStore.Receiver.local(clientSupplier)))
             .sensorsSupplier(() -> Map.of(this.costFunction.metricSensor(), (integer, e) -> {}))
             .build();
   }

--- a/common/src/main/java/org/astraea/common/assignor/Assignor.java
+++ b/common/src/main/java/org/astraea/common/assignor/Assignor.java
@@ -116,7 +116,7 @@ public abstract class Assignor implements ConsumerPartitionAssignor, Configurabl
                     });
     metricStore =
         MetricStore.builder()
-            .localReceiver(clientSupplier)
+            .addLocalReceiver(clientSupplier)
             .sensorsSupplier(() -> Map.of(this.costFunction.metricSensor(), (integer, e) -> {}))
             .build();
   }

--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
@@ -170,10 +170,9 @@ public interface MetricStore extends AutoCloseable {
     }
 
     public MetricStore build() {
-      if (Utils.isBlank(receivers)) throw new IllegalArgumentException("receivers can't be empty");
       return new MetricStoreImpl(
           Objects.requireNonNull(sensorsSupplier, "sensorsSupplier can't be null"),
-          receivers,
+          Utils.requireNonEmpty(receivers, "receivers can't be empty"),
           Objects.requireNonNull(beanExpiration, "beanExpiration can't be null"));
     }
   }

--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
@@ -170,6 +170,8 @@ public interface MetricStore extends AutoCloseable {
     }
 
     public MetricStore build() {
+      if (Objects.requireNonNull(receivers, "receivers can't be null").isEmpty())
+        throw new IllegalArgumentException("receivers can't be empty");
       return new MetricStoreImpl(
           Objects.requireNonNull(sensorsSupplier, "sensorsSupplier can't be null"),
           Objects.requireNonNull(receivers, "receivers can't be null"),

--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
@@ -170,11 +170,10 @@ public interface MetricStore extends AutoCloseable {
     }
 
     public MetricStore build() {
-      if (Objects.requireNonNull(receivers, "receivers can't be null").isEmpty())
-        throw new IllegalArgumentException("receivers can't be empty");
+      if (Utils.isBlank(receivers)) throw new IllegalArgumentException("receivers can't be empty");
       return new MetricStoreImpl(
           Objects.requireNonNull(sensorsSupplier, "sensorsSupplier can't be null"),
-          Objects.requireNonNull(receivers, "receivers can't be null"),
+          receivers,
           Objects.requireNonNull(beanExpiration, "beanExpiration can't be null"));
     }
   }

--- a/common/src/main/java/org/astraea/common/partitioner/SmoothWeightRoundRobinPartitioner.java
+++ b/common/src/main/java/org/astraea/common/partitioner/SmoothWeightRoundRobinPartitioner.java
@@ -136,7 +136,7 @@ public class SmoothWeightRoundRobinPartitioner extends Partitioner {
 
     metricStore =
         MetricStore.builder()
-            .localReceiver(clientSupplier)
+            .addLocalReceiver(clientSupplier)
             .sensorsSupplier(
                 () -> Map.of(this.neutralIntegratedCost.metricSensor(), (integer, e) -> {}))
             .build();

--- a/common/src/main/java/org/astraea/common/partitioner/SmoothWeightRoundRobinPartitioner.java
+++ b/common/src/main/java/org/astraea/common/partitioner/SmoothWeightRoundRobinPartitioner.java
@@ -19,6 +19,7 @@ package org.astraea.common.partitioner;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -136,7 +137,7 @@ public class SmoothWeightRoundRobinPartitioner extends Partitioner {
 
     metricStore =
         MetricStore.builder()
-            .addLocalReceiver(clientSupplier)
+            .receivers(List.of(MetricStore.Receiver.local(clientSupplier)))
             .sensorsSupplier(
                 () -> Map.of(this.neutralIntegratedCost.metricSensor(), (integer, e) -> {}))
             .build();

--- a/common/src/main/java/org/astraea/common/partitioner/StrictCostPartitioner.java
+++ b/common/src/main/java/org/astraea/common/partitioner/StrictCostPartitioner.java
@@ -157,7 +157,7 @@ public class StrictCostPartitioner extends Partitioner {
 
     metricStore =
         MetricStore.builder()
-            .localReceiver(clientSupplier)
+            .addLocalReceiver(clientSupplier)
             .sensorsSupplier(() -> Map.of(this.costFunction.metricSensor(), (integer, e) -> {}))
             .build();
     this.roundRobinKeeper = RoundRobinKeeper.of(ROUND_ROBIN_LENGTH, roundRobinLease);

--- a/common/src/main/java/org/astraea/common/partitioner/StrictCostPartitioner.java
+++ b/common/src/main/java/org/astraea/common/partitioner/StrictCostPartitioner.java
@@ -19,6 +19,7 @@ package org.astraea.common.partitioner;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -157,7 +158,7 @@ public class StrictCostPartitioner extends Partitioner {
 
     metricStore =
         MetricStore.builder()
-            .addLocalReceiver(clientSupplier)
+            .receivers(List.of(MetricStore.Receiver.local(clientSupplier)))
             .sensorsSupplier(() -> Map.of(this.costFunction.metricSensor(), (integer, e) -> {}))
             .build();
     this.roundRobinKeeper = RoundRobinKeeper.of(ROUND_ROBIN_LENGTH, roundRobinLease);

--- a/common/src/test/java/org/astraea/common/UtilsTest.java
+++ b/common/src/test/java/org/astraea/common/UtilsTest.java
@@ -357,4 +357,11 @@ public class UtilsTest {
     Assertions.assertDoesNotThrow(() -> Utils.close(obj));
     Assertions.assertEquals(1, count.get());
   }
+
+  @Test
+  void testRequireNonEmpty() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> Utils.requireNonEmpty(Set.of(), ""));
+    Assertions.assertDoesNotThrow(() -> Utils.requireNonEmpty(List.of(1), ""));
+  }
 }

--- a/common/src/test/java/org/astraea/common/metrics/collector/LocalMetricsTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/collector/LocalMetricsTest.java
@@ -42,7 +42,8 @@ public class LocalMetricsTest {
     try (var store =
         MetricStore.builder()
             .beanExpiration(Duration.ofSeconds(1))
-            .localReceiver(() -> CompletableFuture.completedStage(Map.of(-1, JndiClient.local())))
+            .addLocalReceiver(
+                () -> CompletableFuture.completedStage(Map.of(-1, JndiClient.local())))
             .build()) {
       Utils.sleep(Duration.ofSeconds(3));
       Assertions.assertNotEquals(0, store.clusterBean().all().size());

--- a/common/src/test/java/org/astraea/common/metrics/collector/LocalMetricsTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/collector/LocalMetricsTest.java
@@ -18,6 +18,7 @@ package org.astraea.common.metrics.collector;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.astraea.common.Utils;
@@ -42,8 +43,10 @@ public class LocalMetricsTest {
     try (var store =
         MetricStore.builder()
             .beanExpiration(Duration.ofSeconds(1))
-            .addLocalReceiver(
-                () -> CompletableFuture.completedStage(Map.of(-1, JndiClient.local())))
+            .receivers(
+                List.of(
+                    MetricStore.Receiver.local(
+                        () -> CompletableFuture.completedStage(Map.of(-1, JndiClient.local())))))
             .build()) {
       Utils.sleep(Duration.ofSeconds(3));
       Assertions.assertNotEquals(0, store.clusterBean().all().size());

--- a/common/src/test/java/org/astraea/common/metrics/collector/MetricStoreTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/collector/MetricStoreTest.java
@@ -60,6 +60,10 @@ public class MetricStoreTest {
     // Receiver not set
     var builder = MetricStore.builder();
     Assertions.assertThrows(NullPointerException.class, builder::build);
+    // Receiver set to empty
+    builder.receivers(List.of());
+    Assertions.assertThrows(IllegalArgumentException.class, builder::build);
+
     builder.receivers(List.of(timeout -> Map.of()));
     var store = builder.build();
     store.close();

--- a/common/src/test/java/org/astraea/common/metrics/collector/MetricStoreTest.java
+++ b/common/src/test/java/org/astraea/common/metrics/collector/MetricStoreTest.java
@@ -59,7 +59,7 @@ public class MetricStoreTest {
   void testNullCheck() {
     // Receiver not set
     var builder = MetricStore.builder();
-    Assertions.assertThrows(NullPointerException.class, builder::build);
+    Assertions.assertThrows(IllegalArgumentException.class, builder::build);
     // Receiver set to empty
     builder.receivers(List.of());
     Assertions.assertThrows(IllegalArgumentException.class, builder::build);


### PR DESCRIPTION
related to #1718 

這隻 PR 是 #1718 提出的實做，重構 `MetricStore::Builder` 的 `receiver` 方法，原來的方法是指定 `MetricStore` 要使用哪一個 `Receiver`，這隻 PR 改成新增一個 `Receiver` 給 `MetricStore` 管理，因為 #1718 需要不同的 metric 來源端，所以做此重構。