### PR TITLE
[METRICS] Add mbean to metric store and metric fetcher

### DIFF
--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
@@ -47,6 +47,9 @@ import org.astraea.common.metrics.BeanQuery;
 import org.astraea.common.metrics.ClusterBean;
 import org.astraea.common.metrics.HasBeanObject;
 import org.astraea.common.metrics.MBeanClient;
+import org.astraea.common.metrics.MBeanRegister;
+import org.astraea.common.metrics.Sensor;
+import org.astraea.common.metrics.stats.Sum;
 
 public interface MetricStore extends AutoCloseable {
 
@@ -178,6 +181,15 @@ public interface MetricStore extends AutoCloseable {
   }
 
   class MetricStoreImpl implements MetricStore {
+    public static final String DOMAIN_NAME = "org.astraea";
+    public static final String TYPE_PROPERTY = "type";
+    public static final String TYPE_VALUE = "metricStore";
+    public static final String NAME_PROPERTY = "name";
+    public static final String BEAN_COUNT_NAME = "BeanCount";
+    public static final String BEAN_RECEIVE_NAME = "BeanReceived";
+    public static final String ID_PROPERTY = "id";
+    public static final String COUNT_PROPERTY = "count";
+    public static final String SUM_PROPERTY = "sum";
 
     private final Map<Integer, Collection<HasBeanObject>> beans = new ConcurrentHashMap<>();
 
@@ -196,6 +208,10 @@ public interface MetricStore extends AutoCloseable {
     private volatile Map<MetricSensor, BiConsumer<Integer, Exception>> lastSensors = Map.of();
     private final Map<CountDownLatch, Predicate<ClusterBean>> waitingList =
         new ConcurrentHashMap<>();
+    // For mbean register. To distinguish mbeans of different metricStore.
+    private final String uid = Utils.randomString();
+    private final Sensor<Long> beanReceivedSensor =
+        Sensor.builder().addStat(SUM_PROPERTY, Sum.ofLong()).build();
 
     private MetricStoreImpl(
         Supplier<Map<MetricSensor, BiConsumer<Integer, Exception>>> sensorsSupplier,
@@ -232,6 +248,8 @@ public interface MetricStore extends AutoCloseable {
                     .map(r -> r.receive(Duration.ofSeconds(3)))
                     .forEach(
                         allBeans -> {
+                          beanReceivedSensor.record(
+                              allBeans.values().stream().mapToLong(Collection::size).sum());
                           identities.addAll(allBeans.keySet());
                           lastSensors = sensorsSupplier.get();
                           allBeans.forEach(
@@ -264,6 +282,24 @@ public interface MetricStore extends AutoCloseable {
           };
       executor.execute(cleanerJob);
       executor.execute(receiverJob);
+
+      // ------------ MBean register ------------
+      MBeanRegister.local()
+          .domainName(DOMAIN_NAME)
+          .property(TYPE_PROPERTY, TYPE_VALUE)
+          .property(ID_PROPERTY, uid)
+          .property(NAME_PROPERTY, BEAN_COUNT_NAME)
+          .attribute(COUNT_PROPERTY, Long.class, () -> beans.values().stream().mapToLong(Collection::size).sum())
+          .description("The number of beans stored in this metricStore.")
+          .register();
+      MBeanRegister.local()
+          .domainName(DOMAIN_NAME)
+          .property(TYPE_PROPERTY, TYPE_VALUE)
+          .property(ID_PROPERTY, uid)
+          .property(NAME_PROPERTY, BEAN_RECEIVE_NAME)
+          .attribute(SUM_PROPERTY, Long.class, () -> beanReceivedSensor.measure(SUM_PROPERTY))
+          .description("The total number of beans received.")
+          .register();
     }
 
     @Override

--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
@@ -150,7 +150,7 @@ public interface MetricStore extends AutoCloseable {
                     (client, bean) ->
                         client.beans(BeanQuery.all()).stream()
                             .map(bs -> (HasBeanObject) () -> bs)
-                            .collect(Collectors.toUnmodifiableList()),
+                            .toList(),
                 (id, ignored) -> {});
 
     private Collection<Receiver> receivers;
@@ -289,7 +289,10 @@ public interface MetricStore extends AutoCloseable {
           .property(TYPE_PROPERTY, TYPE_VALUE)
           .property(ID_PROPERTY, uid)
           .property(NAME_PROPERTY, BEAN_COUNT_NAME)
-          .attribute(COUNT_PROPERTY, Long.class, () -> beans.values().stream().mapToLong(Collection::size).sum())
+          .attribute(
+              COUNT_PROPERTY,
+              Long.class,
+              () -> beans.values().stream().mapToLong(Collection::size).sum())
           .description("The number of beans stored in this metricStore.")
           .register();
       MBeanRegister.local()

--- a/common/src/main/java/org/astraea/common/partitioner/StrictCostPartitioner.java
+++ b/common/src/main/java/org/astraea/common/partitioner/StrictCostPartitioner.java
@@ -132,7 +132,6 @@ public class StrictCostPartitioner extends Partitioner {
     var configuredFunctions =
         Utils.costFunctions(
             config.filteredPrefixConfigs(COST_PREFIX).raw(), HasBrokerCost.class, config);
-    System.out.println(configuredFunctions);
     if (!configuredFunctions.isEmpty()) this.costFunction = HasBrokerCost.of(configuredFunctions);
     var customJmxPort = PartitionerUtils.parseIdJMXPort(config);
     var defaultJmxPort = config.integer(JMX_PORT);

--- a/common/src/main/java/org/astraea/common/partitioner/StrictCostPartitioner.java
+++ b/common/src/main/java/org/astraea/common/partitioner/StrictCostPartitioner.java
@@ -132,6 +132,7 @@ public class StrictCostPartitioner extends Partitioner {
     var configuredFunctions =
         Utils.costFunctions(
             config.filteredPrefixConfigs(COST_PREFIX).raw(), HasBrokerCost.class, config);
+    System.out.println(configuredFunctions);
     if (!configuredFunctions.isEmpty()) this.costFunction = HasBrokerCost.of(configuredFunctions);
     var customJmxPort = PartitionerUtils.parseIdJMXPort(config);
     var defaultJmxPort = config.integer(JMX_PORT);


### PR DESCRIPTION
這隻 PR 在 `MetricStore` 和 `MetricFetcher` 紀錄 bean 收集的速率。

### 動機

在降低 metric 收集的資源消耗外，也應該要考慮收集 metric 的數量 (速率)。

在 metric 量多時， fetch 的時間可能遠大於 `fetchBeanDelay`，這時候 metric 收集速度將會有所不同。
在我的預期中，topic collector 應該要有較快的收集速度 + 較低資源消耗。目前較低的資源消耗已經有方法證實，我認為再來需要看看 metric 收集的速率，證實 "較低資源消耗 不是因為 收集較少資料"。