### PR TITLE
[EXPORTER] Add metadata in record writer

### DIFF
--- a/common/src/main/java/org/astraea/common/backup/RecordReaderBuilder.java
+++ b/common/src/main/java/org/astraea/common/backup/RecordReaderBuilder.java
@@ -107,7 +107,7 @@ public class RecordReaderBuilder {
 
   public RecordReader build() {
     var version = ByteUtils.readShort(fs);
-    if (version == 0 || version == 1 ) return V0.apply(fs);
+    if (version == 0 || version == 1) return V0.apply(fs);
 
     throw new IllegalArgumentException("unsupported version: " + version);
   }

--- a/common/src/main/java/org/astraea/common/backup/RecordWriter.java
+++ b/common/src/main/java/org/astraea/common/backup/RecordWriter.java
@@ -53,7 +53,7 @@ public interface RecordWriter extends AutoCloseable {
   }
 
   static RecordWriterBuilder builder(OutputStream outputStream) {
-    return new RecordWriterBuilder(RecordWriterBuilder.LATEST_VERSION, outputStream);
+    return new RecordWriterBuilder((short) 0, outputStream);
   }
 
   static RecordWriterBuilder builder(

--- a/common/src/main/java/org/astraea/common/backup/RecordWriter.java
+++ b/common/src/main/java/org/astraea/common/backup/RecordWriter.java
@@ -19,6 +19,7 @@ package org.astraea.common.backup;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
+import org.astraea.common.Configuration;
 import org.astraea.common.DataSize;
 import org.astraea.common.Utils;
 import org.astraea.common.consumer.Record;
@@ -53,5 +54,11 @@ public interface RecordWriter extends AutoCloseable {
 
   static RecordWriterBuilder builder(OutputStream outputStream) {
     return new RecordWriterBuilder(RecordWriterBuilder.LATEST_VERSION, outputStream);
+  }
+
+  static RecordWriterBuilder builder(
+      OutputStream outputStream, Configuration configuration, Record record) {
+    return new RecordWriterBuilder(
+        RecordWriterBuilder.LATEST_VERSION, outputStream, configuration, record);
   }
 }

--- a/common/src/main/java/org/astraea/common/backup/RecordWriter.java
+++ b/common/src/main/java/org/astraea/common/backup/RecordWriter.java
@@ -56,9 +56,7 @@ public interface RecordWriter extends AutoCloseable {
     return new RecordWriterBuilder((short) 0, outputStream);
   }
 
-  static RecordWriterBuilder builder(
-      OutputStream outputStream, Configuration configuration, Record record) {
-    return new RecordWriterBuilder(
-        RecordWriterBuilder.LATEST_VERSION, outputStream, configuration, record);
+  static RecordWriterBuilder builder(OutputStream outputStream, Configuration configuration) {
+    return new RecordWriterBuilder(RecordWriterBuilder.LATEST_VERSION, outputStream, configuration);
   }
 }

--- a/common/src/main/java/org/astraea/common/backup/RecordWriterBuilder.java
+++ b/common/src/main/java/org/astraea/common/backup/RecordWriterBuilder.java
@@ -19,26 +19,90 @@ package org.astraea.common.backup;
 import com.google.protobuf.ByteString;
 import java.io.BufferedOutputStream;
 import java.io.OutputStream;
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
-import java.util.function.Function;
 import java.util.zip.GZIPOutputStream;
 import org.astraea.common.ByteUtils;
+import org.astraea.common.Configuration;
 import org.astraea.common.DataSize;
 import org.astraea.common.Utils;
 import org.astraea.common.consumer.Record;
+import org.astraea.common.function.Bi3Function;
 import org.astraea.common.generated.RecordOuterClass;
 
 public class RecordWriterBuilder {
 
-  private static final Function<OutputStream, RecordWriter> V0 =
-      outputStream ->
+  private static final Bi3Function<Configuration, Record, OutputStream, RecordWriter> V0 =
+      (configuration, record, outputStream) ->
           new RecordWriter() {
             private final AtomicInteger count = new AtomicInteger();
             private final LongAdder size = new LongAdder();
-
             private final AtomicLong latestAppendTimestamp = new AtomicLong();
+            private final String connectorName;
+            private final Long interval;
+            private final String compressionType;
+            private OutputStream targetOutputStream;
+
+            // instance initializer block
+            {
+              this.connectorName = configuration.requireString("connector.name");
+              this.interval =
+                  configuration
+                      .string("roll.duration")
+                      .map(Utils::toDuration)
+                      .orElse(Duration.ofSeconds(3))
+                      .toMillis();
+              this.compressionType = configuration.string("compression.type").orElse("none");
+
+              switch (this.compressionType) {
+                case "gzip" -> Utils.packException(
+                    () -> this.targetOutputStream = new GZIPOutputStream(outputStream));
+                case "none" -> this.targetOutputStream = outputStream;
+                default -> throw new IllegalArgumentException(
+                    String.format("compression type '%s' is not supported", this.compressionType));
+              }
+            }
+
+            byte[] extendString(String input, int length) {
+              byte[] original = input.getBytes();
+              byte[] result = new byte[length];
+              System.arraycopy(original, 0, result, 0, original.length);
+              for (int i = original.length; i < result.length; i++) {
+                result[i] = (byte) ' ';
+              }
+              return result;
+            }
+
+            void appendMetadata() {
+              Utils.packException(
+                  () -> {
+                    if (this.compressionType.equals("gzip")) {
+                      ((GZIPOutputStream) targetOutputStream).finish();
+                    }
+
+                    // 552 Bytes total for whole metadata.
+                    outputStream.write(
+                        this.extendString(
+                            this.connectorName, 255)); // 255 Bytes for this connector name
+                    outputStream.write(
+                        this.extendString(record.topic(), 255)); // 255 Bytes for topic name
+                    // 42 Bytes
+                    outputStream.write(
+                        ByteUtils.toBytes(record.partition())); // 4 Bytes for partition
+                    outputStream.write(
+                        ByteUtils.toBytes(record.offset())); // 8 bytes for 1st record offset
+                    outputStream.write(
+                        ByteUtils.toBytes(record.timestamp())); // 8 bytes for 1st record timestamp
+                    outputStream.write(ByteUtils.toBytes(this.count())); // 4 Bytes for count
+                    outputStream.write(
+                        ByteUtils.toBytes(this.interval)); // 8 Bytes for mills of roll.duration
+                    outputStream.write(
+                        this.extendString(
+                            this.compressionType, 10)); // 10 Bytes for compression type name.
+                  });
+            }
 
             @Override
             public void append(Record<byte[], byte[]> record) {
@@ -71,16 +135,11 @@ public class RecordWriterBuilder {
                                                 .build())
                                     .toList())
                             .build();
-                    recordBuilder.writeDelimitedTo(outputStream);
+                    recordBuilder.writeDelimitedTo(this.targetOutputStream);
                     this.size.add(recordBuilder.getSerializedSize());
                   });
               count.incrementAndGet();
               this.latestAppendTimestamp.set(System.currentTimeMillis());
-            }
-
-            @Override
-            public long latestAppendTimestamp() {
-              return this.latestAppendTimestamp.get();
             }
 
             @Override
@@ -99,9 +158,15 @@ public class RecordWriterBuilder {
             }
 
             @Override
+            public long latestAppendTimestamp() {
+              return this.latestAppendTimestamp.get();
+            }
+
+            @Override
             public void close() {
               Utils.packException(
                   () -> {
+                    appendMetadata();
                     outputStream.flush();
                     outputStream.close();
                   });
@@ -112,24 +177,20 @@ public class RecordWriterBuilder {
 
   private final short version;
   private OutputStream fs;
+  private Configuration configuration;
+  private Record record;
 
   RecordWriterBuilder(short version, OutputStream outputStream) {
     this.version = version;
     this.fs = outputStream;
   }
 
-  public RecordWriterBuilder compression(String type) {
-    switch (type) {
-      case "gzip":
-        this.fs = Utils.packException(() -> new GZIPOutputStream(this.fs));
-        break;
-      case "none":
-        // do nothing.
-        break;
-      default:
-        throw new IllegalArgumentException("unsupported compression type: " + type);
-    }
-    return this;
+  RecordWriterBuilder(
+      short version, OutputStream outputStream, Configuration configuration, Record record) {
+    this.version = version;
+    this.fs = outputStream;
+    this.configuration = configuration;
+    this.record = record;
   }
 
   public RecordWriterBuilder buffered() {
@@ -147,7 +208,7 @@ public class RecordWriterBuilder {
         () -> {
           if (version == 0) {
             fs.write(ByteUtils.toBytes(version));
-            return V0.apply(fs);
+            return V0.apply(this.configuration, this.record, fs);
           }
           throw new IllegalArgumentException("unsupported version: " + version);
         });

--- a/common/src/main/java/org/astraea/common/backup/RecordWriterBuilder.java
+++ b/common/src/main/java/org/astraea/common/backup/RecordWriterBuilder.java
@@ -20,7 +20,6 @@ import com.google.protobuf.ByteString;
 import java.io.BufferedOutputStream;
 import java.io.OutputStream;
 import java.time.Duration;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;

--- a/connector/src/main/java/org/astraea/connector/SinkTaskContext.java
+++ b/connector/src/main/java/org/astraea/connector/SinkTaskContext.java
@@ -37,6 +37,11 @@ public interface SinkTaskContext {
 
         @Override
         public void requestCommit() {}
+
+        @Override
+        public Map<String, String> configs() {
+          return null;
+        }
       };
 
   /**
@@ -67,6 +72,8 @@ public interface SinkTaskContext {
    */
   void requestCommit();
 
+  Map<String, String> configs();
+
   static SinkTaskContext of(org.apache.kafka.connect.sink.SinkTaskContext context) {
     return new SinkTaskContext() {
       @Override
@@ -94,6 +101,12 @@ public interface SinkTaskContext {
       public void requestCommit() {
         context.requestCommit();
       }
+
+      @Override
+      public Map<String, String> configs() {
+        return context.configs();
+      }
+      ;
     };
   }
 }

--- a/connector/src/main/java/org/astraea/connector/backup/Exporter.java
+++ b/connector/src/main/java/org/astraea/connector/backup/Exporter.java
@@ -215,8 +215,7 @@ public class Exporter extends SinkConnector {
               fs.write(
                   String.join(
                       "/", path, record.topic(), String.valueOf(record.partition()), fileName)),
-              configuration,
-              record)
+              configuration)
           .build();
     }
 
@@ -226,8 +225,7 @@ public class Exporter extends SinkConnector {
               fs.write(
                   String.join(
                       "/", path, record.topic(), String.valueOf(record.partition()), fileName)),
-              this.configuration,
-              record)
+              this.configuration)
           .build();
     }
 

--- a/connector/src/test/java/org/astraea/connector/backup/ExporterTest.java
+++ b/connector/src/test/java/org/astraea/connector/backup/ExporterTest.java
@@ -300,7 +300,7 @@ public class ExporterTest {
 
       var fs = FileSystem.of("ftp", new Configuration(configs));
 
-      task.start(configs);
+      task.init(new Configuration(configs), context);
 
       var records1 =
           Record.builder()
@@ -375,7 +375,7 @@ public class ExporterTest {
 
       var fs = FileSystem.of("ftp", new Configuration(configs));
 
-      task.start(configs);
+      task.init(new Configuration(configs), context);
 
       var record1 =
           Record.builder()
@@ -480,7 +480,7 @@ public class ExporterTest {
               "fs.hdfs.override.dfs.client.use.datanode.hostname",
               "true");
 
-      task.start(configs);
+      task.init(new Configuration(configs), context);
 
       var records =
           List.of(
@@ -579,7 +579,7 @@ public class ExporterTest {
               "roll.duration",
               "300ms");
 
-      task.start(configs);
+      task.init(new Configuration(configs), context);
 
       var records1 =
           Record.builder()
@@ -652,7 +652,7 @@ public class ExporterTest {
               "roll.duration",
               "100ms");
 
-      task.start(configs);
+      task.init(new Configuration(configs), context);
 
       var record1 =
           Record.builder()
@@ -776,7 +776,7 @@ public class ExporterTest {
       var testRecord = Record.builder().topic(topicName).topicPartition(tp).offset(offset).build();
       var configs =
           Map.of(
-              "name",
+              "connector.name",
               "test",
               "fs.schema",
               "hdfs",
@@ -844,6 +844,8 @@ public class ExporterTest {
       var path = "/test";
       var configs =
           Map.of(
+              "connector.name",
+              "test",
               "fs.schema",
               "hdfs",
               "topics",
@@ -868,6 +870,7 @@ public class ExporterTest {
       var task = new Exporter.Task();
       task.fs = FileSystem.of("hdfs", new Configuration(configs));
       task.compressionType = "none";
+      task.configuration = new Configuration(configs);
       task.size = DataSize.of("100MB");
       task.bufferSize.reset();
       task.recordsQueue.add(
@@ -914,7 +917,7 @@ public class ExporterTest {
 
       var task = new Exporter.Task();
 
-      task.start(configs);
+      task.init(new Configuration(configs), context);
 
       var record1 =
           Record.builder()
@@ -1037,7 +1040,8 @@ public class ExporterTest {
       var input = fs.read("/" + String.join("/", fileSize, topicName, "0/0"));
 
       Assertions.assertArrayEquals(
-          new byte[] {(byte) 0x0, (byte) 0x0, (byte) 0x1f, (byte) 0x8b}, Utils.packException(() -> input.readNBytes(4)));
+          new byte[] {(byte) 0x0, (byte) 0x1, (byte) 0x1f, (byte) 0x8b},
+          Utils.packException(() -> input.readNBytes(4)));
     }
   }
 }

--- a/fs/src/main/java/org/astraea/fs/ftp/FtpFileSystem.java
+++ b/fs/src/main/java/org/astraea/fs/ftp/FtpFileSystem.java
@@ -208,6 +208,11 @@ public class FtpFileSystem implements FileSystem {
             }
 
             @Override
+            public void write(byte b[]) throws IOException {
+              outputStream.write(b);
+            }
+
+            @Override
             public void write(byte b[], int off, int len) throws IOException {
               outputStream.write(b, off, len);
             }


### PR DESCRIPTION
#1830 
更新到了版本1，現在備份的文件尾部增加了檔案的 metadata，有以下資訊
1. connector name -> 255 Bytes
2. ~topic name -> 255 Bytes~
3. ~partition number -> 4 Bytes~
4. ~1st record offset -> 8 Bytes~
5. ~1st record timestamp -> 8 Bytes~
6. record count -> 4 Bytes
7. roll.duration in mills -> 8 Bytes
8. compression.type -> 10Bytes

以上總共 ~552Bytes~ 277 Bytes，後續 importer 要先讀取 metadata 可以固定跳到尾部前的 metadata 位置先讀取。
目前針對 importer 中的測試部分，因為還沒有針對 metadata 的部分做處理，因此在判斷有無下一筆資料時遇到 metadata 的 protocol buffer 錯誤會先不理會，等到後續更新 v1 版本的 importer 時可以把這段拔掉。

現在因為要針對些 connector 與 1st record 等資料作紀錄，導致 v1 版的 RecordWriter 所需參數增加到三個。
分別為
1. configuration: 為了取得 connector name, roll.duration 或 compression.type 等創建 connector 時的資訊
2. record: 跟 1st record 相關資訊
3. outputStream

本次取消在 RecordWriterBuilder 中就依照 compression.type 就創建壓縮的 outputStream 如 GZIPOutputStream，而是改為在 RecordWrtier 中透過 configuration 來判斷並處理壓縮的原因，其原因是為了在關閉前寫上無壓縮資訊的 metadata 的緣故。如果按照前方法直接將 GZIPOutputStream 或類似的物件傳到 recordWriter 中，會不方便再寫入無壓縮資訊。