### PR TITLE
[COST] fix BrokerDiskSpaceCost

### DIFF
--- a/common/src/main/java/org/astraea/common/cost/BrokerDiskSpaceCost.java
+++ b/common/src/main/java/org/astraea/common/cost/BrokerDiskSpaceCost.java
@@ -83,9 +83,8 @@ public class BrokerDiskSpaceCost implements HasMoveCost {
           (Long)
               after
                   .replicaStream(id)
-                  .filter(r -> before.replicaStream(id).noneMatch(r::equals))
-                  .map(Replica::size)
-                  .mapToLong(y -> y)
+                  .filter(r -> !before.replicas(r.topicPartition()).contains(r))
+                  .mapToLong(Replica::size)
                   .sum();
       if ((beforeSize + addedSize)
           > brokerMoveCostLimit.getOrDefault(id, DataSize.Byte.of(Long.MAX_VALUE)).bytes())
@@ -115,9 +114,8 @@ public class BrokerDiskSpaceCost implements HasMoveCost {
             (Long)
                 after
                     .replicaStream(brokerPaths.getKey())
-                    .filter(r -> before.replicaStream(brokerPaths.getKey()).noneMatch(r::equals))
-                    .map(Replica::size)
-                    .mapToLong(y -> y)
+                    .filter(r -> !before.replicas(r.topicPartition()).contains(r))
+                    .mapToLong(Replica::size)
                     .sum();
         if ((beforeSize + addedSize)
             > diskMoveCostLimit.getOrDefault(brokerPath, DataSize.Byte.of(Long.MAX_VALUE)).bytes())


### PR DESCRIPTION
此PR修正在使用`BalancerBenchmark `測試`BrokerDiskSpaceCost`的效能問題

修正前在90秒內只能計算100~200個`CostFunction`，修正後在90秒內可以計算大約7500個`CostFunction`

