### PR TITLE
[TEST] Fix flaky BackupTest#testRestoreDistribution()

### DIFF
--- a/app/src/test/java/org/astraea/app/backup/BackupTest.java
+++ b/app/src/test/java/org/astraea/app/backup/BackupTest.java
@@ -69,6 +69,10 @@ public class BackupTest {
           admin.clusterInfo(Set.of(topic1, topic2)).toCompletableFuture().join();
       Utils.sleep(Duration.ofSeconds(2));
 
+      // As the value of Broker.isController may change during each information retrieval from the
+      // KRaft cluster, we refrain from comparing Replica.broker before and after the restore
+      // operation.
+      Assertions.assertEquals(clusterInfo.topics(), restoredClusterInfo.topics());
       Assertions.assertEquals(
           clusterInfo.topicPartitionReplicas(), restoredClusterInfo.topicPartitionReplicas());
       Assertions.assertEquals(

--- a/app/src/test/java/org/astraea/app/backup/BackupTest.java
+++ b/app/src/test/java/org/astraea/app/backup/BackupTest.java
@@ -69,9 +69,9 @@ public class BackupTest {
           admin.clusterInfo(Set.of(topic1, topic2)).toCompletableFuture().join();
       Utils.sleep(Duration.ofSeconds(2));
 
-      // As the value of Broker.isController may change during each information retrieval from the
-      // KRaft cluster, we refrain from comparing Replica.broker before and after the restore
-      // operation.
+      // Comparing with partial information between ClusterInfos. We do this because in KRaft world,
+      // Kafka chooses a random broker node to report as the controller, resulting in different
+      // Replica.broker.isController values.
       Assertions.assertEquals(clusterInfo.topics(), restoredClusterInfo.topics());
       Assertions.assertEquals(
           clusterInfo.topicPartitionReplicas(), restoredClusterInfo.topicPartitionReplicas());

--- a/app/src/test/java/org/astraea/app/backup/BackupTest.java
+++ b/app/src/test/java/org/astraea/app/backup/BackupTest.java
@@ -18,8 +18,10 @@ package org.astraea.app.backup;
 
 import java.time.Duration;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.astraea.common.Utils;
 import org.astraea.common.admin.Admin;
+import org.astraea.common.admin.Replica;
 import org.astraea.it.Service;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -41,16 +43,16 @@ public class BackupTest {
       admin
           .creator()
           .topic(topic1)
-          .numberOfPartitions(3)
-          .numberOfReplicas((short) 3)
+          .numberOfPartitions(2)
+          .numberOfReplicas((short) 2)
           .run()
           .toCompletableFuture()
           .join();
       admin
           .creator()
           .topic(topic2)
-          .numberOfPartitions(3)
-          .numberOfReplicas((short) 3)
+          .numberOfPartitions(2)
+          .numberOfReplicas((short) 2)
           .run()
           .toCompletableFuture()
           .join();
@@ -67,7 +69,15 @@ public class BackupTest {
           admin.clusterInfo(Set.of(topic1, topic2)).toCompletableFuture().join();
       Utils.sleep(Duration.ofSeconds(2));
 
-      Assertions.assertEquals(clusterInfo.replicas(), restoredClusterInfo.replicas());
+      Assertions.assertEquals(
+          clusterInfo.topicPartitionReplicas(), restoredClusterInfo.topicPartitionReplicas());
+      Assertions.assertEquals(
+          clusterInfo.replicaLeaders().stream()
+              .map(Replica::topicPartitionReplica)
+              .collect(Collectors.toSet()),
+          restoredClusterInfo.replicaLeaders().stream()
+              .map(Replica::topicPartitionReplica)
+              .collect(Collectors.toSet()));
     }
   }
 }


### PR DESCRIPTION
fix #1784
在 SERVICE 中獲取到的 controller id 是隨機的 
(`case KRaftCachedControllerId(_) => metadataCache.getRandomAliveBrokerId`)，
所以會導致replica 在重新建構後所在的同一個Broker.isController 不一致
目前改成只透過 replica 及 leader 的 topic partition 對應的 `broker id` 判斷分佈是否一致