### PR TITLE
[FS] Using try-with-resources with Files.list() in local listFolders

### DIFF
--- a/fs/src/main/java/org/astraea/fs/local/LocalFileSystem.java
+++ b/fs/src/main/java/org/astraea/fs/local/LocalFileSystem.java
@@ -72,6 +72,10 @@ public class LocalFileSystem implements FileSystem {
   private synchronized List<String> listFolders(String path, boolean requireFile) {
     var folder = resolvePath(path);
     if (!Files.isDirectory(folder)) throw new IllegalArgumentException(path + " is not a folder");
+    // We use this method within a try-with-resources statement to ensure that the stream's open
+    // directory is closed promptly after the stream's operations have completed.
+    // See
+    // https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/file/Files.html#list(java.nio.file.Path)
     try (var directories = Utils.packException(() -> Files.list(folder))) {
       return directories
           .filter(f -> requireFile ? Files.isRegularFile(f) : Files.isDirectory(f))

--- a/fs/src/main/java/org/astraea/fs/local/LocalFileSystem.java
+++ b/fs/src/main/java/org/astraea/fs/local/LocalFileSystem.java
@@ -26,7 +26,6 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.astraea.common.Configuration;
 import org.astraea.common.Utils;
 import org.astraea.fs.FileSystem;
@@ -73,17 +72,19 @@ public class LocalFileSystem implements FileSystem {
   private synchronized List<String> listFolders(String path, boolean requireFile) {
     var folder = resolvePath(path);
     if (!Files.isDirectory(folder)) throw new IllegalArgumentException(path + " is not a folder");
-    return Utils.packException(() -> Files.list(folder))
-        .filter(f -> requireFile ? Files.isRegularFile(f) : Files.isDirectory(f))
-        .map(Path::toAbsolutePath)
-        .map(
-            p ->
-                Path.of("/")
-                    .resolve(
-                        root.map(r -> p.subpath(Path.of(r).getNameCount(), p.getNameCount()))
-                            .orElse(p))
-                    .toString())
-        .collect(Collectors.toList());
+    try (var directories = Utils.packException(() -> Files.list(folder))) {
+      return directories
+          .filter(f -> requireFile ? Files.isRegularFile(f) : Files.isDirectory(f))
+          .map(Path::toAbsolutePath)
+          .map(
+              p ->
+                  Path.of("/")
+                      .resolve(
+                          root.map(r -> p.subpath(Path.of(r).getNameCount(), p.getNameCount()))
+                              .orElse(p))
+                      .toString())
+          .toList();
+    }
   }
 
   @Override


### PR DESCRIPTION
fix #1801

此 Pr 透過 try-with-resources 的方式，確保 `Files.list()` 能在 `Stream` 完成後自動關閉。
有再透過 Importer 測試，不會有`Too many open files`錯誤。