### PR TITLE
[METRICS] Not block on BeanObject receiving

### DIFF
--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
@@ -261,6 +261,11 @@ public interface MetricStore extends AutoCloseable {
             while (!closed.get()) {
               try {
                 receivers.stream()
+                    // TODO: Busy waiting on metric receiving.
+                    // issue: https://github.com/skiptests/astraea/issues/1834
+                    // To prevent specific receiver block other receivers' job, we set receive
+                    // timeout to zero. But if all receivers return empty immediately, it may cause
+                    // this thread busy waiting on doing `receiver.receive`.
                     .map(r -> r.receive(Duration.ZERO))
                     .forEach(
                         allBeans -> {

--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
@@ -261,7 +261,7 @@ public interface MetricStore extends AutoCloseable {
             while (!closed.get()) {
               try {
                 receivers.stream()
-                    .map(r -> r.receive(Duration.ofSeconds(3)))
+                    .map(r -> r.receive(Duration.ZERO))
                     .forEach(
                         allBeans -> {
                           beanReceivedSensor.record(

--- a/common/src/test/java/org/astraea/common/partitioner/StrictCostPartitionerTest.java
+++ b/common/src/test/java/org/astraea/common/partitioner/StrictCostPartitionerTest.java
@@ -149,7 +149,7 @@ public class StrictCostPartitionerTest {
           new byte[0],
           new byte[0],
           ClusterInfoTest.of(List.of(replicaInfo0, replicaInfo1)));
-      Assertions.assertEquals(0, partitioner.metricStore.sensors().size());
+      Assertions.assertEquals(1, partitioner.metricStore.sensors().size());
     }
   }
 

--- a/common/src/test/java/org/astraea/common/partitioner/StrictCostPartitionerTest.java
+++ b/common/src/test/java/org/astraea/common/partitioner/StrictCostPartitionerTest.java
@@ -149,6 +149,7 @@ public class StrictCostPartitionerTest {
           new byte[0],
           new byte[0],
           ClusterInfoTest.of(List.of(replicaInfo0, replicaInfo1)));
+      Utils.sleep(Duration.ofSeconds(1));
       Assertions.assertEquals(1, partitioner.metricStore.sensors().size());
     }
   }


### PR DESCRIPTION
原本作法在 `reciever` 中沒有 `BeanObject` 時，線程會等到有資料或者 3 秒鐘時限到。這個等待會影響到其他 `receiver` 取得 `BeanObject`。

這隻 PR 改成不等待，`receiver` 當下沒有資料時會馬上回傳，換使用下一個 `receiver` 嘗試取得 `BeanObejct`。

這隻 PR 會導致一個測試發生錯誤 (`MetricSensor` 數量)，這項測試原本就應該要錯誤，但因為先前作法會讓 `metricStore` 較晚更新 `MetricSensor` (為了等待 metric)，所以剛好 `MetricSensor` 數量符合預期 (0)。但這隻 PR 不等待 metric 取得，所以馬上就會更新 `MetricSensor` 導致測試時 `MetricSensor` 數量為 1 ，內容為 `MetricSensor.EMPTY`。