### PR TITLE
[METRICS] New thread for waiting list checking

### DIFF
--- a/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
+++ b/common/src/main/java/org/astraea/common/metrics/collector/MetricStore.java
@@ -259,8 +259,6 @@ public interface MetricStore extends AutoCloseable {
           };
       Runnable receiverJob =
           () -> {
-            var isChecking = new AtomicBoolean(false);
-            var needChecking = new AtomicBoolean(false);
             while (!closed.get()) {
               try {
                 receivers.stream()


### PR DESCRIPTION
實驗時發現，MetricStore 檢查 waiting list 會影響指標拉取速率，這隻 PR 改成獨立使用一條執行緒來檢查。

在使用 Cost Aware Assignor 時，該程式會等待 MetricStore 有"完整"效能指標時才會做計算，其判斷"完整"的方式是實際代入 cost-function 計算，會在 MetricStore 有更新指標的時候檢查。但這些計算不應該由佔用 "MetricStore 的拉取執行緒" ，MetricStore 應該繼續拉取最新指標。

所以這裡的作法是建立一個新的執行緒檢查，且同時只會有一個執行緒在執行檢查（透過 `isChecking` 確保一次只會有一個執行緒）。
另外，先前的作法是看本次迴圈指標有無更新，再來執行檢查，但使用多執行緒執行的話，有可能會在前一個迴圈（執行檢查後）更新，為避免漏檢查，所以使用另一個參數 `needChecking` 確保每次更新都有檢查到。
