### PR TITLE
[COST] Reduce calculation on `ReplicaLeaderSize` partition cost

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/ReplicaLeaderSizeCost.java
+++ b/common/src/main/java/org/astraea/common/cost/ReplicaLeaderSizeCost.java
@@ -94,15 +94,7 @@ public class ReplicaLeaderSizeCost
   public PartitionCost partitionCost(ClusterInfo clusterInfo, ClusterBean clusterBean) {
     var result =
         clusterInfo.replicaLeaders().stream()
-            .collect(
-                Collectors.toMap(
-                    Replica::topicPartition,
-                    r ->
-                        (double)
-                            clusterInfo
-                                .replicaLeader(r.topicPartition())
-                                .map(Replica::size)
-                                .orElseThrow()));
+            .collect(Collectors.toMap(Replica::topicPartition, r -> (double) r.size()));
     return () -> result;
   }
 


### PR DESCRIPTION
這隻 PR 是 https://github.com/skiptests/astraea/pull/1654#issuecomment-1514855303 提到的問題，不過 #1654 可能還有一些問題需要處理，還需要一點時間。
這裡先另外開一隻 PR 處理，避免有人踩到同樣的坑。

這隻 PR 化簡 cost function -- `ReplicaLeaderSizeCost` 的計算，避免重複查找 replica leader。