### PR TITLE
[BALANCER] Implementation of `BalancerProblemFormat`

### DIFF
--- a/app/src/main/java/org/astraea/app/web/BalancerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BalancerHandler.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -39,11 +38,9 @@ import org.astraea.common.admin.Replica;
 import org.astraea.common.balancer.AlgorithmConfig;
 import org.astraea.common.balancer.Balancer;
 import org.astraea.common.balancer.BalancerConsole;
-import org.astraea.common.balancer.algorithms.GreedyBalancer;
+import org.astraea.common.balancer.BalancerProblemFormat;
 import org.astraea.common.balancer.executor.RebalancePlanExecutor;
 import org.astraea.common.balancer.executor.StraightPlanExecutor;
-import org.astraea.common.cost.HasClusterCost;
-import org.astraea.common.cost.HasMoveCost;
 import org.astraea.common.cost.MigrationCost;
 import org.astraea.common.json.TypeRef;
 import org.astraea.common.metrics.collector.MetricStore;
@@ -220,52 +217,11 @@ class BalancerHandler implements Handler, AutoCloseable {
     return new PostRequestWrapper(
         balancerPostRequest.balancer,
         Configuration.of(balancerPostRequest.balancerConfig),
-        AlgorithmConfig.builder()
-            .clusterCost(balancerPostRequest.clusterCost())
-            .moveCost(balancerPostRequest.moveCost())
-            .timeout(balancerPostRequest.timeout)
-            .configs(balancerPostRequest.balancerConfig)
-            .build(),
+        balancerPostRequest.parse(),
         currentClusterInfo);
   }
 
-  static class BalancerPostRequest implements Request {
-
-    String balancer = GreedyBalancer.class.getName();
-    Map<String, String> balancerConfig = Map.of();
-    Map<String, String> costConfig = Map.of();
-    Duration timeout = Duration.ofSeconds(3);
-    List<CostWeight> clusterCosts = List.of();
-    Set<String> moveCosts =
-        Set.of(
-            "org.astraea.common.cost.ReplicaLeaderCost",
-            "org.astraea.common.cost.RecordSizeCost",
-            "org.astraea.common.cost.ReplicaNumberCost",
-            "org.astraea.common.cost.ReplicaLeaderSizeCost");
-
-    HasClusterCost clusterCost() {
-      if (clusterCosts.isEmpty())
-        throw new IllegalArgumentException("clusterCosts is not specified");
-      var config = Configuration.of(costConfig);
-      return HasClusterCost.of(
-          Utils.costFunctions(
-              clusterCosts.stream()
-                  .collect(Collectors.toMap(e -> e.cost, e -> String.valueOf(e.weight))),
-              HasClusterCost.class,
-              config));
-    }
-
-    HasMoveCost moveCost() {
-      var config = Configuration.of(costConfig);
-      var cf = Utils.costFunctions(moveCosts, HasMoveCost.class, config);
-      return HasMoveCost.of(cf);
-    }
-  }
-
-  static class CostWeight implements Request {
-    String cost;
-    double weight = 1.D;
-  }
+  static class BalancerPostRequest extends BalancerProblemFormat implements Request {}
 
   static class BalancerPutRequest implements Request {
     String id;

--- a/common/src/main/java/org/astraea/common/balancer/BalancerProblemFormat.java
+++ b/common/src/main/java/org/astraea/common/balancer/BalancerProblemFormat.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.balancer;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.astraea.common.Configuration;
+import org.astraea.common.Utils;
+import org.astraea.common.balancer.algorithms.GreedyBalancer;
+import org.astraea.common.cost.HasClusterCost;
+import org.astraea.common.cost.HasMoveCost;
+
+/** A data class represents the skeleton for a balancer problem. */
+public class BalancerProblemFormat {
+
+  public String balancer = GreedyBalancer.class.getName();
+  public Map<String, String> balancerConfig = Map.of();
+  public Map<String, String> costConfig = Map.of();
+  public Duration timeout = Duration.ofSeconds(3);
+  public List<CostWeight> clusterCosts = List.of();
+  public Set<String> moveCosts =
+      Set.of(
+          "org.astraea.common.cost.ReplicaLeaderCost",
+          "org.astraea.common.cost.RecordSizeCost",
+          "org.astraea.common.cost.ReplicaNumberCost",
+          "org.astraea.common.cost.ReplicaLeaderSizeCost");
+
+  public AlgorithmConfig parse() {
+    return AlgorithmConfig.builder()
+        .timeout(timeout)
+        .configs(balancerConfig)
+        .clusterCost(clusterCost())
+        .moveCost(moveCost())
+        .build();
+  }
+
+  private HasClusterCost clusterCost() {
+    if (clusterCosts.isEmpty()) throw new IllegalArgumentException("clusterCosts is not specified");
+    var config = Configuration.of(costConfig);
+    return HasClusterCost.of(
+        Utils.costFunctions(
+            clusterCosts.stream()
+                .collect(Collectors.toMap(e -> e.cost, e -> String.valueOf(e.weight))),
+            HasClusterCost.class,
+            config));
+  }
+
+  private HasMoveCost moveCost() {
+    var config = Configuration.of(costConfig);
+    var cf = Utils.costFunctions(moveCosts, HasMoveCost.class, config);
+    return HasMoveCost.of(cf);
+  }
+
+  public static class CostWeight {
+    public String cost;
+    public double weight = 1.0;
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      CostWeight that = (CostWeight) o;
+      return Double.compare(that.weight, weight) == 0 && Objects.equals(cost, that.cost);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(cost, weight);
+    }
+  }
+}

--- a/common/src/test/java/org/astraea/common/balancer/BalancerProblemFormatTest.java
+++ b/common/src/test/java/org/astraea/common/balancer/BalancerProblemFormatTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.balancer;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.astraea.common.json.JsonConverter;
+import org.astraea.common.json.TypeRef;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class BalancerProblemFormatTest {
+
+  @Test
+  void testSerializationFromJson() {
+    var payload =
+        """
+        {
+          "timeout": "5s",
+          "balancer": "org.astraea.common.balancer.algorithms.GreedyBalancer",
+          "balancerConfig": {
+            "shuffle.tweaker.min.step": "1",
+            "shuffle.tweaker.max.step": "10"
+          },
+          "clusterCosts": [
+            { "cost": "org.astraea.common.cost.ReplicaLeaderCost", "weight": 1 }
+          ],
+          "moveCosts": [
+            "org.astraea.common.cost.ReplicaLeaderCost",
+            "org.astraea.common.cost.RecordSizeCost"
+          ],
+          "costConfig": {
+            "max.migrated.size": "500MB",
+            "max.migrated.leader.number": 5
+          }
+        }
+        """;
+    var timeout = Duration.ofSeconds(5);
+    var balancer = "org.astraea.common.balancer.algorithms.GreedyBalancer";
+    var balancerConfig =
+        Map.ofEntries(
+            Map.entry("shuffle.tweaker.min.step", "1"),
+            Map.entry("shuffle.tweaker.max.step", "10"));
+    var costWeight = List.of(costWeight("org.astraea.common.cost.ReplicaLeaderCost", 1.0));
+    var moveCosts =
+        Set.of(
+            "org.astraea.common.cost.ReplicaLeaderCost", "org.astraea.common.cost.RecordSizeCost");
+    var costConfig =
+        Map.ofEntries(
+            Map.entry("max.migrated.size", "500MB"), Map.entry("max.migrated.leader.number", "5"));
+
+    var converted =
+        JsonConverter.defaultConverter().fromJson(payload, TypeRef.of(BalancerProblemFormat.class));
+
+    Assertions.assertEquals(timeout, converted.timeout);
+    Assertions.assertEquals(balancer, converted.balancer);
+    Assertions.assertEquals(balancerConfig, converted.balancerConfig);
+    Assertions.assertEquals(costWeight, converted.clusterCosts);
+    Assertions.assertEquals(moveCosts, converted.moveCosts);
+    Assertions.assertEquals(costConfig, converted.costConfig);
+
+    var algorithmConfig = converted.parse();
+    Assertions.assertEquals(timeout, algorithmConfig.timeout());
+    Assertions.assertEquals(balancerConfig, algorithmConfig.balancerConfig().raw());
+  }
+
+  @Test
+  void testCovertError() {
+    {
+      var payload =
+          """
+          { "clusterCosts": [ { "cost": "no.such.cluster.Cost", "weight": 1 } ] }
+          """;
+      var converted =
+          JsonConverter.defaultConverter()
+              .fromJson(payload, TypeRef.of(BalancerProblemFormat.class));
+      Assertions.assertEquals("no.such.cluster.Cost", converted.clusterCosts.get(0).cost);
+      Assertions.assertThrows(IllegalArgumentException.class, converted::parse);
+    }
+    {
+      var payload = """
+          { "moveCosts": [ "no.such.move.Cost" ] }
+          """;
+      var converted =
+          JsonConverter.defaultConverter()
+              .fromJson(payload, TypeRef.of(BalancerProblemFormat.class));
+      Assertions.assertEquals(Set.of("no.such.move.Cost"), converted.moveCosts);
+      Assertions.assertThrows(IllegalArgumentException.class, converted::parse);
+    }
+  }
+
+  private static BalancerProblemFormat.CostWeight costWeight(String cost, double weight) {
+    var cw = new BalancerProblemFormat.CostWeight();
+    cw.cost = cost;
+    cw.weight = weight;
+    return cw;
+  }
+}


### PR DESCRIPTION
Related Issue: #1693

後面 BalancerBench 會需要進到 App 裡面，我們需要有一個手法讓使用者從程式輸入描述整個 Balancer 的優化問題。目前我打算重複利用 [POST /balancer](https://github.com/skiptests/astraea/blob/main/docs/web_server/web_api_balancer_chinese.md#%E6%8E%92%E7%A8%8B%E6%90%9C%E5%B0%8B%E6%96%B0%E7%9A%84%E8%B2%A0%E8%BC%89%E5%84%AA%E5%8C%96%E8%A8%88%E5%8A%83) Web API 的輸入 JSON Payload 格式。這個 PR 把 `BalancerHandler` 內描述 Balancer 問題的那個 Data Class 移動到 `common` 裡面，方便後續 Web API 和 App 重複利用他，後面 BalancerBench 的 App 也會和使用者要一個 JSON，讀取 JSON 的內容來得知優化問題的細部資訊(AlgorithmConfig & Balancer Implementation)。