### PR TITLE
[EXPORTER] Add support for gzip compression

### DIFF
--- a/common/src/main/java/org/astraea/common/backup/RecordWriterBuilder.java
+++ b/common/src/main/java/org/astraea/common/backup/RecordWriterBuilder.java
@@ -18,7 +18,6 @@ package org.astraea.common.backup;
 
 import com.google.protobuf.ByteString;
 import java.io.BufferedOutputStream;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -119,8 +118,17 @@ public class RecordWriterBuilder {
     this.fs = outputStream;
   }
 
-  public RecordWriterBuilder compression() throws IOException {
-    this.fs = new GZIPOutputStream(this.fs);
+  public RecordWriterBuilder compression(String type) {
+    switch (type) {
+      case "gzip":
+        this.fs = Utils.packException(() -> new GZIPOutputStream(this.fs));
+        break;
+      case "none":
+        // do nothing.
+        break;
+      default:
+        throw new IllegalArgumentException("unsupported compression type: " + type);
+    }
     return this;
   }
 

--- a/connector/src/main/java/org/astraea/connector/backup/Exporter.java
+++ b/connector/src/main/java/org/astraea/connector/backup/Exporter.java
@@ -312,7 +312,10 @@ public class Exporter extends SinkConnector {
               .bytes();
       this.taskContext = context;
       this.compressionType =
-          configuration.string(COMPRESSION_TYPE_KEY.name()).orElse(COMPRESSION_TYPE_DEFAULT);
+          configuration
+              .string(COMPRESSION_TYPE_KEY.name())
+              .orElse(COMPRESSION_TYPE_DEFAULT)
+              .toLowerCase();
 
       // fetches key-value pairs from the configuration's variable matching the regular expression
       // '.*offset.from', updates the values of 'offsetForTopic' or 'offsetForTopicPartition' based

--- a/connector/src/test/java/org/astraea/connector/backup/ExporterTest.java
+++ b/connector/src/test/java/org/astraea/connector/backup/ExporterTest.java
@@ -777,6 +777,7 @@ public class ExporterTest {
       var task = new Exporter.Task();
       task.fs = FileSystem.of("hdfs", new Configuration(configs));
       task.interval = 1000;
+      task.compressionType = "none";
 
       RecordWriter recordWriter = task.createRecordWriter(tp, offset);
 
@@ -841,6 +842,7 @@ public class ExporterTest {
 
       var task = new Exporter.Task();
       task.fs = FileSystem.of("hdfs", new Configuration(configs));
+      task.compressionType = "none";
       task.size = DataSize.of("100MB");
       task.bufferSize.reset();
       task.recordsQueue.add(

--- a/connector/src/test/java/org/astraea/connector/backup/ExporterTest.java
+++ b/connector/src/test/java/org/astraea/connector/backup/ExporterTest.java
@@ -950,4 +950,67 @@ public class ExporterTest {
       Assertions.assertEquals(1, task.seekOffset.size());
     }
   }
+
+  @Test
+  void testCompression() {
+    try (var server = HdfsServer.local()) {
+      var fileSize = "500Byte";
+      var topicName = Utils.randomString(10);
+
+      var task = new Exporter.Task();
+      var configs =
+          Map.of(
+              "fs.schema",
+              "hdfs",
+              "topics",
+              topicName,
+              "fs.hdfs.hostname",
+              String.valueOf(server.hostname()),
+              "fs.hdfs.port",
+              String.valueOf(server.port()),
+              "fs.hdfs.user",
+              String.valueOf(server.user()),
+              "path",
+              "/" + fileSize,
+              "size",
+              fileSize,
+              "fs.hdfs.override.dfs.client.use.datanode.hostname",
+              "true",
+              "compression.type",
+              "gzip");
+
+      task.start(configs);
+
+      var records =
+          List.of(
+              Record.builder()
+                  .topic(topicName)
+                  .key("test".getBytes())
+                  .value("test value".getBytes())
+                  .partition(0)
+                  .offset(0)
+                  .timestamp(System.currentTimeMillis())
+                  .build(),
+              Record.builder()
+                  .topic(topicName)
+                  .key("test".getBytes())
+                  .value("test value".getBytes())
+                  .partition(0)
+                  .offset(1)
+                  .timestamp(System.currentTimeMillis())
+                  .build());
+
+      task.put(records);
+
+      Utils.sleep(Duration.ofMillis(1000));
+
+      task.close();
+      var fs = FileSystem.of("hdfs", new Configuration(configs));
+
+      var input = fs.read("/" + String.join("/", fileSize, topicName, "0/0"));
+
+      Assertions.assertArrayEquals(
+          new byte[] {(byte) 0x1f, (byte) 0x8b}, Utils.packException(() -> input.readNBytes(2)));
+    }
+  }
 }


### PR DESCRIPTION
#1822 
目前增加參數 `compression.type` 使的 exporter 支援 gzip 壓縮方法，未來支援其他的壓縮演算法可以透過這個參數設定。
目前在建立 gzip 壓縮檔按時，有發現文件內容開頭會是 `1f 8b` ，因此沒有在針對寫出的檔案附加上 gzip 結尾。