### PR TITLE
[COMMON] refine Broker structure to avoid duplicate large collection

### DIFF
--- a/app/src/main/java/org/astraea/app/web/BrokerHandler.java
+++ b/app/src/main/java/org/astraea/app/web/BrokerHandler.java
@@ -26,7 +26,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 import org.astraea.common.admin.Admin;
 import org.astraea.common.admin.Broker;
-import org.astraea.common.admin.TopicPartition;
+import org.astraea.common.admin.TopicPartitionPath;
 
 class BrokerHandler implements Handler {
 
@@ -95,8 +95,8 @@ class BrokerHandler implements Handler {
     Broker(org.astraea.common.admin.Broker broker) {
       this.id = broker.id();
       this.topics =
-          broker.topicPartitions().stream()
-              .collect(Collectors.groupingBy(TopicPartition::topic))
+          broker.topicPartitionPaths().stream()
+              .collect(Collectors.groupingBy(TopicPartitionPath::topic))
               .entrySet()
               .stream()
               .map(e -> new Topic(e.getKey(), e.getValue().size()))

--- a/app/src/main/java/org/astraea/app/web/ReassignmentHandler.java
+++ b/app/src/main/java/org/astraea/app/web/ReassignmentHandler.java
@@ -35,6 +35,7 @@ import org.astraea.common.admin.Broker;
 import org.astraea.common.admin.ClusterInfo;
 import org.astraea.common.admin.Replica;
 import org.astraea.common.admin.TopicPartition;
+import org.astraea.common.admin.TopicPartitionPath;
 import org.astraea.common.admin.TopicPartitionReplica;
 import org.astraea.common.json.TypeRef;
 
@@ -92,7 +93,7 @@ public class ReassignmentHandler implements Handler {
                               var availableBrokers =
                                   brokers.stream().filter(b -> b.id() != exclude).toList();
                               var partitions =
-                                  excludedBroker.get().topicPartitions().stream()
+                                  excludedBroker.get().topicPartitionPaths().stream()
                                       .filter(
                                           tp ->
                                               excludeNode.topic.isEmpty()
@@ -104,12 +105,14 @@ public class ReassignmentHandler implements Handler {
                                   partitions.stream()
                                       .collect(
                                           Collectors.toMap(
-                                              tp -> tp,
+                                              TopicPartitionPath::topicPartition,
                                               tp -> {
                                                 var ids =
                                                     availableBrokers.stream()
                                                         .filter(
-                                                            b -> b.topicPartitions().contains(tp))
+                                                            b ->
+                                                                b.topicPartitionPaths()
+                                                                    .contains(tp))
                                                         .map(Broker::id)
                                                         .toList();
                                                 if (!ids.isEmpty()) return ids;

--- a/common/src/main/java/org/astraea/common/admin/Admin.java
+++ b/common/src/main/java/org/astraea/common/admin/Admin.java
@@ -178,15 +178,7 @@ public interface Admin extends AutoCloseable {
   default CompletionStage<Map<Integer, Set<String>>> brokerFolders() {
     return brokers()
         .thenApply(
-            brokers ->
-                brokers.stream()
-                    .collect(
-                        Collectors.toMap(
-                            Broker::id,
-                            n ->
-                                n.dataFolders().stream()
-                                    .map(Broker.DataFolder::path)
-                                    .collect(Collectors.toSet()))));
+            brokers -> brokers.stream().collect(Collectors.toMap(Broker::id, Broker::dataFolders)));
   }
 
   CompletionStage<Set<String>> consumerGroupIds();

--- a/common/src/main/java/org/astraea/common/admin/AdminImpl.java
+++ b/common/src/main/java/org/astraea/common/admin/AdminImpl.java
@@ -455,7 +455,6 @@ class AdminImpl implements Admin {
     return FutureUtils.combine(
         to(cluster.clusterId()),
         to(cluster.controller()),
-        topicNames(true).thenCompose(names -> to(kafkaAdmin.describeTopics(names).allTopicNames())),
         nodeFuture.thenCompose(
             nodes ->
                 to(
@@ -472,7 +471,7 @@ class AdminImpl implements Admin {
                                     ConfigResource.Type.BROKER, String.valueOf(n.id())))
                         .collect(Collectors.toList()))),
         nodeFuture,
-        (id, controller, topics, logDirs, configs, nodes) ->
+        (id, controller, logDirs, configs, nodes) ->
             Map.entry(
                 id,
                 nodes.stream()
@@ -482,8 +481,7 @@ class AdminImpl implements Admin {
                                 node.id() == controller.id(),
                                 node,
                                 configs.get(String.valueOf(node.id())),
-                                logDirs.get(node.id()),
-                                topics.values()))
+                                logDirs.get(node.id())))
                     .sorted(Comparator.comparing(Broker::id))
                     .collect(Collectors.toList())));
   }

--- a/common/src/main/java/org/astraea/common/admin/ClusterInfo.java
+++ b/common/src/main/java/org/astraea/common/admin/ClusterInfo.java
@@ -319,13 +319,7 @@ public interface ClusterInfo {
    */
   default Map<Integer, Set<String>> brokerFolders() {
     return brokers().stream()
-        .collect(
-            Collectors.toUnmodifiableMap(
-                Broker::id,
-                node ->
-                    node.dataFolders().stream()
-                        .map(Broker.DataFolder::path)
-                        .collect(Collectors.toUnmodifiableSet())));
+        .collect(Collectors.toUnmodifiableMap(Broker::id, Broker::dataFolders));
   }
 
   // ---------------------[streams methods]---------------------//

--- a/common/src/main/java/org/astraea/common/admin/ClusterInfoBuilder.java
+++ b/common/src/main/java/org/astraea/common/admin/ClusterInfoBuilder.java
@@ -126,10 +126,8 @@ public class ClusterInfoBuilder {
                           node.host(),
                           node.port(),
                           Stream.concat(
-                                  node.dataFolders().stream(),
-                                  folders.get(node.id()).stream()
-                                      .map(ClusterInfoBuilder::fakeDataFolder))
-                              .toList());
+                                  node.dataFolders().stream(), folders.get(node.id()).stream())
+                              .collect(Collectors.toUnmodifiableSet()));
                     else return node;
                   })
               .toList();
@@ -177,9 +175,7 @@ public class ClusterInfoBuilder {
                           Broker::id,
                           node ->
                               node.dataFolders().stream()
-                                  .collect(
-                                      Collectors.toMap(
-                                          Broker.DataFolder::path, x -> new AtomicInteger()))));
+                                  .collect(Collectors.toMap(t -> t, x -> new AtomicInteger()))));
           replicas.forEach(
               replica ->
                   folderLogCounter.get(replica.brokerId()).get(replica.path()).incrementAndGet());
@@ -330,16 +326,10 @@ public class ClusterInfoBuilder {
   private static Broker fakeNode(int brokerId) {
     var host = "fake-node-" + brokerId;
     var port = new Random(brokerId).nextInt(65535) + 1;
-    var folders = List.<Broker.DataFolder>of();
-
-    return fakeBroker(brokerId, host, port, folders);
+    return fakeBroker(brokerId, host, port, Set.of());
   }
 
-  static Broker fakeBroker(int Id, String host, int port, List<Broker.DataFolder> dataFolders) {
-    return new Broker(Id, host, port, false, Config.EMPTY, dataFolders, Set.of(), Set.of());
-  }
-
-  private static Broker.DataFolder fakeDataFolder(String path) {
-    return new Broker.DataFolder(path, Map.of(), Map.of());
+  static Broker fakeBroker(int Id, String host, int port, Set<String> dataFolders) {
+    return new Broker(Id, host, port, false, Config.EMPTY, dataFolders, List.of());
   }
 }

--- a/common/src/main/java/org/astraea/common/admin/TopicPartitionPath.java
+++ b/common/src/main/java/org/astraea/common/admin/TopicPartitionPath.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.common.admin;
+
+public record TopicPartitionPath(String topic, int partition, long size, String path) {
+
+  public TopicPartition topicPartition() {
+    return new TopicPartition(topic, partition);
+  }
+}

--- a/common/src/main/proto/org/astraea/common/generated/admin/Broker.proto
+++ b/common/src/main/proto/org/astraea/common/generated/admin/Broker.proto
@@ -10,13 +10,13 @@ message Broker {
   int32 port = 3;
   bool isController = 4;
   map<string, string> config = 5;
-  repeated DataFolder dataFolder = 6;
-  repeated TopicPartition topicPartitions = 7;
-  repeated TopicPartition topicPartitionLeaders = 8;
+  repeated string dataFolders = 6;
+  repeated TopicPartitionPath topicPartitionPaths = 7;
 
-  message DataFolder {
-    string path = 1;
-    map<string, int64> partitionSizes = 2;
-    map<string, int64> orphanPartitionSizes = 3;
+  message TopicPartitionPath {
+    string topic = 1;
+    int32 partition = 2;
+    int64 size = 3;
+    string path = 4;
   }
 }

--- a/common/src/test/java/org/astraea/common/admin/AdminTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AdminTest.java
@@ -1492,7 +1492,9 @@ public class AdminTest {
           .join()
           .forEach(
               broker ->
-                  broker.topicPartitionPaths().forEach(d -> Assertions.assertEquals(0, d.size())));
+                  broker.topicPartitionPaths().stream()
+                      .filter(tp -> tp.topic().equals(topic))
+                      .forEach(d -> Assertions.assertEquals(0, d.size())));
     }
   }
 

--- a/common/src/test/java/org/astraea/common/admin/AdminTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AdminTest.java
@@ -1275,38 +1275,7 @@ public class AdminTest {
       Assertions.assertEquals(3, brokers.size());
       brokers.forEach(broker -> Assertions.assertNotEquals(0, broker.config().raw().size()));
       Assertions.assertEquals(1, brokers.stream().filter(Broker::isController).count());
-      brokers.forEach(broker -> Assertions.assertNotEquals(0, broker.topicPartitions().size()));
-      brokers.forEach(
-          broker -> Assertions.assertNotEquals(0, broker.topicPartitionLeaders().size()));
-    }
-  }
-
-  @Test
-  void testBrokerFolders() {
-    try (var admin = Admin.of(SERVICE.bootstrapServers())) {
-      Assertions.assertEquals(
-          SERVICE.dataFolders().keySet().size(),
-          admin.brokers().toCompletableFuture().join().size());
-      // list all
-      SERVICE
-          .dataFolders()
-          .forEach(
-              (id, ds) ->
-                  Assertions.assertEquals(
-                      admin.brokerFolders().toCompletableFuture().join().get(id).size(),
-                      ds.size()));
-
-      admin
-          .brokers()
-          .toCompletableFuture()
-          .join()
-          .forEach(
-              broker ->
-                  Assertions.assertEquals(
-                      broker.topicPartitions().size(),
-                      broker.dataFolders().stream()
-                          .mapToInt(e -> e.partitionSizes().size())
-                          .sum()));
+      brokers.forEach(broker -> Assertions.assertNotEquals(0, broker.topicPartitionPaths().size()));
     }
   }
 
@@ -1523,14 +1492,7 @@ public class AdminTest {
           .join()
           .forEach(
               broker ->
-                  broker
-                      .dataFolders()
-                      .forEach(
-                          d ->
-                              d.partitionSizes().entrySet().stream()
-                                  .filter(e -> e.getKey().topic().equals(topic))
-                                  .map(Map.Entry::getValue)
-                                  .forEach(v -> Assertions.assertEquals(0, v))));
+                  broker.topicPartitionPaths().forEach(d -> Assertions.assertEquals(0, d.size())));
     }
   }
 

--- a/common/src/test/java/org/astraea/common/admin/AdminWithOfflineBrokerTest.java
+++ b/common/src/test/java/org/astraea/common/admin/AdminWithOfflineBrokerTest.java
@@ -112,11 +112,7 @@ public class AdminWithOfflineBrokerTest {
     try (var admin = Admin.of(SERVICE.bootstrapServers())) {
       var brokers = admin.brokers().toCompletableFuture().join();
       Assertions.assertEquals(2, brokers.size());
-      brokers.forEach(
-          b ->
-              b.dataFolders()
-                  .forEach(d -> Assertions.assertEquals(0, d.orphanPartitionSizes().size())));
-      var offlineBrokers = brokers.stream().filter(Broker::offline).collect(Collectors.toList());
+      var offlineBrokers = brokers.stream().filter(Broker::offline).toList();
       Assertions.assertEquals(0, offlineBrokers.size());
     }
   }
@@ -127,8 +123,7 @@ public class AdminWithOfflineBrokerTest {
     try (var admin = Admin.of(SERVICE.bootstrapServers())) {
       var partitions = admin.partitions(Set.of(TOPIC_NAME)).toCompletableFuture().join();
       Assertions.assertEquals(PARTITIONS, partitions.size());
-      var offlinePartitions =
-          partitions.stream().filter(p -> p.leaderId().isEmpty()).collect(Collectors.toList());
+      var offlinePartitions = partitions.stream().filter(p -> p.leaderId().isEmpty()).toList();
       offlinePartitions.forEach(
           p -> {
             Assertions.assertEquals(1, p.replicas().size());

--- a/common/src/test/java/org/astraea/common/admin/ClusterInfoBuilderTest.java
+++ b/common/src/test/java/org/astraea/common/admin/ClusterInfoBuilderTest.java
@@ -332,7 +332,7 @@ class ClusterInfoBuilderTest {
         "300, host3, 3000",
       })
   void testFakeBrokerInteraction(int id, String host, int port) {
-    var node0 = ClusterInfoBuilder.fakeBroker(id, host, port, List.of());
+    var node0 = ClusterInfoBuilder.fakeBroker(id, host, port, Set.of());
     var node1 = Broker.of(id, host, port);
     var node2 = Broker.of(id + 1, host, port);
 

--- a/common/src/test/java/org/astraea/common/admin/ClusterInfoTest.java
+++ b/common/src/test/java/org/astraea/common/admin/ClusterInfoTest.java
@@ -51,14 +51,7 @@ public class ClusterInfoTest {
             .map(
                 r ->
                     new Broker(
-                        r.brokerId(),
-                        "hpost",
-                        22222,
-                        false,
-                        Config.EMPTY,
-                        List.of(),
-                        Set.of(),
-                        Set.of()))
+                        r.brokerId(), "hpost", 22222, false, Config.EMPTY, Set.of(), List.of()))
             .collect(Collectors.groupingBy(Broker::id, Collectors.reducing((x, y) -> x)))
             .values()
             .stream()

--- a/common/src/test/java/org/astraea/common/balancer/FakeClusterInfo.java
+++ b/common/src/test/java/org/astraea/common/balancer/FakeClusterInfo.java
@@ -84,11 +84,8 @@ public class FakeClusterInfo {
                         node.port(),
                         false,
                         new Config(Map.of()),
-                        dataDirectories.stream()
-                            .map(path -> new Broker.DataFolder(path, Map.of(), Map.of()))
-                            .toList(),
-                        Set.of(),
-                        Set.of()))
+                        dataDirectories,
+                        List.of()))
             .toList();
     final var dataDirectoryList = List.copyOf(dataDirectories);
     final var topics = topicNameGenerator.apply(topicCount);

--- a/common/src/test/java/org/astraea/common/cost/BrokerDiskSpaceCostTest.java
+++ b/common/src/test/java/org/astraea/common/cost/BrokerDiskSpaceCostTest.java
@@ -219,16 +219,7 @@ class BrokerDiskSpaceCostTest {
   }
 
   public static ClusterInfo of(List<Replica> replicas) {
-    var dataPath =
-        Map.of(
-            0,
-            List.of(new Broker.DataFolder("/path0", Map.of(), Map.of())),
-            1,
-            List.of(new Broker.DataFolder("/path0", Map.of(), Map.of())),
-            2,
-            List.of(
-                new Broker.DataFolder("/path0", Map.of(), Map.of()),
-                new Broker.DataFolder("/path1", Map.of(), Map.of())));
+    var dataPath = Map.of(0, Set.of("/path0"), 1, Set.of("/path0"), 2, Set.of("/path0", "/path1"));
     return ClusterInfo.of(
         "fake",
         replicas.stream()
@@ -237,14 +228,7 @@ class BrokerDiskSpaceCostTest {
             .map(
                 brokerId ->
                     new Broker(
-                        brokerId,
-                        "",
-                        2222,
-                        false,
-                        Config.EMPTY,
-                        dataPath.get(brokerId),
-                        Set.of(),
-                        Set.of()))
+                        brokerId, "", 2222, false, Config.EMPTY, dataPath.get(brokerId), List.of()))
             .collect(Collectors.toList()),
         Map.of(),
         replicas);
@@ -266,14 +250,7 @@ class BrokerDiskSpaceCostTest {
    */
   private static ClusterInfo beforeClusterInfo() {
 
-    var dataPath =
-        Map.of(
-            0, List.of(new Broker.DataFolder("/path0", Map.of(), Map.of())),
-            1, List.of(new Broker.DataFolder("/path0", Map.of(), Map.of())),
-            2,
-                List.of(
-                    new Broker.DataFolder("/path0", Map.of(), Map.of()),
-                    new Broker.DataFolder("/path1", Map.of(), Map.of())));
+    var dataPath = Map.of(0, Set.of("/path0"), 1, Set.of("/path0"), 2, Set.of("/path0", "/path1"));
     var replicas =
         List.of(
             Replica.builder()
@@ -332,29 +309,14 @@ class BrokerDiskSpaceCostTest {
             .map(
                 brokerId ->
                     new Broker(
-                        brokerId,
-                        "",
-                        2222,
-                        false,
-                        Config.EMPTY,
-                        dataPath.get(brokerId),
-                        Set.of(),
-                        Set.of()))
+                        brokerId, "", 2222, false, Config.EMPTY, dataPath.get(brokerId), List.of()))
             .collect(Collectors.toList()),
         Map.of(),
         replicas);
   }
 
   private static ClusterInfo afterClusterInfo() {
-
-    var dataPath =
-        Map.of(
-            0, List.of(new Broker.DataFolder("/path0", Map.of(), Map.of())),
-            1, List.of(new Broker.DataFolder("/path0", Map.of(), Map.of())),
-            2,
-                List.of(
-                    new Broker.DataFolder("/path0", Map.of(), Map.of()),
-                    new Broker.DataFolder("/path1", Map.of(), Map.of())));
+    var dataPath = Map.of(0, Set.of("/path0"), 1, Set.of("/path0"), 2, Set.of("/path0", "/path1"));
     var replicas =
         List.of(
             Replica.builder()
@@ -413,14 +375,7 @@ class BrokerDiskSpaceCostTest {
             .map(
                 brokerId ->
                     new Broker(
-                        brokerId,
-                        "",
-                        2222,
-                        false,
-                        Config.EMPTY,
-                        dataPath.get(brokerId),
-                        Set.of(),
-                        Set.of()))
+                        brokerId, "", 2222, false, Config.EMPTY, dataPath.get(brokerId), List.of()))
             .collect(Collectors.toList()),
         Map.of(),
         replicas);

--- a/common/src/test/java/org/astraea/common/cost/CostUtilsTest.java
+++ b/common/src/test/java/org/astraea/common/cost/CostUtilsTest.java
@@ -73,16 +73,7 @@ class CostUtilsTest {
    */
   private static ClusterInfo beforeClusterInfo() {
 
-    var dataPath =
-        Map.of(
-            0,
-            List.of(new Broker.DataFolder("/path0", Map.of(), Map.of())),
-            1,
-            List.of(new Broker.DataFolder("/path0", Map.of(), Map.of())),
-            2,
-            List.of(
-                new Broker.DataFolder("/path0", Map.of(), Map.of()),
-                new Broker.DataFolder("/path1", Map.of(), Map.of())));
+    var dataPath = Map.of(0, Set.of("/path0"), 1, Set.of("/path0"), 2, Set.of("/path0", "/path1"));
     var replicas =
         List.of(
             Replica.builder()
@@ -147,8 +138,7 @@ class CostUtilsTest {
                         false,
                         Config.EMPTY,
                         dataPath.get(brokerId),
-                        Set.of(),
-                        Set.of()))
+                        List.of()))
             .collect(Collectors.toList()),
         Map.of(),
         replicas);
@@ -156,16 +146,7 @@ class CostUtilsTest {
 
   private static ClusterInfo afterClusterInfo() {
 
-    var dataPath =
-        Map.of(
-            0,
-            List.of(new Broker.DataFolder("/path0", Map.of(), Map.of())),
-            1,
-            List.of(new Broker.DataFolder("/path0", Map.of(), Map.of())),
-            2,
-            List.of(
-                new Broker.DataFolder("/path0", Map.of(), Map.of()),
-                new Broker.DataFolder("/path1", Map.of(), Map.of())));
+    var dataPath = Map.of(0, Set.of("/path0"), 1, Set.of("/path0"), 2, Set.of("/path0", "/path1"));
     var replicas =
         List.of(
             Replica.builder()
@@ -230,8 +211,7 @@ class CostUtilsTest {
                         false,
                         Config.EMPTY,
                         dataPath.get(brokerId),
-                        Set.of(),
-                        Set.of()))
+                        List.of()))
             .collect(Collectors.toList()),
         Map.of(),
         replicas);

--- a/gui/src/main/java/org/astraea/gui/tab/topic/TopicNode.java
+++ b/gui/src/main/java/org/astraea/gui/tab/topic/TopicNode.java
@@ -41,6 +41,7 @@ import org.astraea.common.admin.ConsumerGroup;
 import org.astraea.common.admin.Partition;
 import org.astraea.common.admin.ProducerState;
 import org.astraea.common.admin.TopicConfigs;
+import org.astraea.common.admin.TopicPartitionPath;
 import org.astraea.common.metrics.broker.HasRate;
 import org.astraea.common.metrics.broker.ServerMetrics;
 import org.astraea.gui.Context;
@@ -363,12 +364,12 @@ public class TopicNode {
       List<ProducerState> producerStates) {
     var topicSize =
         brokers.stream()
-            .flatMap(
-                n -> n.dataFolders().stream().flatMap(d -> d.partitionSizes().entrySet().stream()))
+            .flatMap(n -> n.topicPartitionPaths().stream())
             .collect(
                 Collectors.groupingBy(
-                    e -> e.getKey().topic(),
-                    Collectors.mapping(Map.Entry::getValue, Collectors.reducing(0L, Long::sum))));
+                    TopicPartitionPath::topic,
+                    Collectors.mapping(
+                        TopicPartitionPath::size, Collectors.reducing(0L, Long::sum))));
 
     var topicPartitions = partitions.stream().collect(Collectors.groupingBy(Partition::topic));
     var topicGroups =


### PR DESCRIPTION
Broker 裡面有多個資料結構描述`TopicPartition`，這會讓大型叢集在操作時要創建好幾個大型集合才能形成`Broker`這個結構，此外 orphan 是一個很抽象的概念，實際上不常發生所以也移除