### PR TITLE
[SCRIPT] Enable to restart kafka container

### DIFF
--- a/docker/start_broker.sh
+++ b/docker/start_broker.sh
@@ -314,7 +314,7 @@ if [[ "$quorum" == "kraft" ]]; then
   setPropertyIfEmpty "node.id" "$NODE_ID"
   setPropertyIfEmpty "process.roles" "broker"
   setPropertyIfEmpty "controller.listener.names" "CONTROLLER"
-  command="./bin/kafka-storage.sh format -t $CLUSTER_ID -c /tmp/broker.properties && ./bin/kafka-server-start.sh /tmp/broker.properties"
+  command="./bin/kafka-storage.sh format -t $CLUSTER_ID -c /tmp/broker.properties --ignore-formatted && ./bin/kafka-server-start.sh /tmp/broker.properties"
 fi
 
 docker run -d --init \

--- a/docker/start_controller.sh
+++ b/docker/start_controller.sh
@@ -233,7 +233,7 @@ docker run -d --init \
   -p $CONTROLLER_PORT:9093 \
   -p $CONTROLLER_JMX_PORT:$CONTROLLER_JMX_PORT \
   -p $EXPORTER_PORT:$EXPORTER_PORT \
-  "$IMAGE_NAME" sh -c "./bin/kafka-storage.sh format -t $CLUSTER_ID -c /tmp/controller.properties && ./bin/kafka-server-start.sh /tmp/controller.properties"
+  "$IMAGE_NAME" sh -c "./bin/kafka-storage.sh format -t $CLUSTER_ID -c /tmp/controller.properties --ignore-formatted && ./bin/kafka-server-start.sh /tmp/controller.properties"
 
 echo "================================================="
 [[ -n "$META_FOLDER" ]] && echo "mount $META_FOLDER to container: $CONTAINER_NAME"


### PR DESCRIPTION
目前專案的 kafka container 的啟動指令是 `sh -c "./bin/kafka-storage.sh format -t $CLUSTER_ID -c /tmp/controller.properties && ./bin/kafka-server-start.sh /tmp/controller.properties"`，這個啟動的指令會在 container restart 時再執行一次，而從第二次執行開始前面的 `kafka-storage.sh` 會因為已經格式化過而噴錯，進而導致後面的 `kafka-server-start.sh` 沒辦法執行，因此專案腳本的 container 沒辦法透過 `docker stop`, `docker start` 重開。

這個 PR 給格式化的腳本使用 `--ignore-formatted`，這個選項會忽略已經格式化過的 log dir，讓後面的 `kafka-server-start.sh` 可以順利執行。