### PR TITLE
[EXPORTER] Close fs in Task.close()

### DIFF
--- a/connector/src/main/java/org/astraea/connector/backup/Exporter.java
+++ b/connector/src/main/java/org/astraea/connector/backup/Exporter.java
@@ -408,7 +408,7 @@ public class Exporter extends SinkConnector {
     protected void close() {
       this.closed.set(true);
       Utils.packException(() -> writerFuture.toCompletableFuture().get(10, TimeUnit.SECONDS));
-      this.fs.close();
+      Utils.close(this.fs);
     }
 
     boolean isWriterDone() {

--- a/connector/src/main/java/org/astraea/connector/backup/Exporter.java
+++ b/connector/src/main/java/org/astraea/connector/backup/Exporter.java
@@ -408,6 +408,7 @@ public class Exporter extends SinkConnector {
     protected void close() {
       this.closed.set(true);
       Utils.packException(() -> writerFuture.toCompletableFuture().get(10, TimeUnit.SECONDS));
+      this.fs.close();
     }
 
     boolean isWriterDone() {


### PR DESCRIPTION
修正關閉 task 時沒有將 field fs 關閉的問題，這會導致即便刪除 connector 還是會佔用 filesystem 的連線數。