### PR TITLE
[METRICS] Migrate topic collector to balancer, partitioiner

### DIFF
--- a/app/src/test/java/org/astraea/app/web/TopicHandlerTest.java
+++ b/app/src/test/java/org/astraea/app/web/TopicHandlerTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.astraea.common.Configuration;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.admin.TopicPartition;
@@ -69,7 +70,8 @@ public class TopicHandlerTest {
               Admin.of(SERVICE.bootstrapServers()),
               0,
               id -> SERVICE.jmxServiceURL().getPort(),
-              Duration.ofMillis(5))) {
+              Duration.ofMillis(5),
+              Configuration.EMPTY)) {
         Response<TopicHandler.Topics> response =
             HttpExecutor.builder()
                 .build()

--- a/common/src/main/java/org/astraea/common/partitioner/StrictCostPartitioner.java
+++ b/common/src/main/java/org/astraea/common/partitioner/StrictCostPartitioner.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -38,6 +39,7 @@ import org.astraea.common.cost.NodeLatencyCost;
 import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.MBeanClient;
 import org.astraea.common.metrics.collector.MetricStore;
+import org.astraea.common.producer.ProducerConfigs;
 
 /**
  * this partitioner scores the nodes by multiples cost functions. Each function evaluate the target
@@ -55,6 +57,9 @@ import org.astraea.common.metrics.collector.MetricStore;
  * `org.astraea.cost.ThroughputCost=1,org.astraea.cost.broker.BrokerOutputCost=1`.
  */
 public class StrictCostPartitioner extends Partitioner {
+  public static final String METRIC_STORE_KEY = "metric.store";
+  public static final String METRIC_STORE_TOPIC = "topic";
+  public static final String METRIC_STORE_LOCAL = "local";
   static final int ROUND_ROBIN_LENGTH = 400;
   static final String JMX_PORT = "jmx.port";
   static final String ROUND_ROBIN_LEASE_KEY = "round.robin.lease";
@@ -140,27 +145,50 @@ public class StrictCostPartitioner extends Partitioner {
         .string(ROUND_ROBIN_LEASE_KEY)
         .map(Utils::toDuration)
         .ifPresent(d -> this.roundRobinLease = d);
-    Supplier<CompletionStage<Map<Integer, MBeanClient>>> clientSupplier =
-        () ->
-            admin
-                .brokers()
-                .thenApply(
-                    brokers -> {
-                      var map = new HashMap<Integer, JndiClient>();
-                      brokers.forEach(
-                          b ->
-                              map.put(
-                                  b.id(), JndiClient.of(b.host(), jmxPortGetter.apply(b.id()))));
-                      // add local client to fetch consumer metrics
-                      map.put(-1, JndiClient.local());
-                      return Collections.unmodifiableMap(map);
-                    });
 
-    metricStore =
-        MetricStore.builder()
-            .receivers(List.of(MetricStore.Receiver.local(clientSupplier)))
-            .sensorsSupplier(() -> Map.of(this.costFunction.metricSensor(), (integer, e) -> {}))
-            .build();
+    switch (config.string(METRIC_STORE_KEY).orElse(METRIC_STORE_LOCAL)) {
+      case METRIC_STORE_TOPIC -> metricStore =
+          MetricStore.builder()
+              .receivers(
+                  List.of(
+                      MetricStore.Receiver.topic(
+                          config.requireString(ProducerConfigs.BOOTSTRAP_SERVERS_CONFIG)),
+                      MetricStore.Receiver.local(
+                          () -> CompletableFuture.completedStage(Map.of(-1, JndiClient.local())))))
+              .sensorsSupplier(() -> Map.of(this.costFunction.metricSensor(), (integer, e) -> {}))
+              .build();
+      case METRIC_STORE_LOCAL -> {
+        Supplier<CompletionStage<Map<Integer, MBeanClient>>> clientSupplier =
+            () ->
+                admin
+                    .brokers()
+                    .thenApply(
+                        brokers -> {
+                          var map = new HashMap<Integer, JndiClient>();
+                          brokers.forEach(
+                              b ->
+                                  map.put(
+                                      b.id(),
+                                      JndiClient.of(b.host(), jmxPortGetter.apply(b.id()))));
+                          // add local client to fetch consumer metrics
+                          map.put(-1, JndiClient.local());
+                          return Collections.unmodifiableMap(map);
+                        });
+        metricStore =
+            MetricStore.builder()
+                .receivers(List.of(MetricStore.Receiver.local(clientSupplier)))
+                .sensorsSupplier(() -> Map.of(this.costFunction.metricSensor(), (integer, e) -> {}))
+                .build();
+      }
+      default -> throw new IllegalArgumentException(
+          "unknown metric store type: "
+              + config.string(METRIC_STORE_KEY)
+              + ". Use "
+              + METRIC_STORE_TOPIC
+              + " or "
+              + METRIC_STORE_LOCAL);
+    }
+
     this.roundRobinKeeper = RoundRobinKeeper.of(ROUND_ROBIN_LENGTH, roundRobinLease);
   }
 


### PR DESCRIPTION
這隻 PR 將 topic collector 整合到 `WebService` (balancer) 以及 `StrictcostPartitioner` 中，讓兩者可以指定要使用哪一種 metric 收集方法。

原來的作法是 "使用 JMX 直接收集"。現在的作法除了 "使用 JMX 直接收集" ，多了從 topic 收集 metric 的方法。

使用範例如下：
```java
try (var web =
    new WebService(
        Mockito.mock(Admin.class),
        0,
        id -> -1,
        Duration.ofMillis(5),
        new Configuration(
            Map.of(
                WebService.METRIC_STORE_KEY,
                WebService.METRIC_STORE_TOPIC,
                WebService.BOOTSTRAP_SERVERS_KEY,
                "ignore")))) {
  // webservice created metric store which receive metric from topic
}
```