### PR TITLE
[EXPORTER] Fix the size in RecordWriter never be updated

### DIFF
--- a/common/src/main/java/org/astraea/common/backup/RecordWriterBuilder.java
+++ b/common/src/main/java/org/astraea/common/backup/RecordWriterBuilder.java
@@ -44,34 +44,37 @@ public class RecordWriterBuilder {
             @Override
             public void append(Record<byte[], byte[]> record) {
               Utils.packException(
-                  () ->
-                      RecordOuterClass.Record.newBuilder()
-                          .setTopic(record.topic())
-                          .setPartition(record.partition())
-                          .setOffset(record.offset())
-                          .setTimestamp(record.timestamp())
-                          .setKey(
-                              record.key() == null
-                                  ? ByteString.EMPTY
-                                  : ByteString.copyFrom(record.key()))
-                          .setValue(
-                              record.value() == null
-                                  ? ByteString.EMPTY
-                                  : ByteString.copyFrom(record.value()))
-                          .addAllHeaders(
-                              record.headers().stream()
-                                  .map(
-                                      header ->
-                                          RecordOuterClass.Record.Header.newBuilder()
-                                              .setKey(header.key())
-                                              .setValue(
-                                                  header.value() == null
-                                                      ? ByteString.EMPTY
-                                                      : ByteString.copyFrom(header.value()))
-                                              .build())
-                                  .toList())
-                          .build()
-                          .writeDelimitedTo(outputStream));
+                  () -> {
+                    var recordBuilder =
+                        RecordOuterClass.Record.newBuilder()
+                            .setTopic(record.topic())
+                            .setPartition(record.partition())
+                            .setOffset(record.offset())
+                            .setTimestamp(record.timestamp())
+                            .setKey(
+                                record.key() == null
+                                    ? ByteString.EMPTY
+                                    : ByteString.copyFrom(record.key()))
+                            .setValue(
+                                record.value() == null
+                                    ? ByteString.EMPTY
+                                    : ByteString.copyFrom(record.value()))
+                            .addAllHeaders(
+                                record.headers().stream()
+                                    .map(
+                                        header ->
+                                            RecordOuterClass.Record.Header.newBuilder()
+                                                .setKey(header.key())
+                                                .setValue(
+                                                    header.value() == null
+                                                        ? ByteString.EMPTY
+                                                        : ByteString.copyFrom(header.value()))
+                                                .build())
+                                    .toList())
+                            .build();
+                    recordBuilder.writeDelimitedTo(outputStream);
+                    this.size.add(recordBuilder.getSerializedSize());
+                  });
               count.incrementAndGet();
               this.latestAppendTimestamp.set(System.currentTimeMillis());
             }

--- a/connector/src/test/java/org/astraea/connector/backup/ExporterTest.java
+++ b/connector/src/test/java/org/astraea/connector/backup/ExporterTest.java
@@ -784,6 +784,8 @@ public class ExporterTest {
 
       writers.put(tp, recordWriter);
 
+      Assertions.assertEquals(DataSize.ZERO, recordWriter.size());
+
       recordWriter.append(
           Record.builder()
               .topic(topicName)
@@ -793,6 +795,8 @@ public class ExporterTest {
               .offset(0)
               .timestamp(System.currentTimeMillis())
               .build());
+
+      Assertions.assertNotEquals(DataSize.ZERO, recordWriter.size());
 
       task.removeOldWriters(writers);
 

--- a/connector/src/test/java/org/astraea/connector/backup/ExporterTest.java
+++ b/connector/src/test/java/org/astraea/connector/backup/ExporterTest.java
@@ -465,15 +465,25 @@ public class ExporterTest {
               Record.builder()
                   .topic(topicName)
                   .key("test".getBytes())
-                  .value("test0".getBytes())
+                  .value(Utils.randomString(1024).getBytes())
                   .partition(0)
+                  .offset(0)
                   .timestamp(System.currentTimeMillis())
                   .build(),
               Record.builder()
                   .topic(topicName)
                   .key("test".getBytes())
-                  .value("test1".getBytes())
+                  .value("test".getBytes())
+                  .partition(0)
+                  .offset(1)
+                  .timestamp(System.currentTimeMillis())
+                  .build(),
+              Record.builder()
+                  .topic(topicName)
+                  .key("test".getBytes())
+                  .value("test".getBytes())
                   .partition(1)
+                  .offset(0)
                   .timestamp(System.currentTimeMillis())
                   .build());
 
@@ -489,6 +499,10 @@ public class ExporterTest {
 
       Assertions.assertEquals(
           2, fs.listFolders("/" + String.join("/", fileSize, topicName)).size());
+      Assertions.assertEquals(
+          2, fs.listFiles("/" + String.join("/", fileSize, topicName, "0")).size());
+      Assertions.assertEquals(
+          1, fs.listFiles("/" + String.join("/", fileSize, topicName, "1")).size());
 
       records.forEach(
           sinkRecord -> {


### PR DESCRIPTION
RecordWriter 中的 size 在 append 中寫入到檔案後並沒有將寫入的內容大小更新到 size 之中，導致後續在判斷是否需要切檔案時始終判斷寫入檔案並沒有超過設定值而持續寫入同一檔案。
因此在 append 中將 `recordBuilder` 的 serializedSize 計算到 size 之中以避免上述狀況，並新增相關的測試來確認是否有這問題的發生。