### PR TITLE
[Balancer] Implement balancer config `balancer.clear.brokres.regex`

### DIFF
--- a/common/src/main/java/org/astraea/common/admin/ClusterInfoBuilder.java
+++ b/common/src/main/java/org/astraea/common/admin/ClusterInfoBuilder.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -90,6 +91,17 @@ public class ClusterInfoBuilder {
           return Stream.concat(nodes.stream(), brokerIds.stream().map(ClusterInfoBuilder::fakeNode))
               .collect(Collectors.toUnmodifiableList());
         });
+  }
+
+  /**
+   * Remove specific brokers from the cluster state.
+   *
+   * @param toRemove id to remove
+   * @return this
+   */
+  public ClusterInfoBuilder removeNode(Predicate<Integer> toRemove) {
+    return applyNodes(
+        (nodes, replicas) -> nodes.stream().filter(node -> toRemove.test(node.id())).toList());
   }
 
   /**

--- a/common/src/main/java/org/astraea/common/balancer/BalancerConfigs.java
+++ b/common/src/main/java/org/astraea/common/balancer/BalancerConfigs.java
@@ -40,4 +40,36 @@ public final class BalancerConfigs {
    * broker or move its partition to other brokers.
    */
   public static final String BALANCER_ALLOWED_BROKERS_REGEX = "balancer.allowed.brokers.regex";
+
+  /**
+   * A regular expression indicates which brokers should have zero replicas. This configuration
+   * enables the user to clear all loadings for some brokers, which further enables the user to
+   * perform a graceful removal for those brokers. When specified, the proposed rebalance plan from
+   * the {@link Balancer#offer(AlgorithmConfig)} should have no replica allocated to the target
+   * brokers.
+   *
+   * <h3>Flag Interaction:</h3>
+   *
+   * <ol>
+   *   <li>When this flag is used in conjunction with {@link
+   *       BalancerConfigs#BALANCER_ALLOWED_BROKERS_REGEX}, if the clearing target broker is not
+   *       allowed, an exception should be raised.
+   *   <li>When this flag is used in conjunction with {@link
+   *       BalancerConfigs#BALANCER_ALLOWED_BROKERS_REGEX}, if there is insufficient number of
+   *       allowed brokers to fit the required replica factor for a specific partition, an exception
+   *       should be raised.
+   *   <li>When this flag is used in conjunction with {@link
+   *       BalancerConfigs#BALANCER_ALLOWED_TOPICS_REGEX}, if the clearing target broker contains
+   *       partition from those forbidden topics, an exception should be raised.
+   * </ol>
+   *
+   * <h3>Limitation:</h3>
+   *
+   * <ol>
+   *   <li>Any broker with ongoing replica-move-in, replica-move-out or inter-folder-movement cannot
+   *       become the clear target. An exception will be raised if any of the clear broker has such
+   *       ongoing event.
+   * </ol>
+   */
+  public static final String BALANCER_CLEAR_BROKERS_REGEX = "balancer.clear.brokers.regex";
 }

--- a/common/src/main/java/org/astraea/common/balancer/BalancerUtils.java
+++ b/common/src/main/java/org/astraea/common/balancer/BalancerUtils.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.balancer;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.astraea.common.admin.ClusterInfo;
+import org.astraea.common.admin.NodeInfo;
+import org.astraea.common.admin.Replica;
+
+public final class BalancerUtils {
+
+  private BalancerUtils() {}
+
+  /**
+   * Verify there is no logic conflict between {@link
+   * BalancerConfigs#BALANCER_ALLOWED_TOPICS_REGEX}, {@link
+   * BalancerConfigs#BALANCER_ALLOWED_BROKERS_REGEX} and {@link
+   * BalancerConfigs#BALANCER_CLEAR_BROKERS_REGEX}. It also performs other common validness check to
+   * the cluster.
+   */
+  public static void verifyClearBrokerValidness(
+      ClusterInfo cluster,
+      Predicate<Integer> clearBroker,
+      Predicate<Integer> allowedBroker,
+      Predicate<String> allowedTopics) {
+    var disallowedBrokersToClear =
+        cluster.nodes().stream()
+            .map(NodeInfo::id)
+            .filter(Predicate.not(allowedBroker))
+            .filter(clearBroker)
+            .collect(Collectors.toUnmodifiableSet());
+    if (!disallowedBrokersToClear.isEmpty())
+      throw new IllegalArgumentException(
+          "Attempts to clear the following brokers but they are forbidden from being changed due to \""
+              + BalancerConfigs.BALANCER_ALLOWED_BROKERS_REGEX
+              + "\": "
+              + disallowedBrokersToClear);
+
+    var disallowedTopicsToClear =
+        cluster.topicPartitionReplicas().stream()
+            .filter(tpr -> clearBroker.test(tpr.brokerId()))
+            .filter(tpr -> !allowedTopics.test(tpr.topic()))
+            .collect(Collectors.toUnmodifiableSet());
+    if (!disallowedTopicsToClear.isEmpty())
+      throw new IllegalArgumentException(
+          "Attempts to clear some brokers, but some of them contain topics that forbidden from being changed due to \""
+              + BalancerConfigs.BALANCER_ALLOWED_TOPICS_REGEX
+              + "\": "
+              + disallowedTopicsToClear);
+
+    var ongoingEventReplica =
+        cluster.replicas().stream()
+            .filter(r -> clearBroker.test(r.nodeInfo().id()))
+            .filter(r -> r.isAdding() || r.isRemoving() || r.isFuture())
+            .map(Replica::topicPartitionReplica)
+            .collect(Collectors.toUnmodifiableSet());
+    if (!ongoingEventReplica.isEmpty())
+      throw new IllegalArgumentException(
+          "Attempts to clear broker with ongoing migration event (adding/removing/future replica): "
+              + ongoingEventReplica);
+  }
+
+  /**
+   * Move all the replicas at the broker to clear to other brokers. <b>BE CAREFUL, The
+   * implementation made no assumption for MoveCost or ClusterCost of the returned ClusterInfo.</b>
+   * Be aware of this limitation before using it as the starting point for a solution search. Some
+   * balancer implementation might have trouble finding answer when starting at a state where the
+   * MoveCost is already violated.
+   */
+  public static ClusterInfo clearedCluster(
+      ClusterInfo initial, Predicate<Integer> clearBrokers, Predicate<Integer> allowedBrokers) {
+    final var allowed =
+        initial.nodes().stream()
+            .filter(node -> allowedBrokers.test(node.id()))
+            .filter(node -> Predicate.not(clearBrokers).test(node.id()))
+            .collect(Collectors.toUnmodifiableSet());
+    final var nextBroker = Stream.generate(() -> allowed).flatMap(Collection::stream).iterator();
+    final var nextBrokerFolder =
+        initial.brokerFolders().entrySet().stream()
+            .collect(
+                Collectors.toUnmodifiableMap(
+                    Map.Entry::getKey,
+                    x -> Stream.generate(x::getValue).flatMap(Collection::stream).iterator()));
+
+    var trackingReplicaList =
+        initial.topicPartitions().stream()
+            .collect(
+                Collectors.toUnmodifiableMap(
+                    tp -> tp,
+                    tp ->
+                        initial.replicas(tp).stream()
+                            .map(Replica::nodeInfo)
+                            .collect(Collectors.toSet())));
+    return ClusterInfo.builder(initial)
+        .mapLog(
+            replica -> {
+              if (clearBrokers.test(replica.nodeInfo().id())) {
+                var currentReplicaList = trackingReplicaList.get(replica.topicPartition());
+                var broker =
+                    IntStream.range(0, allowed.size())
+                        .mapToObj(i -> nextBroker.next())
+                        .filter(b -> !currentReplicaList.contains(b))
+                        .findFirst()
+                        .orElseThrow(
+                            () ->
+                                new IllegalStateException(
+                                    "Unable to clear replica "
+                                        + replica.topicPartitionReplica()
+                                        + " for broker "
+                                        + replica.nodeInfo().id()
+                                        + ", the allowed destination brokers are "
+                                        + allowed.stream()
+                                            .map(NodeInfo::id)
+                                            .collect(Collectors.toUnmodifiableSet())
+                                        + " but all of them already hosting a replica for this partition. "
+                                        + "There is no broker can adopt this replica."));
+                var folder = nextBrokerFolder.get(broker.id()).next();
+
+                // update the tracking list. have to do this to avoid putting two replicas from the
+                // same tp to one broker.
+                currentReplicaList.remove(replica.nodeInfo());
+                currentReplicaList.add(broker);
+
+                return Replica.builder(replica).nodeInfo(broker).path(folder).build();
+              } else {
+                return replica;
+              }
+            })
+        .build();
+  }
+}


### PR DESCRIPTION
Context: #1551 

這個 PR 實作可以使 Balancer 清空特定節點負載的功能。

這個 PR 的功能實作比較複雜一些，因為 Clear 節點的過程會涉及到這些很多參數之間的互動

* clear 的 broker 必須要是 allow broker，否則會違反設定規則
* clear 的 broker 上面不能有 disallowed topic，否則會違反設定規則
* 被 clear 移出的負載有機會因為 allow 和 replica factor 的限制而沒有節點可以擺放
* clear 的 broker 上面不能有 adding/removing/future replica
