### PR TITLE
[CONNECTOR] add contexts for source/sink

### DIFF
--- a/connector/src/main/java/org/astraea/connector/SinkConnector.java
+++ b/connector/src/main/java/org/astraea/connector/SinkConnector.java
@@ -25,7 +25,7 @@ import org.astraea.common.VersionUtils;
 public abstract class SinkConnector extends org.apache.kafka.connect.sink.SinkConnector {
   public static final String TOPICS_KEY = TOPICS_CONFIG;
 
-  protected void init(Configuration configuration) {
+  protected void init(Configuration configuration, SinkContext context) {
     // empty
   }
 
@@ -42,7 +42,7 @@ public abstract class SinkConnector extends org.apache.kafka.connect.sink.SinkCo
   // -------------------------[final]-------------------------//
   @Override
   public final void start(Map<String, String> props) {
-    init(new Configuration(props));
+    init(new Configuration(props), SinkContext.of(context()));
   }
 
   @Override

--- a/connector/src/main/java/org/astraea/connector/SinkContext.java
+++ b/connector/src/main/java/org/astraea/connector/SinkContext.java
@@ -16,22 +16,14 @@
  */
 package org.astraea.connector;
 
-import java.util.Map;
-import java.util.stream.Collectors;
-import org.apache.kafka.connect.storage.OffsetStorageReader;
+public interface SinkContext {
 
-public interface MetadataStorage {
+  SinkContext EMPTY = e -> {};
 
-  MetadataStorage EMPTY = ignored -> Map.of();
-
-  static MetadataStorage of(OffsetStorageReader reader) {
-    return index -> {
-      var v = reader.offset(index);
-      if (v == null) return Map.of();
-      return v.entrySet().stream()
-          .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> e.getValue().toString()));
-    };
+  static SinkContext of(org.apache.kafka.connect.sink.SinkConnectorContext context) {
+    return context::raiseError;
   }
 
-  Map<String, String> metadata(Map<String, String> index);
+  /** {@link org.apache.kafka.connect.sink.SinkConnectorContext#raiseError(Exception)} */
+  void raiseError(Exception e);
 }

--- a/connector/src/main/java/org/astraea/connector/SinkTaskContext.java
+++ b/connector/src/main/java/org/astraea/connector/SinkTaskContext.java
@@ -19,10 +19,9 @@ package org.astraea.connector;
 import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.astraea.common.admin.TopicPartition;
 
-public interface TaskContext {
+public interface SinkTaskContext {
 
   /**
    * Reset the consumer offsets for the specified partitions.
@@ -52,8 +51,8 @@ public interface TaskContext {
    */
   void requestCommit();
 
-  static TaskContext of(SinkTaskContext context) {
-    return new TaskContext() {
+  static SinkTaskContext of(org.apache.kafka.connect.sink.SinkTaskContext context) {
+    return new SinkTaskContext() {
       @Override
       public void offset(Map<TopicPartition, Long> offsets) {
         context.offset(

--- a/connector/src/main/java/org/astraea/connector/SourceConnector.java
+++ b/connector/src/main/java/org/astraea/connector/SourceConnector.java
@@ -25,7 +25,7 @@ import org.astraea.common.VersionUtils;
 public abstract class SourceConnector extends org.apache.kafka.connect.source.SourceConnector {
   public static final String TOPICS_KEY = "topics";
 
-  protected abstract void init(Configuration configuration, MetadataStorage storage);
+  protected abstract void init(Configuration configuration, SourceContext context);
 
   protected abstract Class<? extends SourceTask> task();
 
@@ -40,7 +40,7 @@ public abstract class SourceConnector extends org.apache.kafka.connect.source.So
   // -------------------------[final]-------------------------//
   @Override
   public final void start(Map<String, String> props) {
-    init(new Configuration(props), MetadataStorage.of(context().offsetStorageReader()));
+    init(new Configuration(props), SourceContext.of(context()));
   }
 
   @Override

--- a/connector/src/main/java/org/astraea/connector/SourceContext.java
+++ b/connector/src/main/java/org/astraea/connector/SourceContext.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.connector;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public interface SourceContext {
+
+  SourceContext EMPTY =
+      new SourceContext() {
+        @Override
+        public void raiseError(Exception e) {}
+
+        @Override
+        public Map<String, String> metadata(Map<String, String> index) {
+          return Map.of();
+        }
+      };
+
+  static SourceContext of(org.apache.kafka.connect.source.SourceConnectorContext context) {
+    return new SourceContext() {
+      @Override
+      public void raiseError(Exception e) {
+        context.raiseError(e);
+      }
+
+      @Override
+      public Map<String, String> metadata(Map<String, String> index) {
+        var v = context.offsetStorageReader().offset(index);
+        if (v == null) return Map.of();
+        return v.entrySet().stream()
+            .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> e.getValue().toString()));
+      }
+    };
+  }
+
+  /** {@link org.apache.kafka.connect.source.SourceConnectorContext#raiseError(Exception)} */
+  void raiseError(Exception e);
+
+  Map<String, String> metadata(Map<String, String> index);
+}

--- a/connector/src/main/java/org/astraea/connector/SourceTask.java
+++ b/connector/src/main/java/org/astraea/connector/SourceTask.java
@@ -19,6 +19,7 @@ package org.astraea.connector;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Schema;
 import org.astraea.common.Configuration;
@@ -28,7 +29,7 @@ import org.astraea.common.producer.Record;
 
 public abstract class SourceTask extends org.apache.kafka.connect.source.SourceTask {
 
-  protected abstract void init(Configuration configuration, MetadataStorage storage);
+  protected abstract void init(Configuration configuration, SourceTaskContext storage);
 
   /**
    * use {@link Record#builder()} or {@link SourceRecord#builder()} to construct the returned
@@ -52,7 +53,7 @@ public abstract class SourceTask extends org.apache.kafka.connect.source.SourceT
 
   @Override
   public final void start(Map<String, String> props) {
-    init(new Configuration(props), MetadataStorage.of(context.offsetStorageReader()));
+    init(new Configuration(props), SourceTaskContext.of(Objects.requireNonNull(context)));
   }
 
   @Override

--- a/connector/src/main/java/org/astraea/connector/SourceTaskContext.java
+++ b/connector/src/main/java/org/astraea/connector/SourceTaskContext.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.astraea.connector;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public interface SourceTaskContext {
+
+  SourceTaskContext EMPTY = ignored -> Map.of();
+
+  static SourceTaskContext of(org.apache.kafka.connect.source.SourceTaskContext context) {
+    return index -> {
+      var v = context.offsetStorageReader().offset(index);
+      if (v == null) return Map.of();
+      return v.entrySet().stream()
+          .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> e.getValue().toString()));
+    };
+  }
+
+  Map<String, String> metadata(Map<String, String> index);
+}

--- a/connector/src/main/java/org/astraea/connector/backup/Exporter.java
+++ b/connector/src/main/java/org/astraea/connector/backup/Exporter.java
@@ -37,6 +37,7 @@ import org.astraea.common.backup.RecordWriter;
 import org.astraea.common.consumer.Record;
 import org.astraea.connector.Definition;
 import org.astraea.connector.SinkConnector;
+import org.astraea.connector.SinkContext;
 import org.astraea.connector.SinkTask;
 import org.astraea.fs.FileSystem;
 
@@ -123,7 +124,7 @@ public class Exporter extends SinkConnector {
   private Configuration configs;
 
   @Override
-  protected void init(Configuration configuration) {
+  protected void init(Configuration configuration, SinkContext context) {
     this.configs = configuration;
   }
 

--- a/connector/src/main/java/org/astraea/connector/backup/Importer.java
+++ b/connector/src/main/java/org/astraea/connector/backup/Importer.java
@@ -32,10 +32,11 @@ import org.astraea.common.Utils;
 import org.astraea.common.backup.RecordReader;
 import org.astraea.common.backup.RecordWriter;
 import org.astraea.connector.Definition;
-import org.astraea.connector.MetadataStorage;
 import org.astraea.connector.SourceConnector;
+import org.astraea.connector.SourceContext;
 import org.astraea.connector.SourceRecord;
 import org.astraea.connector.SourceTask;
+import org.astraea.connector.SourceTaskContext;
 import org.astraea.fs.FileSystem;
 import org.astraea.fs.Type;
 
@@ -98,7 +99,7 @@ public class Importer extends SourceConnector {
   private Configuration config;
 
   @Override
-  protected void init(Configuration configuration, MetadataStorage storage) {
+  protected void init(Configuration configuration, SourceContext context) {
     this.config = configuration;
   }
 
@@ -143,7 +144,7 @@ public class Importer extends SourceConnector {
     private String cleanSource;
     private Optional<String> archiveDir;
 
-    protected void init(Configuration configuration, MetadataStorage storage) {
+    protected void init(Configuration configuration, SourceTaskContext storage) {
       this.Client = FileSystem.of(configuration.requireString(SCHEMA_KEY.name()), configuration);
       this.fileSet = configuration.requireInteger(FILE_SET_KEY);
       this.addedPaths = new HashSet<>();

--- a/connector/src/main/java/org/astraea/connector/perf/PerfSink.java
+++ b/connector/src/main/java/org/astraea/connector/perf/PerfSink.java
@@ -24,6 +24,7 @@ import org.astraea.common.Utils;
 import org.astraea.common.consumer.Record;
 import org.astraea.connector.Definition;
 import org.astraea.connector.SinkConnector;
+import org.astraea.connector.SinkContext;
 import org.astraea.connector.SinkTask;
 
 public class PerfSink extends SinkConnector {
@@ -41,7 +42,7 @@ public class PerfSink extends SinkConnector {
   private Configuration config;
 
   @Override
-  protected void init(Configuration configuration) {
+  protected void init(Configuration configuration, SinkContext context) {
     this.config = configuration;
   }
 

--- a/connector/src/main/java/org/astraea/connector/perf/PerfSource.java
+++ b/connector/src/main/java/org/astraea/connector/perf/PerfSource.java
@@ -31,10 +31,11 @@ import org.astraea.common.Utils;
 import org.astraea.common.admin.TopicPartition;
 import org.astraea.common.producer.RecordGenerator;
 import org.astraea.connector.Definition;
-import org.astraea.connector.MetadataStorage;
 import org.astraea.connector.SourceConnector;
+import org.astraea.connector.SourceContext;
 import org.astraea.connector.SourceRecord;
 import org.astraea.connector.SourceTask;
+import org.astraea.connector.SourceTaskContext;
 
 public class PerfSource extends SourceConnector {
 
@@ -146,7 +147,7 @@ public class PerfSource extends SourceConnector {
   private Configuration config;
 
   @Override
-  protected void init(Configuration configuration, MetadataStorage storage) {
+  protected void init(Configuration configuration, SourceContext context) {
     this.config = configuration;
   }
 
@@ -198,7 +199,7 @@ public class PerfSource extends SourceConnector {
     RecordGenerator recordGenerator = null;
 
     @Override
-    protected void init(Configuration configuration, MetadataStorage storage) {
+    protected void init(Configuration configuration, SourceTaskContext storage) {
       var throughput =
           configuration.string(THROUGHPUT_DEF.name()).map(DataSize::of).orElse(THROUGHPUT_DEFAULT);
       var KeySize =

--- a/connector/src/test/java/org/astraea/connector/ConnectorTest.java
+++ b/connector/src/test/java/org/astraea/connector/ConnectorTest.java
@@ -109,7 +109,7 @@ public class ConnectorTest {
     private static final AtomicInteger CLOSE_COUNT = new AtomicInteger(0);
 
     @Override
-    protected void init(Configuration configuration, MetadataStorage storage) {
+    protected void init(Configuration configuration, SourceContext context) {
       INIT_COUNT.incrementAndGet();
     }
 
@@ -141,7 +141,7 @@ public class ConnectorTest {
     private static final AtomicInteger CLOSE_COUNT = new AtomicInteger(0);
 
     @Override
-    protected void init(Configuration configuration, MetadataStorage storage) {
+    protected void init(Configuration configuration, SourceTaskContext storage) {
       INIT_COUNT.incrementAndGet();
     }
 

--- a/connector/src/test/java/org/astraea/connector/MetadataStorageTest.java
+++ b/connector/src/test/java/org/astraea/connector/MetadataStorageTest.java
@@ -103,9 +103,9 @@ public class MetadataStorageTest {
     private Configuration configuration;
 
     @Override
-    protected void init(Configuration configuration, MetadataStorage storage) {
+    protected void init(Configuration configuration, SourceContext context) {
       this.configuration = configuration;
-      FETCHED_METADATA = storage.metadata(KEY);
+      FETCHED_METADATA = context.metadata(KEY);
     }
 
     @Override
@@ -132,7 +132,7 @@ public class MetadataStorageTest {
     private Set<String> topics = Set.of();
 
     @Override
-    protected void init(Configuration configuration, MetadataStorage storage) {
+    protected void init(Configuration configuration, SourceTaskContext storage) {
       topics = Set.copyOf(configuration.list(ConnectorConfigs.TOPICS_KEY, ","));
       FETCHED_METADATA = storage.metadata(KEY);
     }

--- a/connector/src/test/java/org/astraea/connector/SourceDataTest.java
+++ b/connector/src/test/java/org/astraea/connector/SourceDataTest.java
@@ -116,7 +116,7 @@ public class SourceDataTest {
     private Configuration configuration = Configuration.EMPTY;
 
     @Override
-    protected void init(Configuration configuration, MetadataStorage storage) {
+    protected void init(Configuration configuration, SourceContext context) {
       this.configuration = configuration;
     }
 
@@ -142,7 +142,7 @@ public class SourceDataTest {
     private boolean isDone = false;
 
     @Override
-    protected void init(Configuration configuration, MetadataStorage storage) {
+    protected void init(Configuration configuration, SourceTaskContext context) {
       topics = Set.copyOf(configuration.list(ConnectorConfigs.TOPICS_KEY, ","));
     }
 

--- a/connector/src/test/java/org/astraea/connector/backup/ImporterTest.java
+++ b/connector/src/test/java/org/astraea/connector/backup/ImporterTest.java
@@ -29,7 +29,7 @@ import org.astraea.common.connector.Config;
 import org.astraea.common.connector.ConnectorClient;
 import org.astraea.common.connector.Value;
 import org.astraea.common.consumer.Record;
-import org.astraea.connector.MetadataStorage;
+import org.astraea.connector.SourceTaskContext;
 import org.astraea.fs.FileSystem;
 import org.astraea.it.FtpServer;
 import org.astraea.it.Service;
@@ -150,7 +150,7 @@ public class ImporterTest {
       records.forEach(writer::append);
       writer.close();
 
-      task.init(new Configuration(configs), MetadataStorage.EMPTY);
+      task.init(new Configuration(configs), SourceTaskContext.EMPTY);
       var returnRecords = new ArrayList<>(task.take());
 
       for (int i = 0; i < records.size(); i++) {

--- a/connector/src/test/java/org/astraea/connector/perf/PerfSourceTest.java
+++ b/connector/src/test/java/org/astraea/connector/perf/PerfSourceTest.java
@@ -30,8 +30,9 @@ import org.astraea.common.connector.ConnectorClient;
 import org.astraea.common.connector.ConnectorConfigs;
 import org.astraea.common.metrics.JndiClient;
 import org.astraea.common.metrics.connector.ConnectorMetrics;
-import org.astraea.connector.MetadataStorage;
 import org.astraea.connector.SourceConnector;
+import org.astraea.connector.SourceContext;
+import org.astraea.connector.SourceTaskContext;
 import org.astraea.it.Service;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -51,7 +52,7 @@ public class PerfSourceTest {
   void testDistributeConfigs() {
     var s = new PerfSource();
     var config = new Configuration(Map.of(SourceConnector.TOPICS_KEY, "a,b,c,d"));
-    s.init(config, MetadataStorage.EMPTY);
+    s.init(config, SourceContext.EMPTY);
     var configs = s.takeConfiguration(10);
     Assertions.assertEquals(4, configs.size());
     Assertions.assertEquals("a", configs.get(0).requireString(SourceConnector.TOPICS_KEY));
@@ -331,7 +332,7 @@ public class PerfSourceTest {
   @Test
   void testInit() {
     var task = new PerfSource.Task();
-    task.init(new Configuration(Map.of(ConnectorConfigs.TOPICS_KEY, "a")), MetadataStorage.EMPTY);
+    task.init(new Configuration(Map.of(ConnectorConfigs.TOPICS_KEY, "a")), SourceTaskContext.EMPTY);
     Assertions.assertNotNull(task.recordGenerator);
     Assertions.assertEquals(1, task.specifyPartitions.size());
   }
@@ -348,7 +349,7 @@ public class PerfSourceTest {
                 "uniform",
                 PerfSource.VALUE_DISTRIBUTION_DEF.name(),
                 "uniform")),
-        MetadataStorage.EMPTY);
+        SourceTaskContext.EMPTY);
     var records = task.take();
     var keySizes =
         records.stream().map(r -> r.key().length).collect(Collectors.toUnmodifiableSet());
@@ -364,7 +365,7 @@ public class PerfSourceTest {
     task.init(
         new Configuration(
             Map.of(ConnectorConfigs.TOPICS_KEY, "a", PerfSource.KEY_SIZE_DEF.name(), "0Byte")),
-        MetadataStorage.EMPTY);
+        SourceTaskContext.EMPTY);
     var records = task.take();
     Assertions.assertNotEquals(0, records.size());
     records.forEach(r -> Assertions.assertNull(r.key()));
@@ -376,7 +377,7 @@ public class PerfSourceTest {
     task.init(
         new Configuration(
             Map.of(ConnectorConfigs.TOPICS_KEY, "a", PerfSource.VALUE_SIZE_DEF.name(), "0Byte")),
-        MetadataStorage.EMPTY);
+        SourceTaskContext.EMPTY);
     var records = task.take();
     Assertions.assertNotEquals(0, records.size());
     records.forEach(r -> Assertions.assertNull(r.value()));


### PR DESCRIPTION
一次把所有 context 放進去給 source/sink，這樣之後就不需要再調整介面了